### PR TITLE
Add dark mode support

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import { Plus_Jakarta_Sans, JetBrains_Mono } from "next/font/google"
+import { ThemeProvider } from "next-themes"
 import { Toaster } from "@/components/ui/sonner"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import "./globals.css"
@@ -31,10 +32,12 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body className="bg-background min-h-dvh font-sans antialiased">
-        <TooltipProvider>
-          {children}
-          <Toaster />
-        </TooltipProvider>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <TooltipProvider>
+            {children}
+            <Toaster />
+          </TooltipProvider>
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,5 +1,6 @@
 import { Separator } from "@/components/ui/separator"
 import { SidebarTrigger } from "@/components/ui/sidebar"
+import { ThemeToggle } from "@/components/theme-toggle"
 
 export function SiteHeader() {
   return (
@@ -11,6 +12,7 @@ export function SiteHeader() {
           className="mx-2 h-4 data-vertical:self-auto"
         />
         <h1 className="text-base font-medium">Dashboard</h1>
+        <ThemeToggle className="ml-auto" />
       </div>
     </header>
   )

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Moon, Sun } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export function ThemeToggle({ className }: { className?: string }) {
+  const { resolvedTheme, setTheme } = useTheme()
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className={className}
+      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+      aria-label="Theme umschalten"
+    >
+      <Sun className="h-4 w-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+      <Moon className="absolute h-4 w-4 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+    </Button>
+  )
+}


### PR DESCRIPTION
Closes https://github.com/voss-labs/verp/issues/21

## What

There is now a ThemeToggle-button at the right side of the site-header for toggling between light (lucide sun icon) and dark (lucide moon icon) mode.

## Why

Why is this change needed?
- It improves the user experience by allowing the user to select his preferred theme.

## How

How was it implemented? Any design decisions worth noting?
- Added the ThemeProvider to the root layout.
- Introduced a new ThemeToggle-Component that uses the `useTheme` hook.
- Added the new ThemeToggle to the right of the site-header component. 

## Testing

How did you verify this works?

- [x] `npm run check` passes
- [x] Tested locally

## Screenshots

Light-Mode site-header:
<img width="910" height="95" alt="light-mode" src="https://github.com/user-attachments/assets/be05e94c-44e1-4aa3-8c90-ecfb7ec545fa" />

Dark-Mode site-header:
<img width="910" height="95" alt="dark-mode" src="https://github.com/user-attachments/assets/4419e11d-24d0-405f-97db-de5458053cff" />
