### PR TITLE
feat(marks): per-component locking and grid export

### DIFF
--- a/src/app/dashboard/class/[classId]/marks/client.tsx
+++ b/src/app/dashboard/class/[classId]/marks/client.tsx
@@ -8,7 +8,13 @@ import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
 import { computeMarks, type CourseInfo } from "@/lib/sgpi"
-import { createSubjectAction, saveMarksAction } from "../../actions"
+import { downloadBase64File } from "@/lib/utils"
+import { exportTableCsv, exportTableXlsx } from "@/lib/xlsx-export"
+import {
+  createSubjectAction,
+  saveMarksAction,
+  setMarksLockAction,
+} from "../../actions"
 
 type Offering = { id: string; code: string; name: string; semester: number }
 type Row = {
@@ -20,7 +26,13 @@ type Row = {
   mse2: number | null
   ese: number | null
 }
-type Grid = { offeringId: string; course: CourseInfo; rows: Row[] }
+type LockComponent = "isa" | "mse" | "ese"
+type Grid = {
+  offeringId: string
+  course: CourseInfo
+  rows: Row[]
+  locked: LockComponent[]
+}
 
 // VIT defaults per assessment type: theory carries the MSE component, practical
 // and project are ISA + ESE only.
@@ -34,20 +46,35 @@ const CAP_PRESETS: Record<
   project: { maxIsa: 40, maxMse: 0, maxEse: 60, maxTotal: 100 },
 }
 
+const LOCK_LABEL: Record<LockComponent, string> = {
+  isa: "ISA",
+  mse: "MSE",
+  ese: "ESE",
+}
+
 export function MarksClient({
   classId,
   offerings,
   selectedId,
   grid,
+  canUnlock,
 }: {
   classId: string
   offerings: Offering[]
   selectedId: string | null
   grid: Grid | null
+  canUnlock: boolean
 }) {
   if (grid && selectedId) {
     const offering = offerings.find((o) => o.id === selectedId)!
-    return <MarksGrid classId={classId} offering={offering} grid={grid} />
+    return (
+      <MarksGrid
+        classId={classId}
+        offering={offering}
+        grid={grid}
+        canUnlock={canUnlock}
+      />
+    )
   }
   return <SubjectSetup classId={classId} offerings={offerings} />
 }
@@ -245,16 +272,90 @@ function MarksGrid({
   classId,
   offering,
   grid,
+  canUnlock,
 }: {
   classId: string
   offering: Offering
   grid: Grid
+  canUnlock: boolean
 }) {
   const router = useRouter()
   const [pending, start] = useTransition()
   const [rows, setRows] = useState<Row[]>(grid.rows)
   const { course } = grid
   const hasMse = course.maxMse > 0
+  const locked = grid.locked
+  const isLocked = (c: LockComponent) => locked.includes(c)
+  // Nothing left to enter: every component this course has is frozen.
+  const allLocked =
+    isLocked("isa") && isLocked("ese") && (!hasMse || isLocked("mse"))
+
+  function toggleLock(component: LockComponent, next: boolean) {
+    start(async () => {
+      const res = await setMarksLockAction({
+        offeringId: offering.id,
+        component,
+        locked: next,
+      })
+      if (res.error) {
+        toast.error(res.error)
+        return
+      }
+      toast.success(
+        next
+          ? `${LOCK_LABEL[component]} locked`
+          : `${LOCK_LABEL[component]} reopened`
+      )
+      router.refresh()
+    })
+  }
+
+  async function handleExport(format: "csv" | "xlsx") {
+    const headers = [
+      "Roll",
+      "Name",
+      "ISA",
+      ...(hasMse ? ["MSE 1", "MSE 2"] : []),
+      "ESE",
+      "Total",
+      "%",
+      "Grade",
+    ]
+    const body = rows.map((r) => {
+      const c = computeMarks(r, course)
+      return [
+        r.rollNumber,
+        r.name,
+        r.isa,
+        ...(hasMse ? [r.mse1, r.mse2] : []),
+        r.ese,
+        c.total,
+        c.percentage,
+        c.gradePoint == null ? "" : String(c.gradePoint),
+      ]
+    })
+    const date = new Date().toISOString().split("T")[0]
+    const filename = `Marks_${offering.code}_${date}.${format}`
+    if (format === "xlsx") {
+      const b64 = await exportTableXlsx({
+        title: `Marks — ${offering.code}`,
+        subtitle: offering.name,
+        headers,
+        rows: body,
+      })
+      downloadBase64File(
+        b64,
+        filename,
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+      )
+    } else {
+      downloadBase64File(
+        await exportTableCsv({ headers, rows: body }),
+        filename,
+        "text/csv"
+      )
+    }
+  }
 
   function edit(
     studentId: string,
@@ -309,10 +410,36 @@ function MarksGrid({
             Total/{course.maxTotal}
           </span>
         </div>
-        <Button size="sm" disabled={pending} onClick={save}>
-          {pending ? "Saving…" : "Save marks"}
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handleExport("csv")}
+            disabled={rows.length === 0}
+          >
+            CSV
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handleExport("xlsx")}
+            disabled={rows.length === 0}
+          >
+            Excel
+          </Button>
+          <Button size="sm" disabled={pending || allLocked} onClick={save}>
+            {pending ? "Saving…" : "Save marks"}
+          </Button>
+        </div>
       </div>
+
+      <LockPanel
+        hasMse={hasMse}
+        isLocked={isLocked}
+        canUnlock={canUnlock}
+        pending={pending}
+        onToggle={toggleLock}
+      />
 
       {rows.length === 0 ? (
         <p className="text-muted-foreground text-sm">
@@ -345,6 +472,7 @@ function MarksGrid({
                       <MarkInput
                         value={r.isa}
                         max={course.maxIsa}
+                        locked={isLocked("isa")}
                         onChange={(v) => edit(r.studentId, "isa", v)}
                       />
                     </td>
@@ -353,6 +481,7 @@ function MarksGrid({
                         <MarkInput
                           value={r.mse1}
                           max={course.maxMse}
+                          locked={isLocked("mse")}
                           onChange={(v) => edit(r.studentId, "mse1", v)}
                         />
                       </td>
@@ -362,6 +491,7 @@ function MarksGrid({
                         <MarkInput
                           value={r.mse2}
                           max={course.maxMse}
+                          locked={isLocked("mse")}
                           onChange={(v) => edit(r.studentId, "mse2", v)}
                         />
                       </td>
@@ -370,6 +500,7 @@ function MarksGrid({
                       <MarkInput
                         value={r.ese}
                         max={course.maxEse}
+                        locked={isLocked("ese")}
                         onChange={(v) => edit(r.studentId, "ese", v)}
                       />
                     </td>
@@ -400,10 +531,12 @@ function MarksGrid({
 function MarkInput({
   value,
   max,
+  locked,
   onChange,
 }: {
   value: number | null
   max: number
+  locked?: boolean
   onChange: (v: string) => void
 }) {
   return (
@@ -412,9 +545,85 @@ function MarkInput({
       min={0}
       max={max}
       value={value ?? ""}
+      readOnly={locked}
+      disabled={locked}
+      aria-label={locked ? "Locked — submitted" : undefined}
       onChange={(e) => onChange(e.target.value)}
-      className="h-8 w-16 tabular-nums"
+      className={cn(
+        "h-8 w-16 tabular-nums",
+        locked && "bg-muted text-muted-foreground cursor-not-allowed"
+      )}
     />
+  )
+}
+
+/**
+ * The components are frozen separately because they finish at different points
+ * in the term. Locking is offered to anyone who can enter marks; reopening is
+ * hidden unless the viewer is the coordinator or above, and the server enforces
+ * that regardless of what this renders.
+ */
+function LockPanel({
+  hasMse,
+  isLocked,
+  canUnlock,
+  pending,
+  onToggle,
+}: {
+  hasMse: boolean
+  isLocked: (c: LockComponent) => boolean
+  canUnlock: boolean
+  pending: boolean
+  onToggle: (c: LockComponent, next: boolean) => void
+}) {
+  const components: LockComponent[] = hasMse
+    ? ["isa", "mse", "ese"]
+    : ["isa", "ese"]
+  return (
+    <div className="border-border flex flex-wrap items-center gap-2 rounded border px-3 py-2">
+      <span className="text-muted-foreground mr-1 text-xs font-medium">
+        Components
+      </span>
+      {components.map((c) => {
+        const locked = isLocked(c)
+        return (
+          <div key={c} className="flex items-center gap-1.5">
+            <Badge variant={locked ? "secondary" : "outline"}>
+              {LOCK_LABEL[c]}
+              {locked ? " · locked" : ""}
+            </Badge>
+            {locked ? (
+              canUnlock ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  disabled={pending}
+                  onClick={() => onToggle(c, false)}
+                >
+                  Unlock
+                </Button>
+              ) : null
+            ) : (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                disabled={pending}
+                onClick={() => onToggle(c, true)}
+              >
+                Lock
+              </Button>
+            )}
+          </div>
+        )
+      })}
+      {!canUnlock && (
+        <span className="text-muted-foreground ml-auto text-xs">
+          Ask the class coordinator to reopen a locked component.
+        </span>
+      )}
+    </div>
   )
 }
 

--- a/src/app/dashboard/class/[classId]/marks/page.tsx
+++ b/src/app/dashboard/class/[classId]/marks/page.tsx
@@ -6,7 +6,7 @@ import { expectedYear } from "@/lib/roll-number"
 import { getClassById } from "@/db/queries/classes"
 import { getStudentsByClassKeys } from "@/db/queries/students"
 import { listOfferingsForClass, getOfferingById } from "@/db/queries/offerings"
-import { getMarksForOffering } from "@/db/queries/marks"
+import { getMarksForOffering, getLockedComponents } from "@/db/queries/marks"
 import { MarksClient } from "./client"
 
 export const dynamic = "force-dynamic"
@@ -43,13 +43,15 @@ export default async function MarksPage({
       ? await getOfferingById(offeringId)
       : null
   if (selected) {
-    const [students, existing] = await Promise.all([
+    const [students, existing, locked] = await Promise.all([
       getStudentsByClassKeys([cls.classKey]),
       getMarksForOffering(selected.id),
+      getLockedComponents(selected.id),
     ])
     const byStudent = Object.fromEntries(existing.map((m) => [m.studentId, m]))
     grid = {
       offeringId: selected.id,
+      locked,
       course: {
         courseType: selected.course.courseType,
         credits: selected.course.credits,
@@ -80,6 +82,12 @@ export default async function MarksPage({
       <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
         <MarksClient
           classId={classId}
+          canUnlock={
+            user.tier === "super_admin" ||
+            (user.tier === "hod" &&
+              user.deptCodes.includes(cls.departmentCode)) ||
+            user.coordinatorClassIds.includes(classId)
+          }
           offerings={offerings.map((o) => ({
             id: o.id,
             code: o.course.courseCode,

--- a/src/app/dashboard/class/actions.ts
+++ b/src/app/dashboard/class/actions.ts
@@ -16,7 +16,14 @@ import { getRequestById, updateRequest } from "@/db/queries/onboarding"
 import { upsertAttendance } from "@/db/queries/attendance"
 import { getCourseByCode, createCourse } from "@/db/queries/courses"
 import { createOffering, getOfferingById } from "@/db/queries/offerings"
-import { upsertMarks } from "@/db/queries/marks"
+import {
+  upsertMarks,
+  getMarksForOffering,
+  getLockedComponents,
+  setMarksLock,
+  isLockComponent,
+  type LockComponent,
+} from "@/db/queries/marks"
 
 type Result = { error: string | null }
 type AttStatus = "present" | "absent" | "late" | "excused"
@@ -251,17 +258,37 @@ export async function saveMarksAction(input: {
     const { ok } = await classInScope(user!, offering.classId)
     if (!ok) return { error: "That class is not in your scope." }
 
-    await upsertMarks(
-      input.rows.map((r) => ({
-        courseOfferingId: input.offeringId,
-        studentId: r.studentId,
-        isa: r.isa,
-        mse1: r.mse1,
-        mse2: r.mse2,
-        ese: r.ese,
-        recordedByFacultyId: user!.facultyId,
-      }))
-    )
+    // A locked component is frozen for everyone, including whoever locked it.
+    // Enforced here and not only in the UI: the grid is the polite reminder,
+    // this is the actual guarantee — a stale tab or a direct call must not slip
+    // a mark past a submitted component.
+    const locked = await getLockedComponents(input.offeringId)
+    const rows = input.rows.map((r) => ({
+      courseOfferingId: input.offeringId,
+      studentId: r.studentId,
+      isa: r.isa,
+      mse1: r.mse1,
+      mse2: r.mse2,
+      ese: r.ese,
+      recordedByFacultyId: user!.facultyId,
+    }))
+    if (locked.length > 0) {
+      const existing = await getMarksForOffering(input.offeringId)
+      const prev = new Map(existing.map((m) => [m.studentId, m]))
+      for (const r of rows) {
+        const before = prev.get(r.studentId)
+        // Carry the stored value forward for every locked component, so an edit
+        // to an open one cannot drag a frozen figure along with it.
+        if (locked.includes("isa")) r.isa = before?.isa ?? null
+        if (locked.includes("mse")) {
+          r.mse1 = before?.mse1 ?? null
+          r.mse2 = before?.mse2 ?? null
+        }
+        if (locked.includes("ese")) r.ese = before?.ese ?? null
+      }
+    }
+
+    await upsertMarks(rows)
     await createAuditLog({
       action: "marks.recorded",
       actorId: user!.id,
@@ -274,4 +301,71 @@ export async function saveMarksAction(input: {
   } catch (err) {
     return { error: getErrorMessage(err, "Could not save marks") }
   }
+}
+
+/**
+ * Freeze or reopen one marks component.
+ *
+ * Locking and unlocking are deliberately not the same privilege. Anyone who can
+ * enter marks can freeze them — that is just the person who finished the work
+ * saying so. Reopening is the class coordinator's call (or an HOD's, or a
+ * super-admin's), because it undoes a submission somebody else may already have
+ * acted on. A TR who spots a typo asks the coordinator; that conversation is the
+ * point, not an obstacle.
+ */
+export async function setMarksLockAction(input: {
+  offeringId: string
+  component: string
+  locked: boolean
+}): Promise<Result> {
+  try {
+    const user = await getSessionUser()
+    authorize(user, "marks:lock")
+    if (!isLockComponent(input.component)) {
+      return { error: "Unknown marks component." }
+    }
+    const component: LockComponent = input.component
+
+    const offering = await getOfferingById(input.offeringId)
+    if (!offering) return { error: "No such subject." }
+    const { ok, cls } = await classInScope(user!, offering.classId)
+    if (!ok || !cls) return { error: "That class is not in your scope." }
+
+    if (
+      !input.locked &&
+      !canUnlock(user!, offering.classId, cls.departmentCode)
+    ) {
+      return {
+        error:
+          "Only the class coordinator, the HOD, or an admin can reopen locked marks.",
+      }
+    }
+
+    await setMarksLock({
+      courseOfferingId: input.offeringId,
+      component,
+      locked: input.locked,
+      facultyId: user!.facultyId,
+    })
+    await createAuditLog({
+      action: input.locked ? "marks.locked" : "marks.unlocked",
+      actorId: user!.id,
+      targetType: "offering",
+      targetId: input.offeringId,
+      details: { component, courseCode: offering.course.courseCode },
+    })
+    revalidatePath(`/dashboard/class/${offering.classId}/marks`)
+    return { error: null }
+  } catch (err) {
+    return { error: getErrorMessage(err, "Could not change the lock") }
+  }
+}
+
+/** Reopening is coordinator-and-above; teaching the class is not enough. */
+function canUnlock(user: SessionUser, classId: string, deptCode: string) {
+  return (
+    user.tier === "super_admin" ||
+    (user.tier === "hod" && user.deptCodes.includes(deptCode)) ||
+    user.coordinatorClassIds.includes(classId)
+  )
 }

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -134,7 +134,10 @@ const facultyNav = [
     title: "My Classes",
     url: "/dashboard/class",
     icon: <Building2Icon />,
-    items: [{ title: "Classes & requests", url: "/dashboard/class" }],
+    // Marks and attendance hang off a specific class, so the class list is the
+    // only sensible entry point. Name what is behind the link — a TR looking for
+    // marks entry should not have to guess that it lives inside a class.
+    items: [{ title: "Classes, marks & attendance", url: "/dashboard/class" }],
   },
   {
     title: "Students",

--- a/src/db/queries/marks.ts
+++ b/src/db/queries/marks.ts
@@ -1,6 +1,6 @@
 import { eq, sql } from "drizzle-orm"
 import { db } from "@/db"
-import { marks } from "@/db/schema"
+import { marks, marksLocks } from "@/db/schema"
 
 type Entry = {
   courseOfferingId: string
@@ -51,4 +51,66 @@ export async function getMarksForStudent(studentId: string) {
     where: eq(marks.studentId, studentId),
     with: { courseOffering: { with: { course: true } } },
   })
+}
+
+// ── locks ──────────────────────────────────────────────────────────────────
+//
+// A component is frozen once its marks are submitted upstream: ISA when
+// internals go in, MSE after mid-sems, ESE at the end of term. They are locked
+// separately because they are finished at different points — freezing the whole
+// subject the moment ISA is done would block the ESE column for the rest of the
+// semester.
+//
+// `mse` covers both mse1 and mse2: they are two halves of one component that is
+// averaged into a single mark, so they are never submitted apart.
+
+export const LOCKABLE_COMPONENTS = ["isa", "mse", "ese"] as const
+export type LockComponent = (typeof LOCKABLE_COMPONENTS)[number]
+
+export function isLockComponent(v: string): v is LockComponent {
+  return (LOCKABLE_COMPONENTS as readonly string[]).includes(v)
+}
+
+/** Locked components for one offering. Absent row = never locked = open. */
+export async function getLockedComponents(
+  courseOfferingId: string
+): Promise<LockComponent[]> {
+  const rows = await db
+    .select({ component: marksLocks.component, isLocked: marksLocks.isLocked })
+    .from(marksLocks)
+    .where(eq(marksLocks.courseOfferingId, courseOfferingId))
+  return rows
+    .filter((r) => r.isLocked && isLockComponent(r.component))
+    .map((r) => r.component as LockComponent)
+}
+
+/**
+ * Freeze or reopen one component. Upserts on the (offering, component) unique
+ * index so re-locking is idempotent. Unlocking keeps the row and clears the
+ * stamp rather than deleting it — who reopened what is recorded in audit_logs,
+ * which is where every other mutation in the app already leaves its trail.
+ */
+export async function setMarksLock(input: {
+  courseOfferingId: string
+  component: LockComponent
+  locked: boolean
+  facultyId: string | null
+}) {
+  const stamp = input.locked
+    ? { lockedByFacultyId: input.facultyId, lockedAt: new Date() }
+    : { lockedByFacultyId: null, lockedAt: null }
+  const [row] = await db
+    .insert(marksLocks)
+    .values({
+      courseOfferingId: input.courseOfferingId,
+      component: input.component,
+      isLocked: input.locked,
+      ...stamp,
+    })
+    .onConflictDoUpdate({
+      target: [marksLocks.courseOfferingId, marksLocks.component],
+      set: { isLocked: input.locked, ...stamp, updatedAt: new Date() },
+    })
+    .returning()
+  return row
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -38,6 +38,8 @@ export type SessionUser = {
   // `classKeys` (the cohort keys) for roster queries, which key off class_key.
   classIds: string[]
   classKeys: string[]
+  // The subset of classIds this faculty coordinates (vs merely teaches).
+  coordinatorClassIds: string[]
   capabilities: ReadonlySet<Capability>
 }
 
@@ -95,6 +97,7 @@ export async function getSessionUser(): Promise<SessionUser | null> {
     deptCodes: [] as string[],
     classIds: [] as string[],
     classKeys: [] as string[],
+    coordinatorClassIds: [] as string[],
     capabilities: new Set<Capability>() as ReadonlySet<Capability>,
   }
 
@@ -125,7 +128,7 @@ export async function getSessionUser(): Promise<SessionUser | null> {
     with: {
       classAssignments: {
         where: (a, { eq }) => eq(a.isActive, true),
-        columns: { classId: true },
+        columns: { classId: true, role: true },
         with: { class: { columns: { classKey: true } } },
       },
       deptAppointments: {
@@ -143,6 +146,12 @@ export async function getSessionUser(): Promise<SessionUser | null> {
     }
     const classIds = fac.classAssignments.map((a) => a.classId)
     const classKeys = fac.classAssignments.map((a) => a.class.classKey)
+    // The coordinator subset, not a second query: the role column rides along on
+    // the assignment rows already being read. A TR and a coordinator both hold a
+    // class, but only the coordinator may reopen marks somebody locked.
+    const coordinatorClassIds = fac.classAssignments
+      .filter((a) => a.role === "academic_coordinator")
+      .map((a) => a.classId)
     const deptCodes =
       tier === "hod" ? fac.deptAppointments.map((d) => d.deptCode) : []
     return {
@@ -153,6 +162,7 @@ export async function getSessionUser(): Promise<SessionUser | null> {
       deptCodes,
       classIds,
       classKeys,
+      coordinatorClassIds,
       capabilities: await capabilitiesFor(tier, userId),
     }
   }
@@ -174,6 +184,7 @@ export async function getSessionUser(): Promise<SessionUser | null> {
       deptCodes: [],
       classIds: [],
       classKeys: stu.classKey ? [stu.classKey] : [],
+      coordinatorClassIds: [],
       capabilities: await capabilitiesFor("student", userId),
     }
   }


### PR DESCRIPTION
## What

Phase 1 of bringing the pre-reset marks surface back — reshaped onto the current schema rather than restored.

- Per-component marks locking (`isa`, `mse`, `ese`)
- CSV / Excel export from the marks grid
- `coordinatorClassIds` on the session, so unlock rights can tell a coordinator from a TR

## Why

`marksLocks` and the `marks:lock` capability both shipped with the MVP rebuild and **neither was ever used** — `git grep marksLocks` hit only the schema definition, and `marks:lock` sat in `ROLE_DEFAULTS.faculty` granting nothing. Dead table, dead capability.

The pre-reset code had all of this working, but it could not be lifted: it hung off `semesters` / `academic_years` tables that no longer exist, keyed offerings `(courseId, semesterId, division)` where main uses `(courseId, classId, semester)`, and authorised on `user.role === "admin"` — a model deleted entirely. So this is the logic re-expressed against the current schema.

## How

**Components lock separately** because they finish at different points in the term. Freezing the whole subject when internals are submitted would block the ESE column for the rest of the semester. `mse` covers `mse1` and `mse2` — two halves of one averaged mark, never submitted apart.

**Locking and unlocking are not the same privilege.** Anyone with `marks:write`/`marks:lock` can freeze — that is the person who did the work saying it is done. Reopening needs the class coordinator, the HOD, or super_admin, because it undoes a submission someone may already have acted on.

**The server is the guarantee, not the grid.** `saveMarksAction` re-reads stored values and carries them forward for locked components instead of trusting the payload, so a stale tab or a direct call cannot slip a mark past a frozen component.

### Reshaping decisions worth flagging

- `marksLocks` lost `unlockedBy` / `unlockedAt` in the rebuild. Rather than adding columns back, unlocks go to `audit_logs`, where every other mutation already leaves its trail. Unlocking clears the stamp and keeps the row.
- `lockedBy` referenced `user.id`; the current column is `lockedByFacultyId`, so the actor is `user.facultyId`.
- `getSessionUser` already read `classAssignments` but dropped the `role` column. Selecting it makes `coordinatorClassIds` free — no extra query.
- Sidebar: the faculty entry is renamed "Classes, marks & attendance" rather than adding a second link to the same URL. Marks genuinely live inside a class; the label just stops it being a guess.

## Testing

Lock queries round-tripped against the live database with a temporary offering, then cleaned up:

```
open at start:        []
after lock isa:       [ 'isa' ]
re-lock idempotent:   [ 'isa' ]      <- no duplicate row
after lock ese:       [ 'ese', 'isa' ]
after unlock isa:     [ 'ese' ]      <- row kept, is_locked=false, locked_at nulled
before/after counts:  identical      <- probe rows fully removed
```

- [x] `npm run check` passes (0 errors; the 2 warnings are pre-existing on `main`)
- [x] `npm run build` passes
- [x] Tested locally

## Not in this PR

Phases 2–5 from the plan: student marks history, the SGPI/CGPA console, course catalogue CRUD, and the open questions (practical batches, semester model, and Tanishq's promotion/graduation flow from #40, which the reset also deleted).
