### PR TITLE
feat: filter students by department, year and division

### DIFF
--- a/src/app/dashboard/students/client.tsx
+++ b/src/app/dashboard/students/client.tsx
@@ -97,6 +97,11 @@ export function StudentsClient({
         columns={studentsColumns}
         data={data}
         globalSearch
+        facets={[
+          { columnId: "department", label: "Department" },
+          { columnId: "year", label: "Year" },
+          { columnId: "division", label: "Division" },
+        ]}
         searchPlaceholder="Search students..."
         exportConfig={{ filename: "Students", onExport: handleExport }}
         rowId={(s) => s.id}

--- a/src/components/columns/students-columns.tsx
+++ b/src/components/columns/students-columns.tsx
@@ -47,6 +47,11 @@ export const studentsColumns: ColumnDef<StudentRow>[] = [
     ),
   },
   {
+    accessorKey: "division",
+    header: "Division",
+    cell: ({ row }) => row.getValue("division") ?? "-",
+  },
+  {
     accessorKey: "year",
     header: "Year",
   },

--- a/src/components/data-table-view.tsx
+++ b/src/components/data-table-view.tsx
@@ -9,6 +9,8 @@ import {
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
   getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
@@ -26,11 +28,22 @@ import { Button, buttonVariants } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { SearchIcon, DownloadIcon, Loader2Icon } from "lucide-react"
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu"
+
+// Radix Select cannot hold an empty string as a value, so "no filter" needs a
+// sentinel rather than "".
+const ALL = "__all"
 
 interface DataTableViewProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
@@ -38,6 +51,10 @@ interface DataTableViewProps<TData, TValue> {
   searchKey?: string
   searchPlaceholder?: string
   globalSearch?: boolean
+  // Dropdown filters built from the values actually present in the data.
+  // Counts come from TanStack's faceted row model, so no extra queries are
+  // needed and the numbers always match what the table is showing.
+  facets?: { columnId: string; label: string }[]
   exportConfig?: {
     filename: string
     onExport: (data: TData[], format: "csv" | "xlsx") => Promise<void>
@@ -55,6 +72,7 @@ export function DataTableView<TData, TValue>({
   searchKey,
   searchPlaceholder = "Search...",
   globalSearch,
+  facets,
   exportConfig,
   rowId,
   bulkBar,
@@ -110,6 +128,8 @@ export function DataTableView<TData, TValue>({
     getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
     enableRowSelection: selectable,
     getRowId: rowId,
     onRowSelectionChange: setRowSelection,
@@ -122,10 +142,13 @@ export function DataTableView<TData, TValue>({
 
   const showSearch = Boolean(globalSearch || searchKey)
   const selectedIds = table.getSelectedRowModel().rows.map((r) => r.id)
+  const activeFacets = (facets ?? []).filter((f) =>
+    Boolean(table.getColumn(f.columnId)?.getFilterValue())
+  )
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center gap-3">
         {showSearch ? (
           <div className="relative w-full max-w-sm">
             <SearchIcon className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
@@ -151,10 +174,66 @@ export function DataTableView<TData, TValue>({
         ) : (
           <div />
         )}
+        {facets && facets.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2">
+            {facets.map((facet) => {
+              const column = table.getColumn(facet.columnId)
+              if (!column) return null
+              const counts = column.getFacetedUniqueValues()
+              const options = Array.from(counts.keys())
+                .filter(
+                  (v): v is string => v !== null && v !== undefined && v !== ""
+                )
+                .sort((a, b) => String(a).localeCompare(String(b)))
+              if (options.length === 0) return null
+              const value = (column.getFilterValue() as string) ?? ALL
+
+              return (
+                <Select
+                  key={facet.columnId}
+                  value={value}
+                  onValueChange={(next) =>
+                    column.setFilterValue(next === ALL ? undefined : next)
+                  }
+                >
+                  <SelectTrigger
+                    className="w-auto min-w-[9rem]"
+                    aria-label={facet.label}
+                  >
+                    <SelectValue placeholder={facet.label} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={ALL}>
+                      All {facet.label.toLowerCase()}
+                    </SelectItem>
+                    {options.map((option) => (
+                      <SelectItem key={option} value={option}>
+                        {option} ({counts.get(option)})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )
+            })}
+            {activeFacets.length > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() =>
+                  activeFacets.forEach((f) =>
+                    table.getColumn(f.columnId)?.setFilterValue(undefined)
+                  )
+                }
+              >
+                Clear
+              </Button>
+            )}
+          </div>
+        )}
         {exportConfig && (
-          <DropdownMenu>
+          <DropdownMenu modal={false}>
             <DropdownMenuTrigger
-              className={buttonVariants({ variant: "outline" })}
+              className={`ml-auto ${buttonVariants({ variant: "outline" })}`}
               disabled={isExporting}
             >
               {isExporting ? (


### PR DESCRIPTION
Rebases and lands #43 by @Himanshux99.

His branch could not be rebased mechanically: the MVP reset (`cd821b5`) and the
UI pass (`4bea5c4`) rewrote all three files it touched, and the students page
moved onto the shared `DataTableView`. The feature is his; this ports it onto
the current table.

### What it does

Department, Year and Division dropdowns on the students table, each showing a
live count, with a Clear button once any filter is set.

### Differences from the original, and why

- **Filters live on `DataTableView`, not on the students page.** A page opts in
  with `facets={[{ columnId, label }]}`, so faculty and every future table get
  the same behaviour for one prop instead of a copy of the code.
- **Counts come from TanStack's faceted row model, not three `GROUP BY`
  queries.** The table already receives every row, so the extra round trips were
  not buying anything — and the counts now narrow as other filters are applied
  rather than showing stale totals.
- **Division is now a column.** It was filterable in the original but never
  displayed, even though the CSV and XLSX exports have always carried a Division
  field. Added in the export's position so the table and the export agree.
- Radix Select cannot hold an empty string, so clearing a filter uses a sentinel.

### Checks

`npm run check` passes (the two remaining lint warnings are pre-existing, in
`data-table.tsx`). `npm run build` succeeds.

Closes #43.
