### PR TITLE
Guard + scope the student/faculty rosters (security)

### DIFF
--- a/src/app/dashboard/faculty/page.tsx
+++ b/src/app/dashboard/faculty/page.tsx
@@ -1,11 +1,23 @@
+import { redirect } from "next/navigation"
 import { PageHeader } from "@/components/page-header"
 import { FacultyClient } from "./client"
-import { getAllFaculty } from "@/db/queries"
+import { getSessionUser } from "@/lib/session"
+import { can } from "@/lib/rbac"
+import { getAllFaculty, getFacultyByDepartments } from "@/db/queries/faculty"
 
 export const dynamic = "force-dynamic"
 
 export default async function FacultyPage() {
-  const data = await getAllFaculty()
+  const user = await getSessionUser()
+  if (!user) redirect("/login")
+  // Only HOD (own dept) and super_admin (all) read the faculty roster; a plain
+  // coordinator or a student cannot, by URL or nav.
+  if (!can(user, "faculty:read")) redirect("/dashboard")
+
+  const data =
+    user.tier === "super_admin"
+      ? await getAllFaculty()
+      : await getFacultyByDepartments(user.deptCodes)
 
   return (
     <>

--- a/src/app/dashboard/students/[id]/page.tsx
+++ b/src/app/dashboard/students/[id]/page.tsx
@@ -1,6 +1,8 @@
-import { notFound } from "next/navigation"
+import { notFound, redirect } from "next/navigation"
 import { PageHeader } from "@/components/page-header"
 import { getStudentById } from "@/db/queries/students"
+import { getSessionUser } from "@/lib/session"
+import { can } from "@/lib/rbac"
 import { Badge } from "@/components/ui/badge"
 
 export const dynamic = "force-dynamic"
@@ -11,8 +13,20 @@ export default async function StudentDetailPage({
   params: Promise<{ id: string }>
 }) {
   const { id } = await params
+  const user = await getSessionUser()
+  if (!user) redirect("/login")
+  if (!can(user, "student:read")) redirect("/dashboard")
+
   const student = await getStudentById(id)
   if (!student) return notFound()
+
+  // Scope: the record must be within the viewer's reach — their class (coordinator)
+  // or department (HOD); super_admin sees any.
+  const inScope =
+    user.tier === "super_admin" ||
+    (user.tier === "hod" && user.deptCodes.includes(student.department)) ||
+    (!!student.classId && user.classIds.includes(student.classId))
+  if (!inScope) redirect("/dashboard/students")
 
   const studentName = `${student.firstName} ${student.lastName}`.trim()
   const claimed = student.authUserId !== null

--- a/src/app/dashboard/students/page.tsx
+++ b/src/app/dashboard/students/page.tsx
@@ -1,11 +1,30 @@
+import { redirect } from "next/navigation"
 import { PageHeader } from "@/components/page-header"
 import { StudentsClient } from "./client"
-import { getAllStudents } from "@/db/queries"
+import { getSessionUser } from "@/lib/session"
+import { can } from "@/lib/rbac"
+import {
+  getAllStudents,
+  getStudentsByClassIds,
+  getStudentsByDepartments,
+} from "@/db/queries/students"
 
 export const dynamic = "force-dynamic"
 
 export default async function StudentsPage() {
-  const data = await getAllStudents()
+  const user = await getSessionUser()
+  if (!user) redirect("/login")
+  // A student has no student:read — they can never reach the roster, by URL or nav.
+  if (!can(user, "student:read")) redirect("/dashboard")
+
+  // Scoped: super_admin sees all, an HOD their department, a coordinator only the
+  // classes they run. The capability says "may read students"; scope says "which".
+  const data =
+    user.tier === "super_admin"
+      ? await getAllStudents()
+      : user.tier === "hod"
+        ? await getStudentsByDepartments(user.deptCodes)
+        : await getStudentsByClassIds(user.classIds)
 
   return (
     <>

--- a/src/db/queries/faculty.ts
+++ b/src/db/queries/faculty.ts
@@ -1,6 +1,18 @@
-import { eq, and, sql } from "drizzle-orm"
+import { eq, and, sql, inArray } from "drizzle-orm"
 import { db } from "@/db"
 import { faculty } from "@/db/schema"
+
+// HOD scope: faculty in their department(s).
+export async function getFacultyByDepartments(departments: string[]) {
+  if (departments.length === 0) return []
+  return db.query.faculty.findMany({
+    where: and(
+      eq(faculty.isActive, true),
+      inArray(faculty.department, departments)
+    ),
+    orderBy: (f, { asc }) => [asc(f.lastName), asc(f.firstName)],
+  })
+}
 
 export async function getFacultyById(id: string) {
   return db.query.faculty.findFirst({

--- a/src/db/queries/students.ts
+++ b/src/db/queries/students.ts
@@ -1,6 +1,30 @@
-import { eq, and } from "drizzle-orm"
+import { eq, and, inArray } from "drizzle-orm"
 import { db } from "@/db"
 import { students } from "@/db/schema"
+
+// Coordinator scope: only the students in the classes they run.
+export async function getStudentsByClassIds(classIds: string[]) {
+  if (classIds.length === 0) return []
+  return db.query.students.findMany({
+    where: and(
+      eq(students.isActive, true),
+      inArray(students.classId, classIds)
+    ),
+    orderBy: (s, { asc }) => [asc(s.rollNumber)],
+  })
+}
+
+// HOD scope: every student in their department(s).
+export async function getStudentsByDepartments(departments: string[]) {
+  if (departments.length === 0) return []
+  return db.query.students.findMany({
+    where: and(
+      eq(students.isActive, true),
+      inArray(students.department, departments)
+    ),
+    orderBy: (s, { asc }) => [asc(s.rollNumber)],
+  })
+}
 
 export async function getStudentById(id: string) {
   return db.query.students.findFirst({


### PR DESCRIPTION
The roster pages (`/dashboard/students`, `/students/[id]`, `/dashboard/faculty`) were rendered from `getAllStudents`/`getAllFaculty` with **no authorization and no scope** — hidden from a student's nav, but reachable by URL, and a coordinator saw every student in the college rather than just their class.

Now every roster page requires the capability (`student:read` / `faculty:read` — a student tier has neither, so it's redirected) and is **scoped to the viewer**: super_admin sees all, an HOD their department, a coordinator only the classes they run. The student detail page re-checks the record is in scope. Adds `getStudentsByClassIds` / `getStudentsByDepartments` / `getFacultyByDepartments`.

Typecheck, build, lint green.