### PR TITLE
Phase 5: attendance + marks (coordinator records, student dashboard)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# local ops/seed scripts (may contain college data)
+/scripts/

--- a/src/app/dashboard/class/[classId]/attendance/client.tsx
+++ b/src/app/dashboard/class/[classId]/attendance/client.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import { saveAttendanceAction } from "../../actions"
+
+type Status = "present" | "absent"
+type Student = {
+  id: string
+  name: string
+  rollNumber: string
+  status: Status
+}
+
+export function AttendanceClient({
+  classId,
+  date,
+  slot,
+  students,
+}: {
+  classId: string
+  date: string
+  slot: string
+  students: Student[]
+}) {
+  const router = useRouter()
+  const [pending, start] = useTransition()
+  const [marks, setMarks] = useState<Record<string, Status>>(
+    Object.fromEntries(students.map((s) => [s.id, s.status]))
+  )
+
+  const setAll = (status: Status) =>
+    setMarks(Object.fromEntries(students.map((s) => [s.id, status])))
+
+  const goDate = (d: string) =>
+    router.push(`/dashboard/class/${classId}/attendance?date=${d}&slot=${slot}`)
+
+  const presentCount = Object.values(marks).filter(
+    (s) => s === "present"
+  ).length
+
+  function save() {
+    start(async () => {
+      const res = await saveAttendanceAction({
+        classId,
+        sessionDate: date,
+        sessionSlot: slot,
+        marks: students.map((s) => ({ studentId: s.id, status: marks[s.id] })),
+      })
+      if (res.error) {
+        toast.error(res.error)
+        return
+      }
+      toast.success("Attendance saved")
+      router.refresh()
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div className="grid gap-1.5">
+          <label className="text-muted-foreground text-xs">Date</label>
+          <Input
+            type="date"
+            value={date}
+            onChange={(e) => e.target.value && goDate(e.target.value)}
+            className="h-9 w-44"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => setAll("present")}>
+            All present
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => setAll("absent")}>
+            All absent
+          </Button>
+          <Button size="sm" disabled={pending} onClick={save}>
+            {pending ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </div>
+
+      <p className="text-muted-foreground text-xs">
+        {presentCount} / {students.length} present
+      </p>
+
+      {students.length === 0 ? (
+        <p className="text-muted-foreground text-sm">
+          No students in this class yet.
+        </p>
+      ) : (
+        <div className="border-border overflow-hidden rounded border">
+          <ul className="divide-border divide-y">
+            {students.map((s) => {
+              const status = marks[s.id]
+              return (
+                <li
+                  key={s.id}
+                  className="flex items-center justify-between gap-3 px-4 py-2.5"
+                >
+                  <div className="flex items-center gap-3">
+                    <Badge variant="outline" className="font-mono">
+                      {s.rollNumber}
+                    </Badge>
+                    <span className="text-sm">{s.name}</span>
+                  </div>
+                  <div className="flex overflow-hidden rounded border">
+                    {(["present", "absent"] as const).map((v) => (
+                      <button
+                        key={v}
+                        type="button"
+                        onClick={() => setMarks((m) => ({ ...m, [s.id]: v }))}
+                        className={cn(
+                          "px-3 py-1 text-xs font-medium capitalize transition-colors",
+                          status === v
+                            ? v === "present"
+                              ? "bg-green-600 text-white"
+                              : "bg-destructive text-white"
+                            : "text-muted-foreground hover:bg-muted"
+                        )}
+                      >
+                        {v}
+                      </button>
+                    ))}
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/dashboard/class/[classId]/attendance/page.tsx
+++ b/src/app/dashboard/class/[classId]/attendance/page.tsx
@@ -1,0 +1,69 @@
+import { notFound, redirect } from "next/navigation"
+import { PageHeader } from "@/components/page-header"
+import { getSessionUser } from "@/lib/session"
+import { can } from "@/lib/rbac"
+import { expectedYear } from "@/lib/roll-number"
+import { getClassById } from "@/db/queries/classes"
+import { getStudentsByClassIds } from "@/db/queries/students"
+import { getAttendanceForSession } from "@/db/queries/attendance"
+import { AttendanceClient } from "./client"
+
+export const dynamic = "force-dynamic"
+
+export default async function AttendancePage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ classId: string }>
+  searchParams: Promise<{ date?: string; slot?: string }>
+}) {
+  const { classId } = await params
+  const sp = await searchParams
+  const user = await getSessionUser()
+  if (!user) redirect("/login")
+  if (!can(user, "attendance:write")) redirect("/dashboard")
+
+  const cls = await getClassById(classId)
+  if (!cls) return notFound()
+  const inScope =
+    user.tier === "super_admin" ||
+    user.classIds.includes(classId) ||
+    (user.tier === "hod" && user.deptCodes.includes(cls.departmentCode))
+  if (!inScope) redirect("/dashboard/class")
+
+  const date = sp.date || new Date().toISOString().slice(0, 10)
+  const slot = sp.slot || "1"
+
+  const [students, existing] = await Promise.all([
+    getStudentsByClassIds([classId]),
+    getAttendanceForSession(classId, date, slot),
+  ])
+  const marked: Record<string, string> = {}
+  for (const e of existing) marked[e.studentId] = e.status
+
+  const yr = expectedYear(cls.admissionYear, new Date()) ?? cls.admissionYear
+  const label = `${yr} · ${cls.departmentCode} · ${cls.division}`
+
+  return (
+    <>
+      <PageHeader
+        title={`Attendance — ${label}`}
+        parent="My classes"
+        parentHref={`/dashboard/class/${classId}`}
+      />
+      <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
+        <AttendanceClient
+          classId={classId}
+          date={date}
+          slot={slot}
+          students={students.map((s) => ({
+            id: s.id,
+            name: `${s.firstName} ${s.lastName}`.trim(),
+            rollNumber: s.rollNumber,
+            status: (marked[s.id] as "present" | "absent") ?? "present",
+          }))}
+        />
+      </div>
+    </>
+  )
+}

--- a/src/app/dashboard/class/[classId]/marks/client.tsx
+++ b/src/app/dashboard/class/[classId]/marks/client.tsx
@@ -1,0 +1,420 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import { computeMarks, type CourseInfo } from "@/lib/sgpi"
+import { createSubjectAction, saveMarksAction } from "../../actions"
+
+type Offering = { id: string; code: string; name: string; semester: number }
+type Row = {
+  studentId: string
+  name: string
+  rollNumber: string
+  isa: number | null
+  mse1: number | null
+  mse2: number | null
+  ese: number | null
+}
+type Grid = { offeringId: string; course: CourseInfo; rows: Row[] }
+
+// VIT defaults per assessment type: theory carries the MSE component, practical
+// and project are ISA + ESE only.
+type CourseType = "theory" | "practical" | "project"
+const CAP_PRESETS: Record<
+  CourseType,
+  { maxIsa: number; maxMse: number; maxEse: number; maxTotal: number }
+> = {
+  theory: { maxIsa: 20, maxMse: 20, maxEse: 60, maxTotal: 100 },
+  practical: { maxIsa: 40, maxMse: 0, maxEse: 60, maxTotal: 100 },
+  project: { maxIsa: 40, maxMse: 0, maxEse: 60, maxTotal: 100 },
+}
+
+export function MarksClient({
+  classId,
+  offerings,
+  selectedId,
+  grid,
+}: {
+  classId: string
+  offerings: Offering[]
+  selectedId: string | null
+  grid: Grid | null
+}) {
+  if (grid && selectedId) {
+    const offering = offerings.find((o) => o.id === selectedId)!
+    return <MarksGrid classId={classId} offering={offering} grid={grid} />
+  }
+  return <SubjectSetup classId={classId} offerings={offerings} />
+}
+
+function SubjectSetup({
+  classId,
+  offerings,
+}: {
+  classId: string
+  offerings: Offering[]
+}) {
+  const router = useRouter()
+  const [pending, start] = useTransition()
+  const [courseCode, setCourseCode] = useState("")
+  const [courseName, setCourseName] = useState("")
+  const [courseType, setCourseType] = useState<CourseType>("theory")
+  const [credits, setCredits] = useState(3)
+  const [semester, setSemester] = useState(1)
+  const [caps, setCaps] = useState(CAP_PRESETS.theory)
+
+  function pickType(t: CourseType) {
+    setCourseType(t)
+    setCaps(CAP_PRESETS[t])
+  }
+
+  function add() {
+    start(async () => {
+      const res = await createSubjectAction({
+        classId,
+        courseCode,
+        courseName,
+        courseType,
+        credits,
+        semester,
+        ...caps,
+      })
+      if (res.error) {
+        toast.error(res.error)
+        return
+      }
+      toast.success("Subject added")
+      setCourseCode("")
+      setCourseName("")
+      router.refresh()
+    })
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1fr_360px]">
+      <div className="flex flex-col gap-3">
+        <h2 className="text-sm font-semibold">Subjects</h2>
+        {offerings.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            No subjects yet. Add one to start entering marks.
+          </p>
+        ) : (
+          <div className="border-border overflow-hidden rounded border">
+            <ul className="divide-border divide-y">
+              {offerings.map((o) => (
+                <li key={o.id}>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      router.push(
+                        `/dashboard/class/${classId}/marks?offering=${o.id}`
+                      )
+                    }
+                    className="hover:bg-muted flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors"
+                  >
+                    <div className="flex items-center gap-3">
+                      <Badge variant="outline" className="font-mono">
+                        {o.code}
+                      </Badge>
+                      <span className="text-sm">{o.name}</span>
+                    </div>
+                    <span className="text-muted-foreground text-xs">
+                      Sem {o.semester} · Enter marks →
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      <div className="border-border flex flex-col gap-3 rounded border p-4">
+        <h2 className="text-sm font-semibold">Add subject</h2>
+        <Field label="Course code">
+          <Input
+            value={courseCode}
+            onChange={(e) => setCourseCode(e.target.value.toUpperCase())}
+            placeholder="ITC501"
+            className="h-9 font-mono"
+          />
+        </Field>
+        <Field label="Course name">
+          <Input
+            value={courseName}
+            onChange={(e) => setCourseName(e.target.value)}
+            placeholder="Analog & Digital Communication"
+            className="h-9"
+          />
+        </Field>
+        <Field label="Type">
+          <div className="flex overflow-hidden rounded border">
+            {(["theory", "practical", "project"] as const).map((t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => pickType(t)}
+                className={cn(
+                  "flex-1 px-2 py-1.5 text-xs font-medium capitalize transition-colors",
+                  courseType === t
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:bg-muted"
+                )}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+        </Field>
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Credits">
+            <Input
+              type="number"
+              min={0}
+              value={credits}
+              onChange={(e) => setCredits(Number(e.target.value))}
+              className="h-9"
+            />
+          </Field>
+          <Field label="Semester">
+            <Input
+              type="number"
+              min={1}
+              max={8}
+              value={semester}
+              onChange={(e) => setSemester(Number(e.target.value))}
+              className="h-9"
+            />
+          </Field>
+        </div>
+        <div className="grid grid-cols-4 gap-2">
+          {(["maxIsa", "maxMse", "maxEse", "maxTotal"] as const).map((k) => (
+            <Field
+              key={k}
+              label={
+                { maxIsa: "ISA", maxMse: "MSE", maxEse: "ESE", maxTotal: "Total" }[
+                  k
+                ]
+              }
+            >
+              <Input
+                type="number"
+                min={0}
+                value={caps[k]}
+                onChange={(e) =>
+                  setCaps((c) => ({ ...c, [k]: Number(e.target.value) }))
+                }
+                className="h-9"
+              />
+            </Field>
+          ))}
+        </div>
+        <Button
+          size="sm"
+          className="mt-1"
+          disabled={pending || !courseCode.trim() || !courseName.trim()}
+          onClick={add}
+        >
+          {pending ? "Adding…" : "Add subject"}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function MarksGrid({
+  classId,
+  offering,
+  grid,
+}: {
+  classId: string
+  offering: Offering
+  grid: Grid
+}) {
+  const router = useRouter()
+  const [pending, start] = useTransition()
+  const [rows, setRows] = useState<Row[]>(grid.rows)
+  const { course } = grid
+  const hasMse = course.maxMse > 0
+
+  function edit(
+    studentId: string,
+    field: "isa" | "mse1" | "mse2" | "ese",
+    value: string
+  ) {
+    const n = value === "" ? null : Number(value)
+    setRows((rs) =>
+      rs.map((r) => (r.studentId === studentId ? { ...r, [field]: n } : r))
+    )
+  }
+
+  function save() {
+    start(async () => {
+      const res = await saveMarksAction({
+        offeringId: offering.id,
+        rows: rows.map((r) => ({
+          studentId: r.studentId,
+          isa: r.isa,
+          mse1: r.mse1,
+          mse2: r.mse2,
+          ese: r.ese,
+        })),
+      })
+      if (res.error) {
+        toast.error(res.error)
+        return
+      }
+      toast.success("Marks saved")
+      router.refresh()
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => router.push(`/dashboard/class/${classId}/marks`)}
+          >
+            ← Subjects
+          </Button>
+          <Badge variant="outline" className="font-mono">
+            {offering.code}
+          </Badge>
+          <span className="text-sm font-medium">{offering.name}</span>
+          <span className="text-muted-foreground text-xs">
+            ISA/{course.maxIsa}
+            {hasMse ? ` · MSE/${course.maxMse}` : ""} · ESE/{course.maxEse} ·
+            Total/{course.maxTotal}
+          </span>
+        </div>
+        <Button size="sm" disabled={pending} onClick={save}>
+          {pending ? "Saving…" : "Save marks"}
+        </Button>
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="text-muted-foreground text-sm">
+          No students in this class yet.
+        </p>
+      ) : (
+        <div className="border-border overflow-x-auto rounded border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-muted-foreground text-xs">
+              <tr className="[&>th]:px-3 [&>th]:py-2 [&>th]:text-left [&>th]:font-medium">
+                <th>Roll</th>
+                <th>Name</th>
+                <th className="w-20">ISA</th>
+                {hasMse && <th className="w-20">MSE 1</th>}
+                {hasMse && <th className="w-20">MSE 2</th>}
+                <th className="w-20">ESE</th>
+                <th className="w-16">Total</th>
+                <th className="w-16">%</th>
+                <th className="w-16">Grade</th>
+              </tr>
+            </thead>
+            <tbody className="divide-border divide-y">
+              {rows.map((r) => {
+                const c = computeMarks(r, course)
+                return (
+                  <tr key={r.studentId} className="[&>td]:px-3 [&>td]:py-1.5">
+                    <td className="font-mono text-xs">{r.rollNumber}</td>
+                    <td className="whitespace-nowrap">{r.name}</td>
+                    <td>
+                      <MarkInput
+                        value={r.isa}
+                        max={course.maxIsa}
+                        onChange={(v) => edit(r.studentId, "isa", v)}
+                      />
+                    </td>
+                    {hasMse && (
+                      <td>
+                        <MarkInput
+                          value={r.mse1}
+                          max={course.maxMse}
+                          onChange={(v) => edit(r.studentId, "mse1", v)}
+                        />
+                      </td>
+                    )}
+                    {hasMse && (
+                      <td>
+                        <MarkInput
+                          value={r.mse2}
+                          max={course.maxMse}
+                          onChange={(v) => edit(r.studentId, "mse2", v)}
+                        />
+                      </td>
+                    )}
+                    <td>
+                      <MarkInput
+                        value={r.ese}
+                        max={course.maxEse}
+                        onChange={(v) => edit(r.studentId, "ese", v)}
+                      />
+                    </td>
+                    <td className="tabular-nums">{c.total}</td>
+                    <td className="text-muted-foreground tabular-nums">
+                      {c.percentage ?? "—"}
+                    </td>
+                    <td>
+                      {c.gradePoint == null ? (
+                        <span className="text-muted-foreground">—</span>
+                      ) : c.gradePoint === "Fail" ? (
+                        <Badge variant="destructive">Fail</Badge>
+                      ) : (
+                        <Badge variant="outline">{c.gradePoint}</Badge>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function MarkInput({
+  value,
+  max,
+  onChange,
+}: {
+  value: number | null
+  max: number
+  onChange: (v: string) => void
+}) {
+  return (
+    <Input
+      type="number"
+      min={0}
+      max={max}
+      value={value ?? ""}
+      onChange={(e) => onChange(e.target.value)}
+      className="h-8 w-16 tabular-nums"
+    />
+  )
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="grid gap-1.5">
+      <label className="text-muted-foreground text-xs">{label}</label>
+      {children}
+    </div>
+  )
+}

--- a/src/app/dashboard/class/[classId]/marks/page.tsx
+++ b/src/app/dashboard/class/[classId]/marks/page.tsx
@@ -1,0 +1,98 @@
+import { notFound, redirect } from "next/navigation"
+import { PageHeader } from "@/components/page-header"
+import { getSessionUser } from "@/lib/session"
+import { can } from "@/lib/rbac"
+import { expectedYear } from "@/lib/roll-number"
+import { getClassById } from "@/db/queries/classes"
+import { getStudentsByClassIds } from "@/db/queries/students"
+import {
+  listOfferingsForClass,
+  getOfferingById,
+} from "@/db/queries/offerings"
+import { getMarksForOffering } from "@/db/queries/marks"
+import { MarksClient } from "./client"
+
+export const dynamic = "force-dynamic"
+
+export default async function MarksPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ classId: string }>
+  searchParams: Promise<{ offering?: string }>
+}) {
+  const { classId } = await params
+  const { offering: offeringId } = await searchParams
+  const user = await getSessionUser()
+  if (!user) redirect("/login")
+  if (!can(user, "marks:write")) redirect("/dashboard")
+
+  const cls = await getClassById(classId)
+  if (!cls) return notFound()
+  const inScope =
+    user.tier === "super_admin" ||
+    user.classIds.includes(classId) ||
+    (user.tier === "hod" && user.deptCodes.includes(cls.departmentCode))
+  if (!inScope) redirect("/dashboard/class")
+
+  const offerings = await listOfferingsForClass(classId)
+  const yr = expectedYear(cls.admissionYear, new Date()) ?? cls.admissionYear
+  const label = `${yr} · ${cls.departmentCode} · ${cls.division}`
+
+  // If a subject is selected, load its grid data.
+  let grid = null
+  const selected =
+    offeringId && offerings.find((o) => o.id === offeringId)
+      ? await getOfferingById(offeringId)
+      : null
+  if (selected) {
+    const [students, existing] = await Promise.all([
+      getStudentsByClassIds([classId]),
+      getMarksForOffering(selected.id),
+    ])
+    const byStudent = Object.fromEntries(existing.map((m) => [m.studentId, m]))
+    grid = {
+      offeringId: selected.id,
+      course: {
+        courseType: selected.course.courseType,
+        credits: selected.course.credits,
+        maxIsa: selected.course.maxIsa,
+        maxMse: selected.course.maxMse,
+        maxEse: selected.course.maxEse,
+        maxTotal: selected.course.maxTotal,
+      },
+      rows: students.map((s) => ({
+        studentId: s.id,
+        name: `${s.firstName} ${s.lastName}`.trim(),
+        rollNumber: s.rollNumber,
+        isa: byStudent[s.id]?.isa ?? null,
+        mse1: byStudent[s.id]?.mse1 ?? null,
+        mse2: byStudent[s.id]?.mse2 ?? null,
+        ese: byStudent[s.id]?.ese ?? null,
+      })),
+    }
+  }
+
+  return (
+    <>
+      <PageHeader
+        title={`Marks — ${label}`}
+        parent="My classes"
+        parentHref={`/dashboard/class/${classId}`}
+      />
+      <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
+        <MarksClient
+          classId={classId}
+          offerings={offerings.map((o) => ({
+            id: o.id,
+            code: o.course.courseCode,
+            name: o.course.courseName,
+            semester: o.semester,
+          }))}
+          selectedId={grid?.offeringId ?? null}
+          grid={grid}
+        />
+      </div>
+    </>
+  )
+}

--- a/src/app/dashboard/class/[classId]/page.tsx
+++ b/src/app/dashboard/class/[classId]/page.tsx
@@ -1,5 +1,8 @@
+import Link from "next/link"
 import { notFound, redirect } from "next/navigation"
+import { CalendarCheckIcon } from "lucide-react"
 import { PageHeader } from "@/components/page-header"
+import { buttonVariants } from "@/components/ui/button"
 import { getSessionUser } from "@/lib/session"
 import { expectedYear } from "@/lib/roll-number"
 import { getClassById } from "@/db/queries/classes"
@@ -38,14 +41,23 @@ export default async function ClassDetailPage({
         parentHref="/dashboard/class"
       />
       <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
-        <div>
-          <h3 className="text-sm font-medium">
-            Enrolment requests ({requests.length})
-          </h3>
-          <p className="text-muted-foreground mt-1 text-xs leading-relaxed">
-            Students who claimed a roll number in {label}. Check each against
-            your attendance sheet, then approve to link them.
-          </p>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-medium">
+              Enrolment requests ({requests.length})
+            </h3>
+            <p className="text-muted-foreground mt-1 text-xs leading-relaxed">
+              Students who claimed a roll number in {label}. Check each against
+              your attendance sheet, then approve to link them.
+            </p>
+          </div>
+          <Link
+            href={`/dashboard/class/${classId}/attendance`}
+            className={buttonVariants({ variant: "outline", size: "sm" })}
+          >
+            <CalendarCheckIcon className="mr-1.5 size-3.5" />
+            Take attendance
+          </Link>
         </div>
         <QueueClient
           requests={requests.map((r) => ({

--- a/src/app/dashboard/class/[classId]/page.tsx
+++ b/src/app/dashboard/class/[classId]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link"
 import { notFound, redirect } from "next/navigation"
-import { CalendarCheckIcon } from "lucide-react"
+import { CalendarCheckIcon, GraduationCapIcon } from "lucide-react"
 import { PageHeader } from "@/components/page-header"
 import { buttonVariants } from "@/components/ui/button"
 import { getSessionUser } from "@/lib/session"
@@ -51,13 +51,22 @@ export default async function ClassDetailPage({
               your attendance sheet, then approve to link them.
             </p>
           </div>
-          <Link
-            href={`/dashboard/class/${classId}/attendance`}
-            className={buttonVariants({ variant: "outline", size: "sm" })}
-          >
-            <CalendarCheckIcon className="mr-1.5 size-3.5" />
-            Take attendance
-          </Link>
+          <div className="flex items-center gap-2">
+            <Link
+              href={`/dashboard/class/${classId}/attendance`}
+              className={buttonVariants({ variant: "outline", size: "sm" })}
+            >
+              <CalendarCheckIcon className="mr-1.5 size-3.5" />
+              Take attendance
+            </Link>
+            <Link
+              href={`/dashboard/class/${classId}/marks`}
+              className={buttonVariants({ variant: "outline", size: "sm" })}
+            >
+              <GraduationCapIcon className="mr-1.5 size-3.5" />
+              Enter marks
+            </Link>
+          </div>
         </div>
         <QueueClient
           requests={requests.map((r) => ({

--- a/src/app/dashboard/class/actions.ts
+++ b/src/app/dashboard/class/actions.ts
@@ -7,10 +7,16 @@ import { getErrorMessage } from "@/lib/error-utils"
 import { parseRollNumber, expectedYear } from "@/lib/roll-number"
 import { createAuditLog } from "@/db/queries"
 import { getClassById } from "@/db/queries/classes"
-import { createStudent, getStudentByRollNumber } from "@/db/queries/students"
+import {
+  createStudent,
+  getStudentByRollNumber,
+  getStudentsByClassIds,
+} from "@/db/queries/students"
 import { getRequestById, updateRequest } from "@/db/queries/onboarding"
+import { upsertAttendance } from "@/db/queries/attendance"
 
 type Result = { error: string | null }
+type AttStatus = "present" | "absent" | "late" | "excused"
 
 // A class is in scope if the caller coordinates/teaches it (classIds), is the HOD
 // of its department, or is super_admin.
@@ -118,5 +124,52 @@ export async function rejectEnrollmentAction(input: {
     return { error: null }
   } catch (err) {
     return { error: getErrorMessage(err, "Could not reject") }
+  }
+}
+
+export async function saveAttendanceAction(input: {
+  classId: string
+  sessionDate: string
+  sessionSlot: string
+  marks: { studentId: string; status: AttStatus }[]
+}): Promise<Result> {
+  try {
+    const user = await getSessionUser()
+    authorize(user, "attendance:write")
+    const { ok } = await classInScope(user!, input.classId)
+    if (!ok) return { error: "That class is not in your scope." }
+
+    // Only students actually in this class can be marked — a forged studentId is
+    // dropped, not written.
+    const roster = new Set(
+      (await getStudentsByClassIds([input.classId])).map((s) => s.id)
+    )
+    const entries = input.marks
+      .filter((m) => roster.has(m.studentId))
+      .map((m) => ({
+        studentId: m.studentId,
+        classId: input.classId,
+        sessionDate: input.sessionDate,
+        sessionSlot: input.sessionSlot,
+        status: m.status,
+        recordedByFacultyId: user!.facultyId,
+      }))
+    await upsertAttendance(entries)
+
+    await createAuditLog({
+      action: "attendance.recorded",
+      actorId: user!.id,
+      targetType: "class",
+      targetId: input.classId,
+      details: {
+        date: input.sessionDate,
+        slot: input.sessionSlot,
+        count: entries.length,
+      },
+    })
+    revalidatePath(`/dashboard/class/${input.classId}/attendance`)
+    return { error: null }
+  } catch (err) {
+    return { error: getErrorMessage(err, "Could not save attendance") }
   }
 }

--- a/src/app/dashboard/class/actions.ts
+++ b/src/app/dashboard/class/actions.ts
@@ -14,6 +14,9 @@ import {
 } from "@/db/queries/students"
 import { getRequestById, updateRequest } from "@/db/queries/onboarding"
 import { upsertAttendance } from "@/db/queries/attendance"
+import { getCourseByCode, createCourse } from "@/db/queries/courses"
+import { createOffering, getOfferingById } from "@/db/queries/offerings"
+import { upsertMarks } from "@/db/queries/marks"
 
 type Result = { error: string | null }
 type AttStatus = "present" | "absent" | "late" | "excused"
@@ -171,5 +174,104 @@ export async function saveAttendanceAction(input: {
     return { error: null }
   } catch (err) {
     return { error: getErrorMessage(err, "Could not save attendance") }
+  }
+}
+
+export async function createSubjectAction(input: {
+  classId: string
+  courseCode: string
+  courseName: string
+  courseType: "theory" | "practical" | "project"
+  credits: number
+  maxIsa: number
+  maxMse: number
+  maxEse: number
+  maxTotal: number
+  semester: number
+}): Promise<Result> {
+  try {
+    const user = await getSessionUser()
+    authorize(user, "marks:write")
+    const { ok, cls } = await classInScope(user!, input.classId)
+    if (!ok || !cls) return { error: "That class is not in your scope." }
+    if (!input.courseCode.trim() || !input.courseName.trim())
+      return { error: "Course code and name are required." }
+
+    // Reuse the course if it already exists (a subject is taught to many classes),
+    // else create it under this class's department.
+    let course = await getCourseByCode(input.courseCode)
+    if (!course) {
+      course = await createCourse({
+        courseCode: input.courseCode,
+        courseName: input.courseName.trim(),
+        departmentCode: cls.departmentCode,
+        courseType: input.courseType,
+        credits: input.credits,
+        maxIsa: input.maxIsa,
+        maxMse: input.maxMse,
+        maxEse: input.maxEse,
+        maxTotal: input.maxTotal,
+      })
+    }
+    await createOffering({
+      courseId: course.id,
+      classId: input.classId,
+      facultyId: user!.facultyId,
+      semester: input.semester,
+    })
+    await createAuditLog({
+      action: "offering.created",
+      actorId: user!.id,
+      targetType: "class",
+      targetId: input.classId,
+      details: { courseCode: input.courseCode },
+    })
+    revalidatePath(`/dashboard/class/${input.classId}/marks`)
+    return { error: null }
+  } catch (err) {
+    return { error: getErrorMessage(err, "Could not add subject") }
+  }
+}
+
+export async function saveMarksAction(input: {
+  offeringId: string
+  rows: {
+    studentId: string
+    isa: number | null
+    mse1: number | null
+    mse2: number | null
+    ese: number | null
+  }[]
+}): Promise<Result> {
+  try {
+    const user = await getSessionUser()
+    authorize(user, "marks:write")
+    const offering = await getOfferingById(input.offeringId)
+    if (!offering) return { error: "No such subject." }
+    const { ok } = await classInScope(user!, offering.classId)
+    if (!ok) return { error: "That class is not in your scope." }
+
+    await upsertMarks(
+      input.rows.map((r) => ({
+        courseOfferingId: input.offeringId,
+        studentId: r.studentId,
+        isa: r.isa,
+        mse1: r.mse1,
+        mse2: r.mse2,
+        ese: r.ese,
+        recordedByFacultyId: user!.facultyId,
+      }))
+    )
+    await createAuditLog({
+      action: "marks.recorded",
+      actorId: user!.id,
+      targetType: "offering",
+      targetId: input.offeringId,
+      details: { count: input.rows.length },
+    })
+    revalidatePath(`/dashboard/class/${offering.classId}/marks`)
+    return { error: null }
+  } catch (err) {
+    return { error: getErrorMessage(err, "Could not save marks") }
   }
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,6 +3,9 @@ import { sql } from "drizzle-orm"
 import { PageHeader } from "@/components/page-header"
 import { getSessionUser } from "@/lib/session"
 import { getAttendanceSummaryForStudent } from "@/db/queries/attendance"
+import { getMarksForStudent } from "@/db/queries/marks"
+import { computeMarks, computeSgpi } from "@/lib/sgpi"
+import { Badge } from "@/components/ui/badge"
 import { db } from "@/db"
 import * as schema from "@/db/schema"
 
@@ -55,6 +58,19 @@ export default async function DashboardPage() {
   const attPct =
     att && att.total > 0 ? Math.round((att.present / att.total) * 100) : null
 
+  // A student's marks across every subject, with per-subject grade and SGPI.
+  const marksRows =
+    user.tier === "student" && user.studentId
+      ? await getMarksForStudent(user.studentId)
+      : []
+  const marks = marksRows.map((m) => {
+    const course = m.courseOffering.course
+    return { mark: m, course, computed: computeMarks(m, course) }
+  })
+  const sgpi = computeSgpi(
+    marks.map(({ mark, course }) => ({ marks: mark, course }))
+  )
+
   return (
     <>
       <PageHeader title="Dashboard" />
@@ -106,11 +122,66 @@ export default async function DashboardPage() {
               )}
             </div>
             <div className="border-border bg-card rounded border p-5">
-              <p className="text-muted-foreground text-sm">Marks</p>
-              <p className="text-muted-foreground mt-2 text-sm">
-                Appear here once your coordinator records them.
-              </p>
+              <p className="text-muted-foreground text-sm">SGPI</p>
+              {sgpi.sgpi === null ? (
+                <p className="text-muted-foreground mt-2 text-sm">
+                  Appears once your marks are recorded.
+                </p>
+              ) : (
+                <>
+                  <p className="mt-2 text-3xl font-bold tracking-tight">
+                    {sgpi.hasFail ? "—" : sgpi.sgpi.toFixed(2)}
+                  </p>
+                  <p className="text-muted-foreground mt-1 text-xs">
+                    {sgpi.hasFail
+                      ? "Held — clear all subjects to compute"
+                      : `${sgpi.totalCredits} credits`}
+                  </p>
+                </>
+              )}
             </div>
+          </div>
+        )}
+
+        {user.tier === "student" && marks.length > 0 && (
+          <div className="border-border bg-card overflow-x-auto rounded border">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 text-muted-foreground text-xs">
+                <tr className="[&>th]:px-4 [&>th]:py-2.5 [&>th]:text-left [&>th]:font-medium">
+                  <th>Code</th>
+                  <th>Subject</th>
+                  <th className="w-16">Total</th>
+                  <th className="w-16">%</th>
+                  <th className="w-16">Grade</th>
+                </tr>
+              </thead>
+              <tbody className="divide-border divide-y">
+                {marks.map(({ mark, course, computed }) => (
+                  <tr
+                    key={mark.id}
+                    className="[&>td]:px-4 [&>td]:py-2.5"
+                  >
+                    <td className="font-mono text-xs">{course.courseCode}</td>
+                    <td>{course.courseName}</td>
+                    <td className="tabular-nums">
+                      {computed.total} / {course.maxTotal}
+                    </td>
+                    <td className="text-muted-foreground tabular-nums">
+                      {computed.percentage ?? "—"}
+                    </td>
+                    <td>
+                      {computed.gradePoint == null ? (
+                        <span className="text-muted-foreground">—</span>
+                      ) : computed.gradePoint === "Fail" ? (
+                        <Badge variant="destructive">Fail</Badge>
+                      ) : (
+                        <Badge variant="outline">{computed.gradePoint}</Badge>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         )}
       </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation"
 import { sql } from "drizzle-orm"
 import { PageHeader } from "@/components/page-header"
 import { getSessionUser } from "@/lib/session"
+import { getAttendanceSummaryForStudent } from "@/db/queries/attendance"
 import { db } from "@/db"
 import * as schema from "@/db/schema"
 
@@ -46,6 +47,14 @@ export default async function DashboardPage() {
       ])
     : []
 
+  // A student sees their own attendance.
+  const att =
+    user.tier === "student" && user.studentId
+      ? await getAttendanceSummaryForStudent(user.studentId)
+      : null
+  const attPct =
+    att && att.total > 0 ? Math.round((att.present / att.total) * 100) : null
+
   return (
     <>
       <PageHeader title="Dashboard" />
@@ -57,7 +66,7 @@ export default async function DashboardPage() {
           <p className="text-muted-foreground mt-1 text-sm">
             {staff
               ? "Your workspace across VERP."
-              : "Your attendance and marks will appear here once your class coordinator uploads them."}
+              : "Your attendance and marks."}
           </p>
         </div>
 
@@ -66,7 +75,7 @@ export default async function DashboardPage() {
             {cards.map((c) => (
               <div
                 key={c.label}
-                className="border-border bg-card rounded-xl border p-5"
+                className="border-border bg-card rounded border p-5"
               >
                 <p className="text-muted-foreground text-sm">{c.label}</p>
                 <p className="mt-2 text-3xl font-bold tracking-tight">
@@ -74,6 +83,34 @@ export default async function DashboardPage() {
                 </p>
               </div>
             ))}
+          </div>
+        )}
+
+        {user.tier === "student" && (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="border-border bg-card rounded border p-5">
+              <p className="text-muted-foreground text-sm">Attendance</p>
+              {attPct === null ? (
+                <p className="text-muted-foreground mt-2 text-sm">
+                  No sessions recorded yet.
+                </p>
+              ) : (
+                <>
+                  <p className="mt-2 text-3xl font-bold tracking-tight">
+                    {attPct}%
+                  </p>
+                  <p className="text-muted-foreground mt-1 text-xs">
+                    {att!.present} of {att!.total} sessions present
+                  </p>
+                </>
+              )}
+            </div>
+            <div className="border-border bg-card rounded border p-5">
+              <p className="text-muted-foreground text-sm">Marks</p>
+              <p className="text-muted-foreground mt-2 text-sm">
+                Appear here once your coordinator records them.
+              </p>
+            </div>
           </div>
         )}
       </div>

--- a/src/db/queries/attendance.ts
+++ b/src/db/queries/attendance.ts
@@ -1,0 +1,64 @@
+import { and, eq, sql } from "drizzle-orm"
+import { db } from "@/db"
+import { attendance } from "@/db/schema"
+
+type Entry = {
+  studentId: string
+  classId: string
+  sessionDate: string
+  sessionSlot: string
+  status: "present" | "absent" | "late" | "excused"
+  recordedByFacultyId: string | null
+}
+
+// One row per (student, date, slot); re-recording a session overwrites it.
+export async function upsertAttendance(entries: Entry[]) {
+  if (entries.length === 0) return
+  await db
+    .insert(attendance)
+    .values(entries)
+    .onConflictDoUpdate({
+      target: [
+        attendance.studentId,
+        attendance.sessionDate,
+        attendance.sessionSlot,
+      ],
+      set: {
+        status: sql`excluded.status`,
+        recordedByFacultyId: sql`excluded.recorded_by_faculty_id`,
+        updatedAt: new Date(),
+      },
+    })
+}
+
+export async function getAttendanceForSession(
+  classId: string,
+  sessionDate: string,
+  sessionSlot: string
+) {
+  return db
+    .select({
+      studentId: attendance.studentId,
+      status: attendance.status,
+    })
+    .from(attendance)
+    .where(
+      and(
+        eq(attendance.classId, classId),
+        eq(attendance.sessionDate, sessionDate),
+        eq(attendance.sessionSlot, sessionSlot)
+      )
+    )
+}
+
+// A student's overall attendance — present sessions over total recorded.
+export async function getAttendanceSummaryForStudent(studentId: string) {
+  const [row] = await db
+    .select({
+      present: sql<number>`count(*) filter (where status = 'present')::int`,
+      total: sql<number>`count(*)::int`,
+    })
+    .from(attendance)
+    .where(eq(attendance.studentId, studentId))
+  return { present: row?.present ?? 0, total: row?.total ?? 0 }
+}

--- a/src/db/queries/courses.ts
+++ b/src/db/queries/courses.ts
@@ -1,0 +1,38 @@
+import { and, eq, inArray } from "drizzle-orm"
+import { db } from "@/db"
+import { courses } from "@/db/schema"
+
+export async function getCourseByCode(code: string) {
+  return db.query.courses.findFirst({
+    where: eq(courses.courseCode, code.toUpperCase()),
+  })
+}
+
+export async function listCoursesForDepts(deptCodes: string[]) {
+  if (deptCodes.length === 0) return []
+  return db
+    .select()
+    .from(courses)
+    .where(
+      and(eq(courses.isActive, true), inArray(courses.departmentCode, deptCodes))
+    )
+    .orderBy(courses.courseCode)
+}
+
+export async function createCourse(input: {
+  courseCode: string
+  courseName: string
+  departmentCode: string
+  courseType: "theory" | "practical" | "project"
+  credits: number
+  maxIsa: number
+  maxMse: number
+  maxEse: number
+  maxTotal: number
+}) {
+  const [row] = await db
+    .insert(courses)
+    .values({ ...input, courseCode: input.courseCode.toUpperCase() })
+    .returning()
+  return row
+}

--- a/src/db/queries/marks.ts
+++ b/src/db/queries/marks.ts
@@ -1,0 +1,54 @@
+import { eq, sql } from "drizzle-orm"
+import { db } from "@/db"
+import { marks } from "@/db/schema"
+
+type Entry = {
+  courseOfferingId: string
+  studentId: string
+  isa: number | null
+  mse1: number | null
+  mse2: number | null
+  ese: number | null
+  recordedByFacultyId: string | null
+}
+
+// One row per (offering, student); re-entering overwrites.
+export async function upsertMarks(entries: Entry[]) {
+  if (entries.length === 0) return
+  await db
+    .insert(marks)
+    .values(entries)
+    .onConflictDoUpdate({
+      target: [marks.courseOfferingId, marks.studentId],
+      set: {
+        isa: sql`excluded.isa`,
+        mse1: sql`excluded.mse1`,
+        mse2: sql`excluded.mse2`,
+        ese: sql`excluded.ese`,
+        recordedByFacultyId: sql`excluded.recorded_by_faculty_id`,
+        updatedAt: new Date(),
+      },
+    })
+}
+
+export async function getMarksForOffering(courseOfferingId: string) {
+  return db
+    .select({
+      studentId: marks.studentId,
+      isa: marks.isa,
+      mse1: marks.mse1,
+      mse2: marks.mse2,
+      ese: marks.ese,
+    })
+    .from(marks)
+    .where(eq(marks.courseOfferingId, courseOfferingId))
+}
+
+// A student's marks across every subject, with the course details needed to
+// compute grade points and SGPI.
+export async function getMarksForStudent(studentId: string) {
+  return db.query.marks.findMany({
+    where: eq(marks.studentId, studentId),
+    with: { courseOffering: { with: { course: true } } },
+  })
+}

--- a/src/db/queries/offerings.ts
+++ b/src/db/queries/offerings.ts
@@ -1,0 +1,32 @@
+import { and, eq } from "drizzle-orm"
+import { db } from "@/db"
+import { courseOfferings } from "@/db/schema"
+
+export async function createOffering(input: {
+  courseId: string
+  classId: string
+  facultyId: string | null
+  semester: number
+}) {
+  const [row] = await db.insert(courseOfferings).values(input).returning()
+  return row
+}
+
+export async function getOfferingById(id: string) {
+  return db.query.courseOfferings.findFirst({
+    where: eq(courseOfferings.id, id),
+    with: { course: true, class: true },
+  })
+}
+
+// Every subject a class is being taught, with the course details.
+export async function listOfferingsForClass(classId: string) {
+  return db.query.courseOfferings.findMany({
+    where: and(
+      eq(courseOfferings.classId, classId),
+      eq(courseOfferings.isActive, true)
+    ),
+    with: { course: true },
+    orderBy: courseOfferings.semester,
+  })
+}

--- a/src/lib/sgpi.ts
+++ b/src/lib/sgpi.ts
@@ -1,0 +1,108 @@
+export type MarksInput = {
+  isa: number | null
+  mse1: number | null
+  mse2: number | null
+  ese: number | null
+}
+
+export type CourseInfo = {
+  courseType: string
+  credits: number
+  maxIsa: number
+  maxMse: number
+  maxEse: number
+  maxTotal: number
+}
+
+export type ComputedMarks = {
+  finalMse: number | null
+  total: number
+  percentage: number | null
+  gradePoint: number | "Fail" | null
+  status: "pass" | "fail" | null
+  creditPoints: number | null
+}
+
+export function computeMarks(
+  marks: MarksInput,
+  course: CourseInfo
+): ComputedMarks {
+  const hasMse = course.maxMse > 0
+  const finalMse =
+    hasMse && marks.mse1 != null && marks.mse2 != null
+      ? Math.round((marks.mse1 + marks.mse2) / 2)
+      : hasMse
+        ? null
+        : 0
+
+  const isa = marks.isa ?? 0
+  const mse = finalMse ?? 0
+  const ese = marks.ese ?? 0
+  const total = isa + mse + ese
+
+  const hasAllMarks =
+    marks.isa != null && (!hasMse || finalMse != null) && marks.ese != null
+
+  if (!hasAllMarks) {
+    return {
+      finalMse,
+      total,
+      percentage: null,
+      gradePoint: null,
+      status: null,
+      creditPoints: null,
+    }
+  }
+
+  const percentage = Math.round((total / course.maxTotal) * 100 * 10) / 10
+  const gradePoint = getGradePoint(percentage)
+  const status = percentage >= 40 ? ("pass" as const) : ("fail" as const)
+  const creditPoints =
+    typeof gradePoint === "number" ? gradePoint * course.credits : null
+
+  return { finalMse, total, percentage, gradePoint, status, creditPoints }
+}
+
+export function getGradePoint(pct: number): number | "Fail" {
+  if (pct >= 80) return 10
+  if (pct >= 75) return 9
+  if (pct >= 70) return 8
+  if (pct >= 60) return 7
+  if (pct >= 50) return 6
+  if (pct >= 45) return 5
+  if (pct >= 40) return 4
+  return "Fail"
+}
+
+export type SgpiResult = {
+  totalCreditPoints: number
+  totalCredits: number
+  sgpi: number | null
+  hasFail: boolean
+}
+
+export function computeSgpi(
+  entries: { marks: MarksInput; course: CourseInfo }[]
+): SgpiResult {
+  let totalCreditPoints = 0
+  let totalCredits = 0
+  let hasFail = false
+
+  for (const { marks, course } of entries) {
+    const computed = computeMarks(marks, course)
+    totalCredits += course.credits
+
+    if (computed.status === "fail" || computed.gradePoint === "Fail") {
+      hasFail = true
+    } else if (computed.creditPoints != null) {
+      totalCreditPoints += computed.creditPoints
+    }
+  }
+
+  const sgpi =
+    totalCredits > 0
+      ? Math.round((totalCreditPoints / totalCredits) * 100) / 100
+      : null
+
+  return { totalCreditPoints, totalCredits, sgpi, hasFail }
+}


### PR DESCRIPTION
Phase 5 of the VERP MVP: coordinators/faculty record attendance and marks; students see their own attendance %, marks, and SGPI.

## Attendance
- Coordinator takes attendance per class per date/slot (present/absent, bulk all-present/all-absent). Forged studentIds are dropped against the roster.
- Student dashboard shows attendance %.

## Marks
- Faculty add subjects inline per class (course reused across classes; offering scoped to the class + recording faculty). ISA/MSE/ESE caps auto-fill from VIT presets by type (theory carries MSE; practical/project don't).
- Marks grid: ISA/MSE1/MSE2/ESE per student with live total, %, and grade.
- Student dashboard shows per-subject grades and computed SGPI (held on any Fail).

## Security
- Every write gated by `authorize(attendance:write | marks:write)` plus a server-side `classInScope` re-check.

## Deploy note
Needs `npm run db:push` for the new tables (attendance, courses, course_offerings, marks, marks_locks) before deploy, or /dashboard 500s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)