### PR TITLE
Marks import, roll-derived class membership, faculty CSV import (+ CI/perf fixes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
+        "unpdf": "^1.6.2",
         "vaul": "^1.1.2",
         "ws": "^8.19.0",
         "zod": "^4.3.6"
@@ -9510,7 +9511,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -13997,6 +13998,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpdf": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.6.2.tgz",
+      "integrity": "sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.69"
+      },
+      "peerDependenciesMeta": {
+        "@napi-rs/canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
+    "unpdf": "^1.6.2",
     "vaul": "^1.1.2",
     "ws": "^8.19.0",
     "zod": "^4.3.6"

--- a/src/app/api/marks/import/preview/route.ts
+++ b/src/app/api/marks/import/preview/route.ts
@@ -41,7 +41,10 @@ function guessHeaders(lines: string[][], columnCount: number): string[] {
   const cols = header
     .map((c) => c.trim())
     .filter((c) => c && !/^(sr|s)\.?\s*no|roll|name|student/i.test(c))
-  return Array.from({ length: columnCount }, (_, i) => cols[cols.length - columnCount + i] ?? "")
+  return Array.from(
+    { length: columnCount },
+    (_, i) => cols[cols.length - columnCount + i] ?? ""
+  )
 }
 
 export async function POST(req: NextRequest) {
@@ -66,14 +69,17 @@ export async function POST(req: NextRequest) {
 
     const buffer = Buffer.from(await file.arrayBuffer())
     const isPdf =
-      file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf")
+      file.type === "application/pdf" ||
+      file.name.toLowerCase().endsWith(".pdf")
 
     let lines: string[][]
     if (isPdf) {
       lines = await pdfToLines(buffer)
     } else {
       const wb = new ExcelJS.Workbook()
-      await wb.xlsx.load(buffer as unknown as Parameters<typeof wb.xlsx.load>[0])
+      await wb.xlsx.load(
+        buffer as unknown as Parameters<typeof wb.xlsx.load>[0]
+      )
       if (wb.worksheets.length === 0)
         return apiError("The file has no sheets", 400)
       lines = wb.worksheets.flatMap((w) => xlsxToLines(w))

--- a/src/app/api/marks/import/preview/route.ts
+++ b/src/app/api/marks/import/preview/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest } from "next/server"
+import ExcelJS from "exceljs"
+import { apiError, apiSuccess } from "@/lib/api-response"
+import { getErrorMessage } from "@/lib/error-utils"
+import { getSessionUser } from "@/lib/session"
+import { can } from "@/lib/rbac"
+import { getClassById } from "@/db/queries/classes"
+import { getStudentsByClassIds } from "@/db/queries/students"
+import { extractRows, guessTargets } from "@/lib/marks-import"
+import { pdfToLines } from "@/lib/pdf-extract"
+
+export const dynamic = "force-dynamic"
+
+// Server-side parse, mirroring the roster importer: the file is read once and
+// only the structured, roster-matched preview goes back to the browser. The raw
+// PDF/xlsx is never round-tripped.
+const MAX_ROWS = 3000
+
+function xlsxToLines(sheet: ExcelJS.Worksheet): string[][] {
+  const out: string[][] = []
+  sheet.eachRow({ includeEmpty: false }, (row) => {
+    const cells: string[] = []
+    row.eachCell({ includeEmpty: true }, (cell, col) => {
+      cells[col - 1] = (cell.text ?? "").toString().trim()
+    })
+    out.push(cells)
+  })
+  return out
+}
+
+// Best-effort column headers: the line that names the mark columns (ISA / MSE /
+// ESE / Total / Average) with the Sr/Roll/Name labels stripped, aligned to the
+// trailing mark columns. Only seeds the mapping — the faculty confirms it.
+function guessHeaders(lines: string[][], columnCount: number): string[] {
+  const header = lines.find(
+    (l) =>
+      /ISA|MSE|ESE|Total|Average/i.test(l.join(" ")) &&
+      !l.some((c) => /^\d{2}\d{3}[A-Z]\d{4}$/i.test(c.trim()))
+  )
+  if (!header) return Array(columnCount).fill("")
+  const cols = header
+    .map((c) => c.trim())
+    .filter((c) => c && !/^(sr|s)\.?\s*no|roll|name|student/i.test(c))
+  return Array.from({ length: columnCount }, (_, i) => cols[cols.length - columnCount + i] ?? "")
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = await getSessionUser()
+    if (!can(user, "marks:write")) return apiError("Forbidden", 403)
+
+    const form = await req.formData()
+    const file = form.get("file")
+    const classId = (form.get("classId") ?? "").toString()
+    if (!(file instanceof File)) return apiError("No file uploaded", 400)
+    if (!classId) return apiError("No class specified", 400)
+
+    // The class must be in the caller's scope, same rule as the marks actions.
+    const cls = await getClassById(classId)
+    if (!cls) return apiError("No such class", 404)
+    const inScope =
+      user!.tier === "super_admin" ||
+      user!.classIds.includes(classId) ||
+      (user!.tier === "hod" && user!.deptCodes.includes(cls.departmentCode))
+    if (!inScope) return apiError("That class is not in your scope", 403)
+
+    const buffer = Buffer.from(await file.arrayBuffer())
+    const isPdf =
+      file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf")
+
+    let lines: string[][]
+    if (isPdf) {
+      lines = await pdfToLines(buffer)
+    } else {
+      const wb = new ExcelJS.Workbook()
+      await wb.xlsx.load(buffer as unknown as Parameters<typeof wb.xlsx.load>[0])
+      if (wb.worksheets.length === 0)
+        return apiError("The file has no sheets", 400)
+      lines = wb.worksheets.flatMap((w) => xlsxToLines(w))
+    }
+
+    const { rows, columnCount } = extractRows(lines)
+    if (rows.length === 0)
+      return apiError(
+        "No student rows found. Check the file has roll numbers and marks.",
+        400
+      )
+    const trimmed = rows.slice(0, MAX_ROWS)
+
+    // Match each parsed roll against this class's roster. Rows from another
+    // division (files often stack A and B) or not-yet-enrolled students match
+    // nothing and are flagged, never written.
+    const roster = await getStudentsByClassIds([classId])
+    const byRoll = new Map(roster.map((s) => [s.rollNumber.toUpperCase(), s]))
+
+    const previewRows = trimmed.map((r) => {
+      const student = byRoll.get(r.rollNumber)
+      return {
+        rollNumber: r.rollNumber,
+        name: r.name,
+        marks: r.marks,
+        studentId: student?.id ?? null,
+        matched: Boolean(student),
+      }
+    })
+
+    const headers = guessHeaders(lines, columnCount)
+    return apiSuccess({
+      columnCount,
+      headers,
+      guess: guessTargets(headers),
+      rows: previewRows,
+      totalRows: previewRows.length,
+      matchedRows: previewRows.filter((r) => r.matched).length,
+      truncated: rows.length > MAX_ROWS,
+    })
+  } catch (err) {
+    console.error("Failed to preview marks import:", err)
+    return apiError(getErrorMessage(err, "Could not read that file"), 500)
+  }
+}

--- a/src/app/dashboard/class/[classId]/marks/client.tsx
+++ b/src/app/dashboard/class/[classId]/marks/client.tsx
@@ -208,9 +208,12 @@ function SubjectSetup({
             <Field
               key={k}
               label={
-                { maxIsa: "ISA", maxMse: "MSE", maxEse: "ESE", maxTotal: "Total" }[
-                  k
-                ]
+                {
+                  maxIsa: "ISA",
+                  maxMse: "MSE",
+                  maxEse: "ESE",
+                  maxTotal: "Total",
+                }[k]
               }
             >
               <Input

--- a/src/app/dashboard/class/[classId]/marks/client.tsx
+++ b/src/app/dashboard/class/[classId]/marks/client.tsx
@@ -98,7 +98,18 @@ function SubjectSetup({
   return (
     <div className="grid gap-6 lg:grid-cols-[1fr_360px]">
       <div className="flex flex-col gap-3">
-        <h2 className="text-sm font-semibold">Subjects</h2>
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold">Subjects</h2>
+          <button
+            type="button"
+            onClick={() =>
+              router.push(`/dashboard/class/${classId}/marks/import`)
+            }
+            className="text-muted-foreground hover:text-foreground text-xs underline"
+          >
+            Import from file
+          </button>
+        </div>
         {offerings.length === 0 ? (
           <p className="text-muted-foreground text-sm">
             No subjects yet. Add one to start entering marks.

--- a/src/app/dashboard/class/[classId]/marks/import/client.tsx
+++ b/src/app/dashboard/class/[classId]/marks/import/client.tsx
@@ -1,0 +1,279 @@
+"use client"
+
+import { useRef, useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { applyMapping, type MarkTarget } from "@/lib/marks-import"
+import { saveMarksAction } from "../../../actions"
+
+type Offering = { id: string; code: string; name: string }
+type PreviewRow = {
+  rollNumber: string
+  name: string
+  marks: (number | null)[]
+  studentId: string | null
+  matched: boolean
+}
+type Preview = {
+  columnCount: number
+  headers: string[]
+  guess: MarkTarget[]
+  rows: PreviewRow[]
+  totalRows: number
+  matchedRows: number
+  truncated: boolean
+}
+
+const TARGETS: { value: MarkTarget; label: string }[] = [
+  { value: "skip", label: "Skip" },
+  { value: "isa", label: "ISA" },
+  { value: "mse_avg", label: "MSE (avg)" },
+  { value: "mse1", label: "MSE 1" },
+  { value: "mse2", label: "MSE 2" },
+  { value: "ese", label: "ESE" },
+]
+
+const fmt = (v: number | null) => (v === null ? "AB" : String(v))
+
+export function ImportClient({
+  classId,
+  offerings,
+}: {
+  classId: string
+  offerings: Offering[]
+}) {
+  const router = useRouter()
+  const fileRef = useRef<HTMLInputElement>(null)
+  const [file, setFile] = useState<File | null>(null)
+  const [uploading, setUploading] = useState(false)
+  const [preview, setPreview] = useState<Preview | null>(null)
+  const [mapping, setMapping] = useState<MarkTarget[]>([])
+  const [offeringId, setOfferingId] = useState("")
+  const [committing, start] = useTransition()
+
+  async function runPreview() {
+    if (!file) return
+    setUploading(true)
+    setPreview(null)
+    try {
+      const fd = new FormData()
+      fd.append("file", file)
+      fd.append("classId", classId)
+      const res = await fetch("/api/marks/import/preview", {
+        method: "POST",
+        body: fd,
+      })
+      const json = await res.json()
+      if (!res.ok) {
+        toast.error(json.error ?? "Could not read that file")
+        return
+      }
+      const data = json.data as Preview
+      setPreview(data)
+      setMapping(data.guess)
+    } catch {
+      toast.error("Could not read that file")
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  function setCol(i: number, target: MarkTarget) {
+    setMapping((m) => m.map((t, idx) => (idx === i ? target : t)))
+  }
+
+  function commit() {
+    if (!preview) return
+    if (!offeringId) {
+      toast.error("Pick the subject these marks belong to.")
+      return
+    }
+    if (mapping.every((t) => t === "skip")) {
+      toast.error("Map at least one column to a mark field.")
+      return
+    }
+    const rows = preview.rows
+      .filter((r) => r.matched && r.studentId)
+      .map((r) => ({ studentId: r.studentId!, ...applyMapping(r.marks, mapping) }))
+    if (rows.length === 0) {
+      toast.error("No parsed students match this class roster.")
+      return
+    }
+    start(async () => {
+      const res = await saveMarksAction({ offeringId, rows })
+      if (res.error) {
+        toast.error(res.error)
+        return
+      }
+      toast.success(`Saved marks for ${rows.length} students`)
+      router.push(`/dashboard/class/${classId}/marks?offering=${offeringId}`)
+    })
+  }
+
+  const unmatched = preview ? preview.totalRows - preview.matchedRows : 0
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* Step 1 — upload */}
+      <div className="border-border flex flex-wrap items-end gap-3 rounded border p-4">
+        <div className="grid gap-1.5">
+          <label className="text-muted-foreground text-xs">
+            Marksheet file (PDF or Excel)
+          </label>
+          <input
+            ref={fileRef}
+            type="file"
+            accept=".pdf,.xlsx,.xls"
+            onChange={(e) => {
+              setFile(e.target.files?.[0] ?? null)
+              setPreview(null)
+            }}
+            className="text-sm file:mr-3 file:rounded file:border file:border-border file:bg-muted file:px-3 file:py-1.5 file:text-sm"
+          />
+        </div>
+        <Button size="sm" disabled={!file || uploading} onClick={runPreview}>
+          {uploading ? "Reading…" : "Preview"}
+        </Button>
+        <p className="text-muted-foreground w-full text-xs leading-relaxed">
+          Roll numbers are matched to this class. Rows from other divisions or
+          students not yet enrolled are ignored.
+        </p>
+      </div>
+
+      {preview && (
+        <>
+          {/* Step 2 — map columns + pick subject */}
+          <div className="border-border flex flex-col gap-4 rounded border p-4">
+            <div className="grid gap-1.5 sm:max-w-sm">
+              <label className="text-muted-foreground text-xs">Subject</label>
+              {offerings.length === 0 ? (
+                <p className="text-muted-foreground text-sm">
+                  No subjects yet.{" "}
+                  <a
+                    href={`/dashboard/class/${classId}/marks`}
+                    className="underline"
+                  >
+                    Add a subject
+                  </a>{" "}
+                  first.
+                </p>
+              ) : (
+                <select
+                  value={offeringId}
+                  onChange={(e) => setOfferingId(e.target.value)}
+                  className="border-border h-9 rounded border bg-transparent px-2 text-sm"
+                >
+                  <option value="">Select a subject…</option>
+                  {offerings.map((o) => (
+                    <option key={o.id} value={o.id}>
+                      {o.code} — {o.name}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
+
+            <div>
+              <p className="mb-2 text-sm font-medium">
+                Map columns ({preview.columnCount} detected)
+              </p>
+              <div className="flex flex-wrap gap-3">
+                {Array.from({ length: preview.columnCount }).map((_, i) => {
+                  const samples = preview.rows
+                    .slice(0, 3)
+                    .map((r) => fmt(r.marks[i]))
+                    .join(", ")
+                  return (
+                    <div
+                      key={i}
+                      className="border-border grid min-w-40 gap-1.5 rounded border p-2.5"
+                    >
+                      <span className="text-xs font-medium">
+                        {preview.headers[i]?.trim() || `Column ${i + 1}`}
+                      </span>
+                      <span className="text-muted-foreground text-xs">
+                        e.g. {samples}
+                      </span>
+                      <select
+                        value={mapping[i] ?? "skip"}
+                        onChange={(e) =>
+                          setCol(i, e.target.value as MarkTarget)
+                        }
+                        className="border-border h-8 rounded border bg-transparent px-2 text-sm"
+                      >
+                        {TARGETS.map((t) => (
+                          <option key={t.value} value={t.value}>
+                            {t.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <Button size="sm" disabled={committing} onClick={commit}>
+                {committing
+                  ? "Saving…"
+                  : `Save ${preview.matchedRows} matched`}
+              </Button>
+              <span className="text-muted-foreground text-xs">
+                {preview.matchedRows} matched · {unmatched} ignored
+                {preview.truncated ? " · file truncated" : ""}
+              </span>
+            </div>
+          </div>
+
+          {/* Step 3 — preview */}
+          <div className="border-border overflow-x-auto rounded border">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 text-muted-foreground text-xs">
+                <tr className="[&>th]:px-3 [&>th]:py-2 [&>th]:text-left [&>th]:font-medium">
+                  <th>Roll</th>
+                  <th>Name</th>
+                  {Array.from({ length: preview.columnCount }).map((_, i) => (
+                    <th key={i} className="w-16">
+                      {preview.headers[i]?.trim() || `Col ${i + 1}`}
+                    </th>
+                  ))}
+                  <th className="w-24">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-border divide-y">
+                {preview.rows.map((r, idx) => (
+                  <tr
+                    key={`${r.rollNumber}-${idx}`}
+                    className={
+                      r.matched
+                        ? "[&>td]:px-3 [&>td]:py-1.5"
+                        : "text-muted-foreground [&>td]:px-3 [&>td]:py-1.5"
+                    }
+                  >
+                    <td className="font-mono text-xs">{r.rollNumber}</td>
+                    <td className="whitespace-nowrap">{r.name}</td>
+                    {r.marks.map((m, i) => (
+                      <td key={i} className="tabular-nums">
+                        {fmt(m)}
+                      </td>
+                    ))}
+                    <td>
+                      {r.matched ? (
+                        <Badge variant="outline">In class</Badge>
+                      ) : (
+                        <Badge variant="secondary">Not in class</Badge>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/app/dashboard/class/[classId]/marks/import/client.tsx
+++ b/src/app/dashboard/class/[classId]/marks/import/client.tsx
@@ -96,7 +96,10 @@ export function ImportClient({
     }
     const rows = preview.rows
       .filter((r) => r.matched && r.studentId)
-      .map((r) => ({ studentId: r.studentId!, ...applyMapping(r.marks, mapping) }))
+      .map((r) => ({
+        studentId: r.studentId!,
+        ...applyMapping(r.marks, mapping),
+      }))
     if (rows.length === 0) {
       toast.error("No parsed students match this class roster.")
       return
@@ -130,7 +133,7 @@ export function ImportClient({
               setFile(e.target.files?.[0] ?? null)
               setPreview(null)
             }}
-            className="text-sm file:mr-3 file:rounded file:border file:border-border file:bg-muted file:px-3 file:py-1.5 file:text-sm"
+            className="file:border-border file:bg-muted text-sm file:mr-3 file:rounded file:border file:px-3 file:py-1.5 file:text-sm"
           />
         </div>
         <Button size="sm" disabled={!file || uploading} onClick={runPreview}>
@@ -217,9 +220,7 @@ export function ImportClient({
 
             <div className="flex flex-wrap items-center gap-3">
               <Button size="sm" disabled={committing} onClick={commit}>
-                {committing
-                  ? "Saving…"
-                  : `Save ${preview.matchedRows} matched`}
+                {committing ? "Saving…" : `Save ${preview.matchedRows} matched`}
               </Button>
               <span className="text-muted-foreground text-xs">
                 {preview.matchedRows} matched · {unmatched} ignored

--- a/src/app/dashboard/class/[classId]/marks/import/page.tsx
+++ b/src/app/dashboard/class/[classId]/marks/import/page.tsx
@@ -1,0 +1,53 @@
+import { notFound, redirect } from "next/navigation"
+import { PageHeader } from "@/components/page-header"
+import { getSessionUser } from "@/lib/session"
+import { can } from "@/lib/rbac"
+import { expectedYear } from "@/lib/roll-number"
+import { getClassById } from "@/db/queries/classes"
+import { listOfferingsForClass } from "@/db/queries/offerings"
+import { ImportClient } from "./client"
+
+export const dynamic = "force-dynamic"
+
+export default async function MarksImportPage({
+  params,
+}: {
+  params: Promise<{ classId: string }>
+}) {
+  const { classId } = await params
+  const user = await getSessionUser()
+  if (!user) redirect("/login")
+  if (!can(user, "marks:write")) redirect("/dashboard")
+
+  const cls = await getClassById(classId)
+  if (!cls) return notFound()
+  const inScope =
+    user.tier === "super_admin" ||
+    user.classIds.includes(classId) ||
+    (user.tier === "hod" && user.deptCodes.includes(cls.departmentCode))
+  if (!inScope) redirect("/dashboard/class")
+
+  const offerings = await listOfferingsForClass(classId)
+  const yr = expectedYear(cls.admissionYear, new Date()) ?? cls.admissionYear
+  const label = `${yr} · ${cls.departmentCode} · ${cls.division}`
+
+  return (
+    <>
+      <PageHeader
+        title={`Import marks — ${label}`}
+        parent="Marks"
+        parentHref={`/dashboard/class/${classId}/marks`}
+      />
+      <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
+        <ImportClient
+          classId={classId}
+          offerings={offerings.map((o) => ({
+            id: o.id,
+            code: o.course.courseCode,
+            name: o.course.courseName,
+          }))}
+        />
+      </div>
+    </>
+  )
+}

--- a/src/app/dashboard/class/[classId]/marks/page.tsx
+++ b/src/app/dashboard/class/[classId]/marks/page.tsx
@@ -5,10 +5,7 @@ import { can } from "@/lib/rbac"
 import { expectedYear } from "@/lib/roll-number"
 import { getClassById } from "@/db/queries/classes"
 import { getStudentsByClassIds } from "@/db/queries/students"
-import {
-  listOfferingsForClass,
-  getOfferingById,
-} from "@/db/queries/offerings"
+import { listOfferingsForClass, getOfferingById } from "@/db/queries/offerings"
 import { getMarksForOffering } from "@/db/queries/marks"
 import { MarksClient } from "./client"
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -157,10 +157,7 @@ export default async function DashboardPage() {
               </thead>
               <tbody className="divide-border divide-y">
                 {marks.map(({ mark, course, computed }) => (
-                  <tr
-                    key={mark.id}
-                    className="[&>td]:px-4 [&>td]:py-2.5"
-                  >
+                  <tr key={mark.id} className="[&>td]:px-4 [&>td]:py-2.5">
                     <td className="font-mono text-xs">{course.courseCode}</td>
                     <td>{course.courseName}</td>
                     <td className="tabular-nums">

--- a/src/db/queries/courses.ts
+++ b/src/db/queries/courses.ts
@@ -14,7 +14,10 @@ export async function listCoursesForDepts(deptCodes: string[]) {
     .select()
     .from(courses)
     .where(
-      and(eq(courses.isActive, true), inArray(courses.departmentCode, deptCodes))
+      and(
+        eq(courses.isActive, true),
+        inArray(courses.departmentCode, deptCodes)
+      )
     )
     .orderBy(courses.courseCode)
 }

--- a/src/lib/marks-import.ts
+++ b/src/lib/marks-import.ts
@@ -1,0 +1,156 @@
+import { looksLikeRoll } from "@/lib/roll-number"
+
+// Client-safe. The browser re-runs applyMapping live as the faculty changes the
+// column mapping; the server runs the same extract on upload. No I/O here.
+
+// The four fields our marks schema stores, plus how a detected file column can
+// map onto them. "mse_avg" writes the same value to mse1 and mse2 so the stored
+// average round-trips — real marksheets hand us the average already, not the two
+// halves. "skip" drops the column.
+export type MarkTarget =
+  | "isa"
+  | "mse_avg"
+  | "mse1"
+  | "mse2"
+  | "ese"
+  | "skip"
+
+export type ExtractedRow = {
+  rollNumber: string
+  name: string
+  // One entry per detected mark column, in column order. null = absent / blank /
+  // an Excel error like #DIV/0! — anything that isn't a real number.
+  marks: (number | null)[]
+}
+
+export type MappedMarks = {
+  isa: number | null
+  mse1: number | null
+  mse2: number | null
+  ese: number | null
+}
+
+// Tokens that stand in for "no mark": absent, Excel divide-by-zero, dashes.
+const BLANK_TOKENS = new Set([
+  "AB",
+  "A",
+  "ABS",
+  "ABSENT",
+  "#DIV/0!",
+  "#N/A",
+  "NA",
+  "N/A",
+  "-",
+  "--",
+])
+
+// A token is a mark if it's a number or a known blank marker. Names never are.
+function markValue(token: string): { isMark: boolean; value: number | null } {
+  const t = token.trim()
+  if (!t) return { isMark: false, value: null }
+  if (BLANK_TOKENS.has(t.toUpperCase())) return { isMark: true, value: null }
+  if (/^\d+(\.\d+)?$/.test(t)) return { isMark: true, value: Number(t) }
+  return { isMark: false, value: null }
+}
+
+/**
+ * Pull one student row out of a token list, anchored on the roll number. Works
+ * for both a spreadsheet row (cells as tokens) and a PDF line (whitespace split):
+ * find the roll token, take the alphabetic run after it as the name, and every
+ * numeric / blank token after that as the marks. Sr No before the roll is ignored.
+ * Returns null for any line without a roll (batch separators, headers, titles).
+ */
+export function extractRow(tokens: string[]): ExtractedRow | null {
+  // Drop blank cells: xlsx pads every row with empty trailing cells, and PDF has
+  // no blanks at all. A mark column is a token that reads as a number or an
+  // absent-marker (AB); real marksheets never leave a mark cell truly empty, they
+  // write AB or 0, so contiguous non-blank tokens preserve the columns.
+  const cleaned = tokens.map((t) => t.trim()).filter(Boolean)
+  const rollIdx = cleaned.findIndex((t) => looksLikeRoll(t))
+  if (rollIdx < 0) return null
+
+  const rollNumber = cleaned[rollIdx].toUpperCase()
+  const after = cleaned.slice(rollIdx + 1)
+
+  const nameParts: string[] = []
+  const marks: (number | null)[] = []
+  let inMarks = false
+  for (const tok of after) {
+    const { isMark, value } = markValue(tok)
+    if (!inMarks && !isMark) {
+      nameParts.push(tok)
+      continue
+    }
+    inMarks = true
+    // A stray alphabetic token once we're in the marks region is noise — skip it.
+    if (isMark) marks.push(value)
+  }
+
+  return { rollNumber, name: nameParts.join(" ").trim(), marks }
+}
+
+/**
+ * Extract every student row from a set of token-lists (PDF lines or sheet rows),
+ * and normalise them to a common column count (the widest row wins — short rows
+ * are padded with nulls so column N means the same thing on every row).
+ */
+export function extractRows(lines: string[][]): {
+  rows: ExtractedRow[]
+  columnCount: number
+} {
+  const rows = lines
+    .map(extractRow)
+    .filter((r): r is ExtractedRow => r !== null && r.marks.length > 0)
+  const columnCount = rows.reduce((m, r) => Math.max(m, r.marks.length), 0)
+  for (const r of rows) {
+    while (r.marks.length < columnCount) r.marks.push(null)
+  }
+  return { rows, columnCount }
+}
+
+// Sum helper that stays null when every contributing column is null, so an empty
+// ISA doesn't silently become 0.
+function sumOrNull(values: (number | null)[]): number | null {
+  const present = values.filter((v): v is number => v !== null)
+  return present.length === 0 ? null : present.reduce((a, b) => a + b, 0)
+}
+
+/**
+ * Fold a row's detected mark columns into the four stored fields, using the
+ * faculty's column→target mapping. Columns sharing a target are summed (ISA split
+ * into TH + LAB); mse_avg fills both halves so the stored average is preserved.
+ */
+export function applyMapping(
+  marks: (number | null)[],
+  mapping: MarkTarget[]
+): MappedMarks {
+  const pick = (target: MarkTarget) =>
+    marks.filter((_, i) => mapping[i] === target)
+
+  const avg = sumOrNull(pick("mse_avg"))
+  return {
+    isa: sumOrNull(pick("isa")),
+    ese: sumOrNull(pick("ese")),
+    mse1: avg ?? sumOrNull(pick("mse1")),
+    mse2: avg ?? sumOrNull(pick("mse2")),
+  }
+}
+
+const TARGET_HINTS: { target: MarkTarget; patterns: RegExp[] }[] = [
+  { target: "mse_avg", patterns: [/mse.*av/i, /\bav(g|erage)?\b/i] },
+  { target: "isa", patterns: [/\bisa\b/i, /\btotal\b/i] },
+  { target: "mse1", patterns: [/mse.*1/i] },
+  { target: "mse2", patterns: [/mse.*2/i] },
+  { target: "ese", patterns: [/\bese\b/i, /end.?sem/i] },
+]
+
+// A first-guess mapping from header text, if we found any. The faculty confirms
+// or overrides it in the preview — this only saves clicks, it isn't trusted.
+export function guessTargets(headers: string[]): MarkTarget[] {
+  return headers.map((h) => {
+    for (const { target, patterns } of TARGET_HINTS) {
+      if (patterns.some((p) => p.test(h))) return target
+    }
+    return "skip"
+  })
+}

--- a/src/lib/marks-import.ts
+++ b/src/lib/marks-import.ts
@@ -7,13 +7,7 @@ import { looksLikeRoll } from "@/lib/roll-number"
 // map onto them. "mse_avg" writes the same value to mse1 and mse2 so the stored
 // average round-trips — real marksheets hand us the average already, not the two
 // halves. "skip" drops the column.
-export type MarkTarget =
-  | "isa"
-  | "mse_avg"
-  | "mse1"
-  | "mse2"
-  | "ese"
-  | "skip"
+export type MarkTarget = "isa" | "mse_avg" | "mse1" | "mse2" | "ese" | "skip"
 
 export type ExtractedRow = {
   rollNumber: string

--- a/src/lib/pdf-extract.ts
+++ b/src/lib/pdf-extract.ts
@@ -22,7 +22,11 @@ export async function pdfToLines(buffer: Buffer): Promise<string[][]> {
     const items = content.items
       .map((item) => {
         const it = item as { str?: string; transform?: number[] }
-        return { str: (it.str ?? "").trim(), x: it.transform?.[4], y: it.transform?.[5] }
+        return {
+          str: (it.str ?? "").trim(),
+          x: it.transform?.[4],
+          y: it.transform?.[5],
+        }
       })
       .filter((it): it is { str: string; x: number; y: number } => {
         return Boolean(it.str) && it.x != null && it.y != null

--- a/src/lib/pdf-extract.ts
+++ b/src/lib/pdf-extract.ts
@@ -1,0 +1,53 @@
+import "server-only"
+import { getDocumentProxy } from "unpdf"
+
+// Cells within this many PDF units of vertical distance belong to the same row.
+// Rows sit ~18 units apart; a single row's glyphs jitter by 1-2 units, so a small
+// tolerance keeps a row together without merging neighbours.
+const ROW_TOLERANCE = 5
+
+// Reconstruct visual lines from a PDF's text items. PDF text has no notion of
+// rows — only glyphs at (x, y). We cluster items whose y is within ROW_TOLERANCE
+// into one line and sort each line left-to-right, which recovers the table rows
+// the roll-anchored extractor then reads. Robust to the jumbled reading order and
+// sub-pixel y-jitter that plain text extraction produces on these marksheets.
+export async function pdfToLines(buffer: Buffer): Promise<string[][]> {
+  const pdf = await getDocumentProxy(new Uint8Array(buffer))
+  const lines: string[][] = []
+
+  for (let p = 1; p <= pdf.numPages; p++) {
+    const page = await pdf.getPage(p)
+    const content = await page.getTextContent()
+
+    const items = content.items
+      .map((item) => {
+        const it = item as { str?: string; transform?: number[] }
+        return { str: (it.str ?? "").trim(), x: it.transform?.[4], y: it.transform?.[5] }
+      })
+      .filter((it): it is { str: string; x: number; y: number } => {
+        return Boolean(it.str) && it.x != null && it.y != null
+      })
+      .sort((a, b) => b.y - a.y) // top of page first
+
+    let cur: { x: number; str: string }[] = []
+    let refY: number | null = null
+    const flush = () => {
+      if (cur.length)
+        lines.push(cur.sort((a, b) => a.x - b.x).map((c) => c.str))
+      cur = []
+    }
+    for (const it of items) {
+      if (refY === null || refY - it.y <= ROW_TOLERANCE) {
+        cur.push({ x: it.x, str: it.str })
+        refY = refY === null ? it.y : Math.min(refY, it.y)
+      } else {
+        flush()
+        cur.push({ x: it.x, str: it.str })
+        refY = it.y
+      }
+    }
+    flush()
+  }
+
+  return lines
+}


### PR DESCRIPTION
Phase 5 follow-ups on top of #58.

## Marks import (PDF / Excel)
Faculty upload a marksheet; it's parsed server-side (roll-anchored, PDF via unpdf with y-clustering, xlsx via exceljs), matched against the class roster, column-mapped, and committed through the marks:write action. Verified on four real VIT marksheets.

## Roll-derived class membership (class_key)
A class's roster is now exactly the students whose roll-derived class_key matches it — no stored link to populate or drift. Replaces the unused students.class_id with a derived class_key ('2023-108-A'). classKeyFromRoll folds direct-second-year rolls back to their batch's start year (isDSY -> admissionYear-1) so DSE students share their peers' class; repeaters get an explicit override. Fixes the 'only 2 of 88 students linked' problem.

**Deploy:** after merge + deploy, run `npm run db:push` (drops class_id, adds class_key), then `scripts/backfill-classkey.ts`.

## HOD faculty CSV import
/dashboard/dept/faculty-import (Import > Import faculty). Bulk-creates staff in the HOD's department from a CSV (name, email, employee ID) with a validated preview, reusing existing emails, and optionally assigns each to one class as coordinator/TR.

## Fixes carried along
- Prettier: repaired the format:check that #58's squash turned red on main.
- Perf: getSessionUser cut from ~5 DB reads to 2 (relational faculty+scope query, merged override read) — fewer cold-start round trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)