### PR TITLE
One TR per class

### DIFF
--- a/src/app/dashboard/dept/faculty-import/client.tsx
+++ b/src/app/dashboard/dept/faculty-import/client.tsx
@@ -154,10 +154,10 @@ export function FacultyImportClient({
             </div>
           )}
         </div>
-        {assignClassId && assignRole === "academic_coordinator" && (
+        {assignClassId && (
           <p className="text-muted-foreground text-xs">
-            A class has one coordinator — with multiple rows, only the last
-            stays coordinator. Use TR to assign several.
+            A class has one coordinator and one TR — with multiple rows, only
+            the last stays assigned.
           </p>
         )}
       </div>

--- a/src/db/queries/class-staff.ts
+++ b/src/db/queries/class-staff.ts
@@ -5,9 +5,9 @@ import { facultyClassAssignments, faculty } from "@/db/schema"
 type ClassRole = "academic_coordinator" | "tr"
 
 /**
- * Assign a class role. The academic_coordinator is one-per-class, so the current
- * one is retired first; a tr can be added alongside. Ordered statements — no
- * transaction on neon-http, fine for an admin/HOD action.
+ * Assign a class role. Both roles are one-per-class — coordinator and TR alike —
+ * so the current holder of that role is retired before the new one is written.
+ * Ordered statements — no transaction on neon-http, fine for an admin/HOD action.
  */
 export async function assignClassRole(
   classId: string,
@@ -15,18 +15,16 @@ export async function assignClassRole(
   role: ClassRole,
   assignedBy: string | null
 ) {
-  if (role === "academic_coordinator") {
-    await db
-      .update(facultyClassAssignments)
-      .set({ isActive: false, updatedAt: new Date() })
-      .where(
-        and(
-          eq(facultyClassAssignments.classId, classId),
-          eq(facultyClassAssignments.role, "academic_coordinator"),
-          eq(facultyClassAssignments.isActive, true)
-        )
+  await db
+    .update(facultyClassAssignments)
+    .set({ isActive: false, updatedAt: new Date() })
+    .where(
+      and(
+        eq(facultyClassAssignments.classId, classId),
+        eq(facultyClassAssignments.role, role),
+        eq(facultyClassAssignments.isActive, true)
       )
-  }
+    )
   await db
     .insert(facultyClassAssignments)
     .values({ classId, facultyId, role, assignedBy })


### PR DESCRIPTION
`assignClassRole` now retires the current holder of the role before assigning for BOTH coordinator and TR, so a class has exactly one of each. Previously a TR was added alongside — a class could accumulate several while the picker showed only the first. Faculty-import note updated to match.

Note: this governs future assignments; any class that already has multiple active TRs keeps them until the TR is reassigned once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)