### PR TITLE
Restore VERP blue theme + in-app pending state + bind on every sign-in

### DIFF
--- a/src/app/dashboard/audit/client.tsx
+++ b/src/app/dashboard/audit/client.tsx
@@ -32,7 +32,7 @@ type AuditLogEntry = {
   createdAt: string
 }
 
-// Neutral outline badges by default; orange accent reserved for notable actions
+// Neutral outline badges by default; blue accent reserved for notable actions
 // (locking marks), destructive for removals. No rainbow.
 const ACTION_STYLES: Record<string, string> = {
   "marks.lock": "text-blue border-blue/20 bg-blue/8",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -54,88 +54,90 @@
 
 :root {
   --header-height: 3.5rem;
-  /* VOSS palette: ink primary, orange accent. Neutral warm grays, zero blue hue. */
-  --background: oklch(0.985 0.002 65);
-  --foreground: oklch(0.16 0 0);
+  /* Warm off-white background for depth */
+  --background: oklch(0.98 0.004 260);
+  --foreground: oklch(0.16 0.02 260);
+  /* Cards are pure white - creates surface layering */
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.16 0 0);
+  --card-foreground: oklch(0.16 0.02 260);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.16 0 0);
-  /* Ink primary — the VOSS wordmark */
-  --primary: oklch(0.18 0 0);
+  --popover-foreground: oklch(0.16 0.02 260);
+  /* Deep navy primary */
+  --primary: oklch(0.22 0.03 260);
   --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.96 0.003 65);
-  --secondary-foreground: oklch(0.18 0 0);
-  --muted: oklch(0.955 0.004 65);
-  --muted-foreground: oklch(0.505 0.01 55);
-  --accent: oklch(0.955 0.004 65);
-  --accent-foreground: oklch(0.18 0 0);
+  /* Tinted secondary surface */
+  --secondary: oklch(0.96 0.006 260);
+  --secondary-foreground: oklch(0.22 0.03 260);
+  --muted: oklch(0.955 0.008 260);
+  --muted-foreground: oklch(0.5 0.02 260);
+  --accent: oklch(0.955 0.008 260);
+  --accent-foreground: oklch(0.22 0.03 260);
   --destructive: oklch(0.55 0.22 25);
-  --border: oklch(0.905 0.004 65);
-  --input: oklch(0.905 0.004 65);
-  /* VOSS orange #FB7A3C — the accent and the square in the wordmark. */
-  --ring: oklch(0.72 0.165 47);
-  /* --blue remapped to brand orange: every bg-blue in the app rebrands for free.
-     Dark foreground because orange is too light for white text. */
-  --blue: oklch(0.72 0.165 47);
-  --blue-foreground: oklch(0.16 0 0);
-  --surface: oklch(0.97 0.003 65);
-  --success: oklch(0.6 0.15 155);
-  --warning: oklch(0.75 0.15 70);
-  /* Charts: a warm family anchored on the brand orange, no more blue spread. */
-  --chart-1: oklch(0.72 0.165 47);
-  --chart-2: oklch(0.62 0.14 40);
-  --chart-3: oklch(0.8 0.13 65);
-  --chart-4: oklch(0.5 0.1 45);
-  --chart-5: oklch(0.35 0.04 55);
+  --border: oklch(0.91 0.008 260);
+  --input: oklch(0.91 0.008 260);
+  /* Deep saturated blue - the brand */
+  --ring: oklch(0.52 0.2 258);
+  --blue: oklch(0.52 0.2 258);
+  --blue-foreground: oklch(0.99 0 0);
+  /* Semantic colors */
+  --surface: oklch(0.97 0.005 260);
+  --success: oklch(0.6 0.16 155);
+  --warning: oklch(0.72 0.16 75);
+  /* Charts - cohesive blue family */
+  --chart-1: oklch(0.52 0.2 258);
+  --chart-2: oklch(0.62 0.16 258);
+  --chart-3: oklch(0.42 0.2 258);
+  --chart-4: oklch(0.72 0.1 258);
+  --chart-5: oklch(0.32 0.16 258);
   --radius: 0.625rem;
-  --sidebar: oklch(0.975 0.004 65);
-  --sidebar-foreground: oklch(0.18 0 0);
-  --sidebar-primary: oklch(0.72 0.165 47);
-  --sidebar-primary-foreground: oklch(0.16 0 0);
-  --sidebar-accent: oklch(0.94 0.006 65);
-  --sidebar-accent-foreground: oklch(0.18 0 0);
-  --sidebar-border: oklch(0.9 0.005 65);
-  --sidebar-ring: oklch(0.72 0.165 47);
+  /* Sidebar - tinted blue-gray for brand identity */
+  --sidebar: oklch(0.97 0.008 258);
+  --sidebar-foreground: oklch(0.22 0.03 260);
+  --sidebar-primary: oklch(0.52 0.2 258);
+  --sidebar-primary-foreground: oklch(0.99 0 0);
+  --sidebar-accent: oklch(0.94 0.016 258);
+  --sidebar-accent-foreground: oklch(0.22 0.03 260);
+  --sidebar-border: oklch(0.9 0.012 258);
+  --sidebar-ring: oklch(0.52 0.2 258);
 }
 
 .dark {
-  --background: oklch(0.14 0 0);
+  --background: oklch(0.14 0.01 260);
   --foreground: oklch(0.96 0 0);
-  --card: oklch(0.185 0.002 65);
+  --card: oklch(0.19 0.015 260);
   --card-foreground: oklch(0.96 0 0);
-  --popover: oklch(0.185 0.002 65);
+  --popover: oklch(0.19 0.015 260);
   --popover-foreground: oklch(0.96 0 0);
   --primary: oklch(0.92 0 0);
-  --primary-foreground: oklch(0.185 0 0);
-  --secondary: oklch(0.25 0.003 65);
+  --primary-foreground: oklch(0.19 0.015 260);
+  --secondary: oklch(0.25 0.015 260);
   --secondary-foreground: oklch(0.96 0 0);
-  --muted: oklch(0.25 0.003 65);
-  --muted-foreground: oklch(0.68 0.008 65);
-  --accent: oklch(0.25 0.003 65);
+  --muted: oklch(0.25 0.015 260);
+  --muted-foreground: oklch(0.68 0.01 260);
+  --accent: oklch(0.25 0.015 260);
   --accent-foreground: oklch(0.96 0 0);
   --destructive: oklch(0.65 0.2 25);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.75 0.16 50);
-  --blue: oklch(0.75 0.16 50);
-  --blue-foreground: oklch(0.16 0 0);
-  --surface: oklch(0.22 0.002 65);
+  --ring: oklch(0.6 0.16 258);
+  --blue: oklch(0.6 0.16 258);
+  --blue-foreground: oklch(0.99 0 0);
+  --surface: oklch(0.22 0.012 260);
   --success: oklch(0.65 0.14 155);
-  --warning: oklch(0.78 0.14 70);
-  --chart-1: oklch(0.75 0.16 50);
-  --chart-2: oklch(0.65 0.14 40);
-  --chart-3: oklch(0.82 0.12 65);
-  --chart-4: oklch(0.55 0.11 45);
-  --chart-5: oklch(0.4 0.05 55);
-  --sidebar: oklch(0.185 0.002 65);
+  --warning: oklch(0.75 0.14 75);
+  --chart-1: oklch(0.6 0.16 258);
+  --chart-2: oklch(0.52 0.2 258);
+  --chart-3: oklch(0.72 0.1 258);
+  --chart-4: oklch(0.42 0.2 258);
+  --chart-5: oklch(0.32 0.16 258);
+  --sidebar: oklch(0.19 0.015 260);
   --sidebar-foreground: oklch(0.96 0 0);
-  --sidebar-primary: oklch(0.75 0.16 50);
-  --sidebar-primary-foreground: oklch(0.16 0 0);
-  --sidebar-accent: oklch(0.25 0.003 65);
+  --sidebar-primary: oklch(0.6 0.16 258);
+  --sidebar-primary-foreground: oklch(0.99 0 0);
+  --sidebar-accent: oklch(0.25 0.015 260);
   --sidebar-accent-foreground: oklch(0.96 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.75 0.16 50);
+  --sidebar-ring: oklch(0.6 0.16 258);
 }
 
 @layer base {

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -8,5 +8,5 @@
         textLength="18"
         lengthAdjust="spacingAndGlyphs"
         fill="#FAFAFA">V</text>
-  <rect x="22" y="19" width="6" height="6" fill="#FB7A3C"/>
+  <rect x="22" y="19" width="6" height="6" fill="#2E5CE6"/>
 </svg>

--- a/src/app/unclaimed/page.tsx
+++ b/src/app/unclaimed/page.tsx
@@ -1,15 +1,17 @@
 import { redirect } from "next/navigation"
+import { ClockIcon } from "lucide-react"
+import { AppSidebar } from "@/components/app-sidebar"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { getSessionUser, isUnbound } from "@/lib/session"
 
 export const dynamic = "force-dynamic"
 
 /**
- * The dead end for a real VIT student VOSS authenticated but VERP cannot place.
- *
- * This page exists because the alternative is worse: before, an account with no
- * roster match silently defaulted to the student role and saw a dashboard built
- * out of nothing. Being told plainly that you are not in the roster is better
- * than being shown an empty one.
+ * The pending state for a real VIT student VOSS authenticated but not yet in the
+ * roster. It renders inside the app shell — the account IS in, it just has no
+ * record to act on yet — rather than bouncing them to a bare dead-end page. The
+ * dashboard layout still redirects unbound users here, so no data route is ever
+ * reachable without a role; this is the one screen they can see.
  */
 export default async function UnclaimedPage() {
   const user = await getSessionUser()
@@ -17,29 +19,38 @@ export default async function UnclaimedPage() {
   if (!isUnbound(user)) redirect("/dashboard")
 
   return (
-    <main className="flex min-h-svh items-center justify-center p-6">
-      <div className="w-full max-w-md">
-        <h1 className="text-2xl font-bold tracking-tight">
-          You are not in the roster yet
-        </h1>
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>
+        <div className="flex min-h-svh items-center justify-center p-6">
+          <div className="w-full max-w-md">
+            <div className="bg-muted text-muted-foreground flex size-11 items-center justify-center rounded-full">
+              <ClockIcon className="size-5" />
+            </div>
 
-        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Your VOSS account is verified, but no student or faculty record in
-          VERP matches{" "}
-          <span className="text-foreground font-mono">{user.email}</span>.
-        </p>
+            <h1 className="mt-5 text-2xl font-bold tracking-tight">
+              Access pending
+            </h1>
 
-        <p className="text-muted-foreground mt-4 text-sm leading-relaxed">
-          Ask your TR to add you. Once your record is uploaded, sign in again
-          and you will be linked automatically — there is nothing else for you
-          to do.
-        </p>
+            <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+              You&rsquo;re signed in and verified as{" "}
+              <span className="text-foreground font-mono">{user.email}</span> —
+              we&rsquo;re just waiting for your record to be added to VERP.
+            </p>
 
-        <p className="text-muted-foreground/70 mt-8 text-xs leading-relaxed">
-          If you believe the roster already lists you, the email on your record
-          may differ from the one you signed in with. Your TR can correct it.
-        </p>
-      </div>
-    </main>
+            <p className="text-muted-foreground mt-4 text-sm leading-relaxed">
+              Ask your TR to add you to the roster. The moment they do, your
+              next sign-in links you automatically — there is nothing else for
+              you to do.
+            </p>
+
+            <p className="text-muted-foreground/70 mt-8 text-xs leading-relaxed">
+              Already listed? The email on your record may differ from the one
+              you signed in with. Your TR can correct it.
+            </p>
+          </div>
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
   )
 }

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -103,8 +103,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     avatar: session?.user?.image ?? "",
   }
 
-  let navItems = adminNav
-  if (role === "faculty") navItems = facultyNav
+  // Empty for an unbound (pending) user — they see the shell, not a menu they
+  // cannot use. Never default to adminNav: role null is not an admin.
+  let navItems: typeof adminNav = []
+  if (role === "admin") navItems = adminNav
+  else if (role === "faculty") navItems = facultyNav
   else if (role === "student") navItems = studentNav
 
   return (

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -35,7 +35,7 @@ export function LoginForm({
     <div className={cn("flex min-h-svh", className)} {...props}>
       {/* Left: Branding Panel */}
       <div className="bg-primary text-primary-foreground relative hidden w-[52%] overflow-hidden lg:block">
-        {/* Thin orange accent along the leading edge */}
+        {/* Thin blue accent along the leading edge */}
         <div className="bg-blue absolute inset-y-0 left-0 w-1" />
         {/* Subtle depth gradient — flat ink, no loud multi-color wash */}
         <div className="from-primary absolute inset-0 bg-gradient-to-t via-transparent to-black/20" />

--- a/src/components/voss-logo.tsx
+++ b/src/components/voss-logo.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils"
 
-// The VOSS lockup: heavy wordmark plus an orange square. Reproduced in type, not
+// The VOSS lockup: heavy wordmark plus a blue square. Reproduced in type, not
 // shipped as an image — one less asset, and it inherits the current text color.
 // `product` names the app that sits under the VOSS umbrella (VERP, vboard...).
 export function VossWordmark({
@@ -15,7 +15,7 @@ export function VossWordmark({
       <span className="text-lg leading-none font-black tracking-[-0.03em] select-none">
         VOSS
       </span>
-      <span aria-hidden className="size-[7px] shrink-0 bg-[#FB7A3C]" />
+      <span aria-hidden className="bg-blue size-[7px] shrink-0" />
       {product && (
         <span className="text-muted-foreground ml-1 text-sm font-medium">
           {product}
@@ -25,7 +25,7 @@ export function VossWordmark({
   )
 }
 
-// Compact mark for square tiles (the sidebar header). "V" plus the orange square.
+// Compact mark for square tiles (the sidebar header). "V" plus the blue square.
 export function VossMark({ className }: { className?: string }) {
   return (
     <span
@@ -37,7 +37,7 @@ export function VossMark({ className }: { className?: string }) {
       V
       <span
         aria-hidden
-        className="absolute right-[3px] bottom-[5px] size-[5px] bg-[#FB7A3C]"
+        className="bg-blue absolute right-[3px] bottom-[5px] size-[5px]"
       />
     </span>
   )

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -109,17 +109,26 @@ export const auth = betterAuth({
   ],
 
   databaseHooks: {
-    user: {
+    session: {
       create: {
-        after: async (user) => {
-          // The session cookie is already being issued by now, so a throw here
-          // must not take the login down — it has to land the user somewhere
-          // that explains itself. getSessionUser() treats an unbound account as
-          // roleless and the dashboard sends them to /unclaimed.
+        after: async (session) => {
+          // Bind on every sign-in, not just account creation. This links a
+          // first-time user whose roster row already exists, AND re-links a user
+          // who signed in BEFORE their TR added them — the promise the pending
+          // screen makes ("sign in again and you'll be linked"). bindIdentity is
+          // idempotent: once the row carries this authUserId it is a no-op.
+          //
+          // A throw here must never take the login down — the session cookie is
+          // already issued. An unbound account is roleless and lands on the
+          // pending screen, which is a correct, self-explaining outcome.
           try {
-            await bindIdentity(user.id, user.email)
+            const u = await db.query.user.findFirst({
+              where: (user, { eq }) => eq(user.id, session.userId),
+              columns: { id: true, email: true },
+            })
+            if (u) await bindIdentity(u.id, u.email)
           } catch (error) {
-            console.error("[bind] failed for", user.email, error)
+            console.error("[bind] failed for session", session.userId, error)
           }
         },
       },


### PR DESCRIPTION
## What

- **Blue theme restored.** The orange rebrand reappeared through a squash-merge; this reverts `globals.css` to VERP's blue palette (navy primary, blue accent, blue-tinted neutrals) and turns the VOSS wordmark/favicon square blue via the `--blue` token.
- **In-app pending state.** An unbound (not-yet-in-roster) user now lands inside the app shell on an *Access pending* screen instead of a bare dead-end page. The dashboard layout still redirects unbound users here, so no data route is reachable without a role — the fail-closed invariant holds.
- **Bind on every sign-in.** Identity binding moves from the `user.create` hook to `session.create`, so it runs on every sign-in. A student added to the roster *after* they first signed in now gets linked when they return — making the pending screen's promise true. Idempotent once bound.
- **Sidebar fix.** A null-role user no longer falls through to the admin menu (latent bug) — they get an empty nav.

## Verification

Typecheck, lint, format, and `next build` all pass.