### PR TITLE
fix: Windows compatibility for setup wizard

### DIFF
--- a/scripts/lib/db.ts
+++ b/scripts/lib/db.ts
@@ -28,6 +28,7 @@ function runWithSpinner({
     const child = spawn(command, args, {
       stdio: ["ignore", "pipe", "pipe"],
       env: process.env,
+      shell: true,
     })
     let stderr = ""
     child.stdout?.on("data", () => {})

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process"
+import { exec, spawn } from "node:child_process"
 import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import { color } from "@astrojs/cli-kit"
@@ -180,10 +180,14 @@ async function collectNeonCredentials() {
 
 function openInBrowser(url: string) {
   const platform = process.platform
-  const command =
-    platform === "darwin" ? "open" : platform === "win32" ? "start" : "xdg-open"
   try {
-    spawn(command, [url], { stdio: "ignore", detached: true }).unref()
+    if (platform === "win32") {
+      // 'start' is a cmd.exe built-in, not an executable — must use shell
+      exec(`start "" "${url}"`);
+    } else {
+      const command = platform === "darwin" ? "open" : "xdg-open"
+      spawn(command, [url], { stdio: "ignore", detached: true }).unref()
+    }
   } catch {
     // ignore — not all environments allow this
   }
@@ -447,7 +451,7 @@ async function offerDevServer() {
   ) as boolean
   if (!start) return
   process.stdout.write("\n")
-  spawn("npm", ["run", "dev"], { stdio: "inherit" })
+  spawn("npm", ["run", "dev"], { stdio: "inherit", shell: true })
 }
 
 function getVersion(): string {

--- a/src/db/migrations/0008_fix_marks_locks_user_ref.sql
+++ b/src/db/migrations/0008_fix_marks_locks_user_ref.sql
@@ -1,16 +1,30 @@
 -- Fix marks_locks: locked_by and unlocked_by should be text referencing user.id
 -- (Better Auth uses text IDs, not UUIDs)
 
--- Drop existing FK constraints
-ALTER TABLE marks_locks DROP CONSTRAINT marks_locks_locked_by_fkey;
-ALTER TABLE marks_locks DROP CONSTRAINT marks_locks_unlocked_by_fkey;
+-- Drop existing FK constraints (IF EXISTS for fresh-db idempotency)
+ALTER TABLE marks_locks DROP CONSTRAINT IF EXISTS marks_locks_locked_by_fkey;
+ALTER TABLE marks_locks DROP CONSTRAINT IF EXISTS marks_locks_unlocked_by_fkey;
 
--- Change column types from uuid to text
+-- Change column types from uuid to text (no-op if already text)
 ALTER TABLE marks_locks ALTER COLUMN locked_by TYPE text USING locked_by::text;
 ALTER TABLE marks_locks ALTER COLUMN unlocked_by TYPE text USING unlocked_by::text;
 
--- Add new FK constraints referencing user table
-ALTER TABLE marks_locks ADD CONSTRAINT marks_locks_locked_by_user_fk
-  FOREIGN KEY (locked_by) REFERENCES "user"(id) ON DELETE SET NULL;
-ALTER TABLE marks_locks ADD CONSTRAINT marks_locks_unlocked_by_user_fk
-  FOREIGN KEY (unlocked_by) REFERENCES "user"(id) ON DELETE SET NULL;
+-- Add new FK constraints referencing user table (skip if already present)
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'marks_locks_locked_by_user_fk'
+  ) THEN
+    ALTER TABLE marks_locks ADD CONSTRAINT marks_locks_locked_by_user_fk
+      FOREIGN KEY (locked_by) REFERENCES "user"(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'marks_locks_unlocked_by_user_fk'
+  ) THEN
+    ALTER TABLE marks_locks ADD CONSTRAINT marks_locks_unlocked_by_user_fk
+      FOREIGN KEY (unlocked_by) REFERENCES "user"(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+


### PR DESCRIPTION
## What

Fix `npm run setup` crashing on Windows with `spawn ENOENT` errors, and make migration 0008 idempotent for fresh databases.

## Why

The setup wizard is completely broken on Windows due to three issues:
1. `openInBrowser()` uses `spawn('start', ...)` but `start` is a `cmd.exe` built-in, not an executable — causes `ENOENT`
2. `spawn('npx', ...)` and `spawn('npm', ...)` fail because on Windows these are `.cmd` batch files, not native executables
3. Migration `0008_fix_marks_locks_user_ref.sql` fails on fresh databases because `drizzle-kit push` already creates the correct schema, so the old constraints it tries to drop don't exist

## How

- **`scripts/setup.ts`**: Use `exec()` for Windows `start` command; add `shell: true` to `npm` spawn
- **`scripts/lib/db.ts`**: Add `shell: true` to `npx` spawn so `.cmd` files resolve
- **`0008_fix_marks_locks_user_ref.sql`**: Add `IF EXISTS` to `DROP CONSTRAINT` and `IF NOT EXISTS` guards to `ADD CONSTRAINT`

All changes are backward-compatible with macOS and Linux.

## Testing

- [x] Tested locally on Windows (full `npm run setup` completes successfully)
- [ ] `npm run check` passes

Closes voss-labs/verp#38