### PR TITLE
Fix/sidebar dead links

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,5 +1,4 @@
 "use client"
-
 import * as React from "react"
 
 import { NavMain } from "@/components/nav-main"

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -17,12 +17,8 @@ import {
   GraduationCapIcon,
   UsersIcon,
   BookOpenIcon,
-  CalendarIcon,
   ClipboardCheckIcon,
-  IndianRupeeIcon,
-  SettingsIcon,
   LayoutDashboardIcon,
-  ClockIcon,
   FileTextIcon,
   ClipboardListIcon,
   LayersIcon,
@@ -95,24 +91,6 @@ const adminNav = [
     icon: <ScrollTextIcon />,
     items: [{ title: "All Logs", url: "/dashboard/audit" }],
   },
-  {
-    title: "Examinations",
-    url: "#",
-    icon: <CalendarIcon />,
-    items: [
-      { title: "Schedule", url: "#" },
-      { title: "Results", url: "#" },
-    ],
-  },
-  {
-    title: "Settings",
-    url: "#",
-    icon: <SettingsIcon />,
-    items: [
-      { title: "General", url: "#" },
-      { title: "Users & Roles", url: "#" },
-    ],
-  },
 ]
 
 const facultyNav = [
@@ -159,18 +137,8 @@ const studentNav = [
   },
 ]
 
-const quickAccess = [
-  {
-    name: "Fees & Finance",
-    url: "#",
-    icon: <IndianRupeeIcon />,
-  },
-  {
-    name: "Timetable",
-    url: "#",
-    icon: <ClockIcon />,
-  },
-]
+// FIXED: Properly typed empty array to satisfy NavProjects requirements
+const quickAccess: { name: string; url: string; icon: React.ReactNode }[] = []
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { data: session } = useSession()
@@ -193,7 +161,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       </SidebarHeader>
       <SidebarContent>
         <NavMain items={navItems} />
-        <NavProjects projects={quickAccess} />
+        {quickAccess.length > 0 && <NavProjects projects={quickAccess} />}
       </SidebarContent>
       <SidebarFooter>
         <NavUser user={user} />


### PR DESCRIPTION
## What

This PR removes all dead placeholder links (`#`) and non-functional navigation components from the main application sidebar (`src/components/app-sidebar.tsx`) to streamline the user interface.

## Why

The sidebar contained multiple non-functional structural modules (`Examinations`, `Settings`, `Fees & Finance`, `Timetable`) pointing to empty hashes. Removing these dead ends improves overall UX, avoids user confusion, and ensures the application displays only fully deployed, operational features.

## How

- **Removed Arrays:** Dropped the placeholder navigation blocks completely from `adminNav`.
- **Cleaned Quick Access:** Emptied out the `quickAccess` array variables.
- **TypeScript Mismatch Resolution:** Explicitly typed the empty `quickAccess` list configuration array as `{ name: string; url: string; icon: React.ReactNode }[]` to properly satisfy the structural constraints of the child `<NavProjects />` component interface.
- **Conditional Layout Rendering:** Adjusted layout rules in the markup to cleanly skip rendering empty list containers (`{quickAccess.length > 0 && ...}`).
- **Bundle Optimization:** Trimmed away the unused component asset icon declarations (`CalendarIcon`, `SettingsIcon`, `IndianRupeeIcon`, `ClockIcon`) from the `lucide-react` import statement.

## Testing

- [x] `npm run check` passes / TypeScript compilation completes with 0 errors
- [x] Tested locally and confirmed that the sidebar renders perfectly for all three user roles (Admin, Faculty, Student) with zero breaking layout visual shifts.