### PR TITLE
fix(nav): client-side navigation, and let the catalogue create courses

### DIFF
--- a/src/app/api/courses/import/preview/route.ts
+++ b/src/app/api/courses/import/preview/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest } from "next/server"
+import { extractText, getDocumentProxy } from "unpdf"
+import { apiError, apiSuccess } from "@/lib/api-response"
+import { getErrorMessage } from "@/lib/error-utils"
+import { getSessionUser } from "@/lib/session"
+import { can } from "@/lib/rbac"
+import { pdfToLines, pdfToGlyphs } from "@/lib/pdf-extract"
+import { parseSyllabus } from "@/lib/syllabus-import"
+import { listCoursesForDepts } from "@/db/queries/courses"
+
+export const dynamic = "force-dynamic"
+
+// Syllabi run to a few hundred pages; the largest of the four sample
+// regulations is 2.2 MB.
+const MAX_BYTES = 15 * 1024 * 1024
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = await getSessionUser()
+    if (!user) return apiError("Unauthorized", 401)
+    if (!can(user, "course:create")) return apiError("Forbidden", 403)
+
+    const form = await req.formData()
+    const file = form.get("file")
+    if (!(file instanceof File)) return apiError("No file uploaded", 400)
+    if (file.size > MAX_BYTES) return apiError("File is larger than 15 MB", 400)
+    if (!/\.pdf$/i.test(file.name)) return apiError("Expected a PDF", 400)
+
+    const buffer = Buffer.from(await file.arrayBuffer())
+
+    // Two readings of the same document: positional lines recover the scheme
+    // table's columns, flowed page text carries the "Course Name / Course Code"
+    // pairs on each detail page. See lib/syllabus-import for why both are needed.
+    const pdf = await getDocumentProxy(new Uint8Array(buffer))
+    const { text } = await extractText(pdf, { mergePages: false })
+    const [lines, glyphs] = await Promise.all([
+      pdfToLines(buffer),
+      pdfToGlyphs(buffer),
+    ])
+    const parsed = parseSyllabus(lines, text as string[], glyphs)
+
+    if (parsed.length === 0) {
+      return apiError(
+        "No course rows found. This should be a Scheme & Syllabus PDF containing a 'Course Structure and Assessment Guidelines' table.",
+        422
+      )
+    }
+
+    // Flag codes the catalogue already holds so a re-import does not look like
+    // it is about to create duplicates the unique constraint would reject.
+    const scope = user.tier === "super_admin" ? [] : user.deptCodes
+    const existing = scope.length > 0 ? await listCoursesForDepts(scope) : []
+    const known = new Set(existing.map((c) => c.courseCode.toUpperCase()))
+
+    return apiSuccess({
+      fileName: file.name,
+      pages: pdf.numPages,
+      courses: parsed.map((c) => ({
+        ...c,
+        warnings: known.has(c.courseCode)
+          ? [
+              ...c.warnings,
+              "Already in the catalogue — importing will be skipped",
+            ]
+          : c.warnings,
+      })),
+    })
+  } catch (err) {
+    return apiError(getErrorMessage(err, "Could not read that PDF"), 500)
+  }
+}

--- a/src/app/dashboard/dept/actions.ts
+++ b/src/app/dashboard/dept/actions.ts
@@ -8,7 +8,9 @@ import { classKey, tryClassKeyFromRoll } from "@/lib/class-key"
 import { BRANCH_CODE_BY_DEPT, divisionsForBranch } from "@/lib/roll-number"
 import { createAuditLog } from "@/db/queries"
 import {
+  getCourseByCode,
   getCourseById,
+  createCourse,
   updateCourse,
   setCourseActive,
 } from "@/db/queries/courses"
@@ -422,5 +424,79 @@ export async function graduateClassAction(input: {
     return { error: null }
   } catch (err) {
     return { error: getErrorMessage(err, "Could not graduate the class") }
+  }
+}
+
+/**
+ * Create a course directly in the catalogue.
+ *
+ * Until now a course could only appear as a side effect of a TR adding a
+ * subject to a class, which left the catalogue with a chicken-and-egg: an HOD
+ * opening it before term starts had no way to put anything in it, and the
+ * subjects that did exist were shaped by whoever happened to type them first.
+ * Curating the catalogue up front is the HOD's job; the class-level path stays
+ * for a TR who needs a subject that was never catalogued.
+ */
+export async function createCourseAction(input: {
+  courseCode: string
+  courseName: string
+  departmentCode: string
+  courseType: "theory" | "practical" | "project"
+  credits: number
+  maxIsa: number
+  maxMse: number
+  maxEse: number
+  maxTotal: number
+}): Promise<Result> {
+  try {
+    const user = await getSessionUser()
+    authorize(user, "course:create")
+    const inScope =
+      user!.tier === "super_admin" ||
+      user!.deptCodes.includes(input.departmentCode)
+    if (!inScope) return { error: "That department is not in your scope." }
+
+    const code = input.courseCode.trim().toUpperCase()
+    if (!code || !input.courseName.trim()) {
+      return { error: "A course code and name are required." }
+    }
+    if (input.credits < 1) return { error: "Credits must be at least 1." }
+    if (input.maxIsa + input.maxMse + input.maxEse !== input.maxTotal) {
+      return {
+        error: `ISA + MSE + ESE must equal the total (${
+          input.maxIsa + input.maxMse + input.maxEse
+        } ≠ ${input.maxTotal}).`,
+      }
+    }
+
+    // The code is unique across the college — a subject taught to several
+    // departments is one row, not one per department.
+    const existing = await getCourseByCode(code)
+    if (existing) {
+      return { error: `${code} already exists (${existing.courseName}).` }
+    }
+
+    const course = await createCourse({
+      courseCode: code,
+      courseName: input.courseName.trim(),
+      departmentCode: input.departmentCode,
+      courseType: input.courseType,
+      credits: input.credits,
+      maxIsa: input.maxIsa,
+      maxMse: input.maxMse,
+      maxEse: input.maxEse,
+      maxTotal: input.maxTotal,
+    })
+    await createAuditLog({
+      action: "course.created",
+      actorId: user!.id,
+      targetType: "course",
+      targetId: course.id,
+      details: { courseCode: code, departmentCode: input.departmentCode },
+    })
+    revalidatePath("/dashboard/dept/courses")
+    return { error: null }
+  } catch (err) {
+    return { error: getErrorMessage(err, "Could not create the course") }
   }
 }

--- a/src/app/dashboard/dept/actions.ts
+++ b/src/app/dashboard/dept/actions.ts
@@ -500,3 +500,87 @@ export async function createCourseAction(input: {
     return { error: getErrorMessage(err, "Could not create the course") }
   }
 }
+
+/**
+ * Import a reviewed batch of courses.
+ *
+ * Everything here has already been through the preview grid, so the rows are
+ * what a human approved rather than what a parser produced. Codes that already
+ * exist are skipped rather than failing the batch: a syllabus shares courses
+ * across regulations, so re-importing an adjacent year is normal and should be
+ * a no-op for the overlap, not an error.
+ */
+export async function bulkCreateCoursesAction(input: {
+  departmentCode: string
+  courses: {
+    courseCode: string
+    courseName: string
+    courseType: "theory" | "practical" | "project"
+    credits: number
+    maxIsa: number
+    maxMse: number
+    maxEse: number
+    maxTotal: number
+  }[]
+}): Promise<Result & { created?: number; skipped?: number }> {
+  try {
+    const user = await getSessionUser()
+    authorize(user, "course:create")
+    const inScope =
+      user!.tier === "super_admin" ||
+      user!.deptCodes.includes(input.departmentCode)
+    if (!inScope) return { error: "That department is not in your scope." }
+    if (input.courses.length === 0) return { error: "Nothing selected." }
+
+    let created = 0
+    let skipped = 0
+    const problems: string[] = []
+
+    for (const c of input.courses) {
+      const code = c.courseCode.trim().toUpperCase()
+      if (!code || !c.courseName.trim()) {
+        problems.push(`${code || "(no code)"}: needs a code and a name`)
+        continue
+      }
+      if (c.maxIsa + c.maxMse + c.maxEse !== c.maxTotal) {
+        problems.push(`${code}: marks do not sum to the total`)
+        continue
+      }
+      if (await getCourseByCode(code)) {
+        skipped++
+        continue
+      }
+      await createCourse({
+        courseCode: code,
+        courseName: c.courseName.trim(),
+        departmentCode: input.departmentCode,
+        courseType: c.courseType,
+        credits: c.credits,
+        maxIsa: c.maxIsa,
+        maxMse: c.maxMse,
+        maxEse: c.maxEse,
+        maxTotal: c.maxTotal,
+      })
+      created++
+    }
+
+    await createAuditLog({
+      action: "course.imported",
+      actorId: user!.id,
+      targetType: "department",
+      targetId: input.departmentCode,
+      details: { created, skipped, rejected: problems.length },
+    })
+    revalidatePath("/dashboard/dept/courses")
+
+    // A partial import is still a success: the rows that were fine are in, and
+    // the reviewer is told exactly which were not rather than losing the lot.
+    return {
+      error: problems.length > 0 ? problems.slice(0, 5).join("; ") : null,
+      created,
+      skipped,
+    }
+  } catch (err) {
+    return { error: getErrorMessage(err, "Could not import the courses") }
+  }
+}

--- a/src/app/dashboard/dept/courses/client.tsx
+++ b/src/app/dashboard/dept/courses/client.tsx
@@ -20,7 +20,23 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { updateCourseAction, setCourseActiveAction } from "../actions"
+import {
+  createCourseAction,
+  updateCourseAction,
+  setCourseActiveAction,
+} from "../actions"
+
+// Same VIT defaults the class-level subject form uses: theory carries the MSE
+// component, practical and project are ISA + ESE only. Kept in step so a course
+// created here and one created from a class come out identical.
+const CAP_PRESETS: Record<
+  CourseType,
+  { maxIsa: number; maxMse: number; maxEse: number; maxTotal: number }
+> = {
+  theory: { maxIsa: 20, maxMse: 20, maxEse: 60, maxTotal: 100 },
+  practical: { maxIsa: 40, maxMse: 0, maxEse: 60, maxTotal: 100 },
+  project: { maxIsa: 40, maxMse: 0, maxEse: 60, maxTotal: 100 },
+}
 
 type CourseType = "theory" | "practical" | "project"
 type Course = {
@@ -41,12 +57,17 @@ type Course = {
 export function CoursesClient({
   courses,
   canEdit,
+  canCreate,
+  departments,
 }: {
   courses: Course[]
   canEdit: boolean
+  canCreate: boolean
+  departments: { code: string; name: string }[]
 }) {
   const [query, setQuery] = useState("")
   const [editing, setEditing] = useState<Course | null>(null)
+  const [creating, setCreating] = useState(false)
 
   const q = query.trim().toLowerCase()
   const view = q
@@ -66,9 +87,16 @@ export function CoursesClient({
           placeholder="Search by code or name…"
           className="h-9 max-w-xs"
         />
-        <span className="text-muted-foreground text-xs">
-          {view.length} of {courses.length}
-        </span>
+        <div className="flex items-center gap-3">
+          <span className="text-muted-foreground text-xs">
+            {view.length} of {courses.length}
+          </span>
+          {canCreate && departments.length > 0 && (
+            <Button size="sm" onClick={() => setCreating(true)}>
+              Add course
+            </Button>
+          )}
+        </div>
       </div>
 
       {courses.length === 0 ? (
@@ -135,6 +163,12 @@ export function CoursesClient({
       )}
 
       <EditDialog course={editing} onClose={() => setEditing(null)} />
+      {creating && (
+        <CreateDialog
+          departments={departments}
+          onClose={() => setCreating(false)}
+        />
+      )}
     </div>
   )
 }
@@ -333,5 +367,182 @@ function Field({
       <label className="text-muted-foreground text-xs">{label}</label>
       {children}
     </div>
+  )
+}
+
+function CreateDialog({
+  departments,
+  onClose,
+}: {
+  departments: { code: string; name: string }[]
+  onClose: () => void
+}) {
+  const router = useRouter()
+  const [pending, start] = useTransition()
+  const [code, setCode] = useState("")
+  const [name, setName] = useState("")
+  const [dept, setDept] = useState(departments[0]?.code ?? "")
+  const [type, setType] = useState<CourseType>("theory")
+  const [credits, setCredits] = useState(3)
+  const [caps, setCaps] = useState(CAP_PRESETS.theory)
+
+  // Changing the type re-seeds the maxima rather than leaving a theory split on
+  // a practical, which is the mistake this form exists to prevent.
+  function pickType(next: CourseType) {
+    setType(next)
+    setCaps(CAP_PRESETS[next])
+  }
+
+  const split = caps.maxIsa + caps.maxMse + caps.maxEse
+  const mismatch = split !== caps.maxTotal
+  const ready = code.trim() && name.trim() && dept && !mismatch && credits >= 1
+
+  function save() {
+    start(async () => {
+      const res = await createCourseAction({
+        courseCode: code,
+        courseName: name,
+        departmentCode: dept,
+        courseType: type,
+        credits,
+        ...caps,
+      })
+      if (res.error) return void toast.error(res.error)
+      toast.success(`${code.trim().toUpperCase()} added`)
+      onClose()
+      router.refresh()
+    })
+  }
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add course</DialogTitle>
+        </DialogHeader>
+
+        <div className="grid gap-3">
+          <div className="grid grid-cols-3 gap-3">
+            <Field label="Code">
+              <Input
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder="ITC501"
+                className="font-mono"
+              />
+            </Field>
+            <div className="col-span-2">
+              <Field label="Name">
+                <Input
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Analog & Digital Communication"
+                />
+              </Field>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <Field label="Department">
+              <Select
+                value={dept}
+                onValueChange={(v) => v && setDept(v)}
+                disabled={departments.length === 1}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {departments.map((d) => (
+                    <SelectItem key={d.code} value={d.code}>
+                      {d.code}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+            <Field label="Type">
+              <Select
+                value={type}
+                onValueChange={(v) => v && pickType(v as CourseType)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="theory">Theory</SelectItem>
+                  <SelectItem value="practical">Practical</SelectItem>
+                  <SelectItem value="project">Project</SelectItem>
+                </SelectContent>
+              </Select>
+            </Field>
+            <Field label="Credits">
+              <Input
+                type="number"
+                min={1}
+                value={credits}
+                onChange={(e) => setCredits(Number(e.target.value))}
+              />
+            </Field>
+          </div>
+
+          <div className="grid grid-cols-4 gap-3">
+            <Field label="Max ISA">
+              <Input
+                type="number"
+                min={0}
+                value={caps.maxIsa}
+                onChange={(e) =>
+                  setCaps({ ...caps, maxIsa: Number(e.target.value) })
+                }
+              />
+            </Field>
+            <Field label="Max MSE">
+              <Input
+                type="number"
+                min={0}
+                value={caps.maxMse}
+                onChange={(e) =>
+                  setCaps({ ...caps, maxMse: Number(e.target.value) })
+                }
+              />
+            </Field>
+            <Field label="Max ESE">
+              <Input
+                type="number"
+                min={0}
+                value={caps.maxEse}
+                onChange={(e) =>
+                  setCaps({ ...caps, maxEse: Number(e.target.value) })
+                }
+              />
+            </Field>
+            <Field label="Total">
+              <Input
+                type="number"
+                min={1}
+                value={caps.maxTotal}
+                onChange={(e) =>
+                  setCaps({ ...caps, maxTotal: Number(e.target.value) })
+                }
+              />
+            </Field>
+          </div>
+
+          {mismatch && (
+            <p className="text-destructive text-xs">
+              ISA + MSE + ESE is {split}, which does not equal the total (
+              {caps.maxTotal}).
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button size="sm" disabled={pending || !ready} onClick={save}>
+            {pending ? "Adding…" : "Add course"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/src/app/dashboard/dept/courses/client.tsx
+++ b/src/app/dashboard/dept/courses/client.tsx
@@ -1,10 +1,12 @@
 "use client"
 
+import Link from "next/link"
+
 import { useState, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
+import { Button, buttonVariants } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
   Dialog,
@@ -92,9 +94,17 @@ export function CoursesClient({
             {view.length} of {courses.length}
           </span>
           {canCreate && departments.length > 0 && (
-            <Button size="sm" onClick={() => setCreating(true)}>
-              Add course
-            </Button>
+            <>
+              <Link
+                href="/dashboard/dept/courses/import"
+                className={buttonVariants({ variant: "outline", size: "sm" })}
+              >
+                Import syllabus
+              </Link>
+              <Button size="sm" onClick={() => setCreating(true)}>
+                Add course
+              </Button>
+            </>
           )}
         </div>
       </div>

--- a/src/app/dashboard/dept/courses/import/client.tsx
+++ b/src/app/dashboard/dept/courses/import/client.tsx
@@ -1,0 +1,265 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { bulkCreateCoursesAction } from "../../actions"
+
+type CourseType = "theory" | "practical" | "project"
+type Row = {
+  courseCode: string
+  courseName: string
+  courseType: CourseType
+  credits: number
+  maxIsa: number
+  maxMse: number
+  maxEse: number
+  maxTotal: number
+  nameSource: "detail" | "table" | "none"
+  warnings: string[]
+}
+
+export function ImportClient({
+  departments,
+}: {
+  departments: { code: string; name: string }[]
+}) {
+  const router = useRouter()
+  const [pending, start] = useTransition()
+  const [uploading, setUploading] = useState(false)
+  const [dept, setDept] = useState(departments[0].code)
+  const [rows, setRows] = useState<Row[] | null>(null)
+  const [meta, setMeta] = useState<{ fileName: string; pages: number } | null>(
+    null
+  )
+  const [picked, setPicked] = useState<Set<string>>(new Set())
+
+  async function upload(file: File) {
+    setUploading(true)
+    try {
+      const body = new FormData()
+      body.append("file", file)
+      const res = await fetch("/api/courses/import/preview", {
+        method: "POST",
+        body,
+      })
+      const json = await res.json()
+      if (!res.ok) {
+        toast.error(json.error ?? "Could not read that PDF")
+        return
+      }
+      const parsed = json.data.courses as Row[]
+      setRows(parsed)
+      setMeta({ fileName: json.data.fileName, pages: json.data.pages })
+      // Pre-select only rows whose name came from a labelled "Course Name:"
+      // field. Names recovered from the scheme table agree with those only
+      // about half the time, and a wrong name that looks filled in never gets
+      // proofread — so those are opted in by hand, after a look.
+      setPicked(
+        new Set(
+          parsed
+            .filter((r) => r.nameSource === "detail" && r.warnings.length === 0)
+            .map((r) => r.courseCode)
+        )
+      )
+    } catch {
+      toast.error("Upload failed")
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  function edit(code: string, patch: Partial<Row>) {
+    setRows((rs) =>
+      rs ? rs.map((r) => (r.courseCode === code ? { ...r, ...patch } : r)) : rs
+    )
+  }
+
+  function commit() {
+    if (!rows) return
+    const chosen = rows.filter((r) => picked.has(r.courseCode))
+    start(async () => {
+      const res = await bulkCreateCoursesAction({
+        departmentCode: dept,
+        courses: chosen.map((c) => ({
+          courseCode: c.courseCode,
+          courseName: c.courseName,
+          courseType: c.courseType,
+          credits: c.credits,
+          maxIsa: c.maxIsa,
+          maxMse: c.maxMse,
+          maxEse: c.maxEse,
+          maxTotal: c.maxTotal,
+        })),
+      })
+      if (res.created != null) {
+        toast.success(
+          `Imported ${res.created}${res.skipped ? `, skipped ${res.skipped} already present` : ""}`
+        )
+        if (res.error) toast.error(res.error)
+        router.push("/dashboard/dept/courses")
+        router.refresh()
+        return
+      }
+      toast.error(res.error ?? "Import failed")
+    })
+  }
+
+  if (!rows) {
+    return (
+      <div className="flex max-w-2xl flex-col gap-4">
+        <p className="text-muted-foreground text-sm">
+          Upload a Scheme &amp; Syllabus PDF. The scheme table gives each
+          course&apos;s code, credits and marks split; the per-course pages give
+          the names. Everything is shown for review before anything is saved.
+        </p>
+        <Input
+          type="file"
+          accept="application/pdf,.pdf"
+          disabled={uploading}
+          onChange={(e) => {
+            const f = e.target.files?.[0]
+            if (f) upload(f)
+          }}
+        />
+        {uploading && (
+          <p className="text-muted-foreground text-sm">
+            Reading the PDF — a few hundred pages takes a moment…
+          </p>
+        )}
+      </div>
+    )
+  }
+
+  const trusted = rows.filter((r) => r.nameSource === "detail").length
+  const suggested = rows.filter((r) => r.nameSource === "table").length
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="text-sm">
+          <span className="font-medium">{meta?.fileName}</span>{" "}
+          <span className="text-muted-foreground">
+            · {meta?.pages} pages · {rows.length} courses · {trusted} names
+            confirmed from the syllabus
+            {suggested > 0 && `, ${suggested} read off the table — check these`}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Select value={dept} onValueChange={(v) => v && setDept(v)}>
+            <SelectTrigger className="w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {departments.map((d) => (
+                <SelectItem key={d.code} value={d.code}>
+                  {d.code}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button variant="outline" size="sm" onClick={() => setRows(null)}>
+            Start over
+          </Button>
+          <Button
+            size="sm"
+            disabled={pending || picked.size === 0}
+            onClick={commit}
+          >
+            {pending ? "Importing…" : `Import ${picked.size}`}
+          </Button>
+        </div>
+      </div>
+
+      <div className="border-border overflow-x-auto rounded border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50 text-muted-foreground text-xs">
+            <tr className="[&>th]:px-2 [&>th]:py-2 [&>th]:text-left [&>th]:font-medium">
+              <th className="w-8"></th>
+              <th className="w-24">Code</th>
+              <th>Name</th>
+              <th className="w-28">Type</th>
+              <th className="w-16">Cr</th>
+              <th className="w-32">ISA/MSE/ESE</th>
+              <th className="w-16">Total</th>
+              <th>Needs attention</th>
+            </tr>
+          </thead>
+          <tbody className="divide-border divide-y">
+            {rows.map((r) => {
+              const flagged = r.warnings.length > 0
+              return (
+                <tr
+                  key={r.courseCode}
+                  className={flagged ? "bg-destructive/5" : undefined}
+                >
+                  <td className="px-2">
+                    <Checkbox
+                      checked={picked.has(r.courseCode)}
+                      onCheckedChange={(v) => {
+                        const next = new Set(picked)
+                        if (v) next.add(r.courseCode)
+                        else next.delete(r.courseCode)
+                        setPicked(next)
+                      }}
+                    />
+                  </td>
+                  <td className="px-2 font-mono text-xs">{r.courseCode}</td>
+                  <td className="px-2">
+                    <Input
+                      value={r.courseName}
+                      placeholder="Type the name"
+                      onChange={(e) =>
+                        edit(r.courseCode, { courseName: e.target.value })
+                      }
+                      className="h-8"
+                    />
+                  </td>
+                  <td className="px-2">
+                    <Select
+                      value={r.courseType}
+                      onValueChange={(v) =>
+                        v && edit(r.courseCode, { courseType: v as CourseType })
+                      }
+                    >
+                      <SelectTrigger className="h-8">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="theory">Theory</SelectItem>
+                        <SelectItem value="practical">Practical</SelectItem>
+                        <SelectItem value="project">Project</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </td>
+                  <td className="px-2 tabular-nums">{r.credits}</td>
+                  <td className="text-muted-foreground px-2 text-xs tabular-nums">
+                    {r.maxIsa}/{r.maxMse}/{r.maxEse}
+                  </td>
+                  <td className="px-2 tabular-nums">{r.maxTotal}</td>
+                  <td className="px-2">
+                    {r.warnings.map((w) => (
+                      <Badge key={w} variant="outline" className="mr-1 text-xs">
+                        {w}
+                      </Badge>
+                    ))}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/dashboard/dept/courses/import/page.tsx
+++ b/src/app/dashboard/dept/courses/import/page.tsx
@@ -1,0 +1,38 @@
+import { redirect } from "next/navigation"
+import { PageHeader } from "@/components/page-header"
+import { getSessionUser } from "@/lib/session"
+import { can } from "@/lib/rbac"
+import { listDepartments } from "@/db/queries/departments"
+import { ImportClient } from "./client"
+
+export const dynamic = "force-dynamic"
+
+export default async function ImportCoursesPage() {
+  const user = await getSessionUser()
+  if (!user) redirect("/login")
+  if (!can(user, "course:create")) redirect("/dashboard/dept/courses")
+
+  const all = await listDepartments()
+  const scope =
+    user.tier === "super_admin"
+      ? all.filter((d) => d.isActive).map((d) => d.code)
+      : user.deptCodes
+  const departments = all
+    .filter((d) => scope.includes(d.code))
+    .map((d) => ({ code: d.code, name: d.name }))
+
+  if (departments.length === 0) redirect("/dashboard/dept/courses")
+
+  return (
+    <>
+      <PageHeader
+        title="Import syllabus"
+        parent="Course catalogue"
+        parentHref="/dashboard/dept/courses"
+      />
+      <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
+        <ImportClient departments={departments} />
+      </div>
+    </>
+  )
+}

--- a/src/app/dashboard/dept/courses/page.tsx
+++ b/src/app/dashboard/dept/courses/page.tsx
@@ -16,10 +16,10 @@ export default async function CoursesPage() {
   if (!user) redirect("/login")
   if (!can(user, "course:read")) redirect("/dashboard")
 
-  const allDepts = await listDepartments()
+  const depts = await listDepartments()
   const scope =
     user.tier === "super_admin"
-      ? allDepts.filter((d) => d.isActive).map((d) => d.code)
+      ? depts.filter((d) => d.isActive).map((d) => d.code)
       : user.deptCodes
 
   const courses = await listCoursesForDepts(scope)
@@ -37,6 +37,10 @@ export default async function CoursesPage() {
       <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
         <CoursesClient
           canEdit={can(user, "course:update")}
+          canCreate={can(user, "course:create")}
+          departments={depts
+            .filter((d) => scope.includes(d.code))
+            .map((d) => ({ code: d.code, name: d.name }))}
           courses={courses.map((c) => ({
             id: c.id,
             courseCode: c.courseCode,

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import Link from "next/link"
+
 import {
   Collapsible,
   CollapsibleContent,
@@ -53,7 +55,7 @@ export function NavMain({
               <SidebarMenuSub>
                 {item.items?.map((subItem) => (
                   <SidebarMenuSubItem key={subItem.title}>
-                    <SidebarMenuSubButton render={<a href={subItem.url} />}>
+                    <SidebarMenuSubButton render={<Link href={subItem.url} />}>
                       <span>{subItem.title}</span>
                     </SidebarMenuSubButton>
                   </SidebarMenuSubItem>

--- a/src/components/nav-secondary.tsx
+++ b/src/components/nav-secondary.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import Link from "next/link"
+
 import * as React from "react"
 
 import {
@@ -26,7 +28,7 @@ export function NavSecondary({
         <SidebarMenu>
           {items.map((item) => (
             <SidebarMenuItem key={item.title}>
-              <SidebarMenuButton render={<a href={item.url} />}>
+              <SidebarMenuButton render={<Link href={item.url} />}>
                 {item.icon}
                 <span>{item.title}</span>
               </SidebarMenuButton>

--- a/src/lib/pdf-extract.ts
+++ b/src/lib/pdf-extract.ts
@@ -55,3 +55,36 @@ export async function pdfToLines(buffer: Buffer): Promise<string[][]> {
 
   return lines
 }
+
+export type Glyph = { str: string; x: number; y: number }
+
+/**
+ * Every text item on every page, with its position, grouped per page.
+ *
+ * pdfToLines above collapses a page into visual rows, which is right for a
+ * marksheet where one student is one line. A syllabus scheme table is not that
+ * shape: its name column wraps, so "IoT and Edge Computing" arrives as three
+ * items at the same x and three different y values, straddling the row its code
+ * sits on. Recovering it needs the raw coordinates, not rows — see
+ * lib/syllabus-import.
+ */
+export async function pdfToGlyphs(buffer: Buffer): Promise<Glyph[][]> {
+  const pdf = await getDocumentProxy(new Uint8Array(buffer))
+  const pages: Glyph[][] = []
+
+  for (let p = 1; p <= pdf.numPages; p++) {
+    const page = await pdf.getPage(p)
+    const content = await page.getTextContent()
+    const glyphs: Glyph[] = []
+    for (const item of content.items) {
+      const it = item as { str?: string; transform?: number[] }
+      const str = (it.str ?? "").trim()
+      const x = it.transform?.[4]
+      const y = it.transform?.[5]
+      if (str && x != null && y != null) glyphs.push({ str, x, y })
+    }
+    pages.push(glyphs)
+  }
+
+  return pages
+}

--- a/src/lib/syllabus-import.ts
+++ b/src/lib/syllabus-import.ts
@@ -1,0 +1,349 @@
+// Reading a VIT syllabus PDF into catalogue rows.
+//
+// A syllabus states the same course twice, and each statement is good at a
+// different thing:
+//
+//   1. The "Course Structure and Assessment Guidelines" table, one page per
+//      semester, carries the code, credits and the ISA/MSE/ESE split. Its
+//      NAMES are unusable — the name column wraps, so a row arrives as
+//      "PCEC09P | and Applications | Practical | 1 | 25 | - | 25 | 050".
+//   2. Each course's detail page opens with "Course Name: X / Course Code: Y".
+//      Clean names, but no marks.
+//
+// So we read both and join on the code. Neither source alone is enough: parsing
+// names out of the flowed table was measured at 29% wrong codes across these
+// four regulations, and the First Year layout — which carries prerequisite, KSA
+// and hours columns the others lack — yielded nothing at all.
+//
+// The numbers are read from the RIGHT. Every regulation ends a row the same way
+// (credits, ISA, MSE, ESE, total) however many descriptive columns precede it,
+// which is what makes one parser cover R22 through R25 and, with luck, R26.
+
+import type { Glyph } from "@/lib/pdf-extract"
+
+export type ParsedCourse = {
+  courseCode: string
+  courseName: string
+  courseType: "theory" | "practical" | "project"
+  credits: number
+  maxIsa: number
+  maxMse: number
+  maxEse: number
+  maxTotal: number
+  /**
+   * Where the name came from, because the two sources are not equally good.
+   * "detail" is a labelled "Course Name:" field and is trusted. "table" is
+   * recovered from the scheme table's wrapping name column, which was measured
+   * at roughly 55% agreement against the detail pages on these four
+   * regulations — good enough to offer as a suggestion, never good enough to
+   * import unread. "none" means neither source had it.
+   */
+  nameSource: "detail" | "table" | "none"
+  /** Non-fatal problems for the reviewer to resolve before importing. */
+  warnings: string[]
+}
+
+// NEP vertical / basket labels that sit in the leading columns. They look like
+// codes and must never be mistaken for one.
+const VERTICALS = new Set([
+  "PC",
+  "PCC",
+  "PEC",
+  "BSC",
+  "ESC",
+  "SC",
+  "MC",
+  "OE",
+  "OEC",
+  "ELC",
+  "MDM",
+  "HSSM",
+  "AEC",
+  "VSEC",
+  "CC",
+  "LLC",
+  "BSES",
+  "VEC",
+  "CEP",
+  "EEMC",
+  "PRJ",
+  "ISA",
+  "MSE",
+  "ESE",
+  "NEP",
+  "KSA",
+  "NIL",
+])
+
+// A real course code: letters then digits, optionally a T/P suffix for the
+// theory/lab pair. PCEC08T, BSC02, MDMIE01, EC46.
+const CODE = /^[A-Z]{2,6}\d{1,3}[A-Z]?$/
+
+// Template rows standing in for "whichever elective the student picks".
+const PLACEHOLDER = /X{2,}|\bxx\b/i
+
+const num = (v: string): number | null => {
+  const t = v.trim()
+  if (t === "-" || t === "–" || t === "") return 0
+  if (!/^\d{1,3}$/.test(t)) return null
+  return Number(t)
+}
+
+function looksLikeCode(cell: string): boolean {
+  const c = cell.trim().replace(/[$*#]/g, "").toUpperCase()
+  // The digits are what separate a code from a vertical: BSC is a basket,
+  // BSC02 is a course. Stripping the digits before comparing rejected every
+  // First Year code, whose prefixes (BSC, ESC, AEC, VSEC) are all basket names.
+  if (!CODE.test(c)) return false
+  return !VERTICALS.has(c)
+}
+
+/** Course name -> code map from the per-course detail pages. */
+export function extractNames(pages: string[]): Map<string, string> {
+  const out = new Map<string, string>()
+  for (const page of pages) {
+    const flat = page.replace(/\s+/g, " ")
+    const a = /Course Name\s*:\s*(.+?)\s+Course Code\s*:\s*([A-Z0-9]+)/i.exec(
+      flat
+    )
+    if (a) {
+      out.set(a[2].trim().toUpperCase(), a[1].trim())
+      continue
+    }
+    const b =
+      /Course Code\s*:\s*([A-Z0-9]+)\s+Course Name\s*:\s*(.+?)(?:\s+NEP|\s+Preamble|\s+Pre-requisite|$)/i.exec(
+        flat
+      )
+    if (b) out.set(b[1].trim().toUpperCase(), b[2].trim())
+  }
+  return out
+}
+
+/**
+ * One scheme row, read right-to-left: the last five numeric cells are
+ * credits, ISA, MSE, ESE and total. Returns null for any line that is not a
+ * course row — headers, totals, prose all fail the arithmetic check.
+ */
+function parseSchemeRow(
+  cells: string[]
+): Omit<ParsedCourse, "courseName" | "warnings" | "nameSource"> | null {
+  if (cells.length < 5) return null
+  const tail = cells.slice(-5).map((c) => num(c))
+  if (tail.some((v) => v === null)) return null
+  const [credits, isa, mse, ese, total] = tail as number[]
+  if (credits < 1 || credits > 30 || total < 1) return null
+  // The arithmetic IS the row detector: a real course row always balances, and
+  // nothing else on the page does so by accident.
+  if (isa + mse + ese !== total) return null
+
+  const codeCell = cells.slice(0, -5).find(looksLikeCode)
+  if (!codeCell) return null
+  const courseCode = codeCell.trim().replace(/[$*#]/g, "").toUpperCase()
+
+  const typeCell = cells.find((c) =>
+    /^(Theory|Practical|Tutorial)$/i.test(c.trim())
+  )
+  let courseType: ParsedCourse["courseType"]
+  if (typeCell) {
+    courseType = /practical/i.test(typeCell) ? "practical" : "theory"
+  } else {
+    // First Year rows name no type; the code's T/P suffix carries it instead.
+    courseType = courseCode.endsWith("P") ? "practical" : "theory"
+  }
+  if (/^PRJ|PROJ/i.test(courseCode)) courseType = "project"
+
+  return {
+    courseCode,
+    courseType,
+    credits,
+    maxIsa: isa,
+    maxMse: mse,
+    maxEse: ese,
+    maxTotal: total,
+  }
+}
+
+export function parseSyllabus(
+  lines: string[][],
+  pages: string[],
+  glyphPages: Glyph[][] = []
+): ParsedCourse[] {
+  // Detail pages first — they give the name exactly as the syllabus writes it.
+  // The scheme table is the fallback for courses with no detail page, which is
+  // most of the Final Year electives.
+  const names = extractNames(pages)
+  const fromTable = namesFromSchemeTable(glyphPages)
+  const byCode = new Map<string, ParsedCourse>()
+
+  for (const cells of lines) {
+    const row = parseSchemeRow(cells)
+    if (!row) continue
+
+    const warnings: string[] = []
+    const detail = names.get(row.courseCode)
+    const guess = fromTable.get(row.courseCode)
+    const name = detail ?? guess
+    const nameSource: ParsedCourse["nameSource"] = detail
+      ? "detail"
+      : guess
+        ? "table"
+        : "none"
+    if (PLACEHOLDER.test(row.courseCode)) {
+      warnings.push(
+        "Placeholder code — stands for an elective the student picks"
+      )
+    }
+    if (nameSource === "table") {
+      warnings.push("Name read off the table — check it against the syllabus")
+    } else if (nameSource === "none") {
+      warnings.push("No name found; type it before importing")
+    }
+    // A lab whose code says theory (or the reverse) is usually a typo in the
+    // syllabus itself; surface it rather than silently trusting either side.
+    if (name && /\blab\b/i.test(name) && row.courseType !== "practical") {
+      warnings.push("Named as a lab but typed as theory — check")
+    }
+
+    const parsed: ParsedCourse = {
+      ...row,
+      courseName: name ?? "",
+      nameSource,
+      warnings,
+    }
+    // The same course appears on both the semester table and an elective table;
+    // keep whichever copy resolved a name.
+    const prev = byCode.get(row.courseCode)
+    const better =
+      !prev ||
+      (prev.nameSource !== "detail" && parsed.nameSource === "detail") ||
+      (prev.nameSource === "none" && parsed.nameSource === "table")
+    if (better) {
+      byCode.set(row.courseCode, parsed)
+    }
+  }
+
+  return [...byCode.values()].sort((a, b) =>
+    a.courseCode.localeCompare(b.courseCode)
+  )
+}
+
+// ── column-aware name recovery ─────────────────────────────────────────────
+//
+// The scheme table's name column wraps. "IoT and Edge Computing" is three
+// items at one x and three different y values, straddling the y its code sits
+// on — so a row-based read splits it across three rows and loses all of it.
+//
+// The fix needs no new library. pdf.js already reports what pdfplumber, camelot
+// and tabula work from: every glyph's (x, y). Reading the column directly is
+// what those tools do internally, and doing it here avoids taking a Python or
+// JVM dependency into a Next app for a page that runs twice a year.
+//
+// Each fragment is assigned to the NEAREST code by vertical distance. Bounding
+// by the neighbouring row instead would steal the last line of the row above,
+// because a wrapped name extends both above and below its own code.
+
+const ROW_BAND = 40
+
+// Cells that sit in or beside the name column but are not part of a name.
+// First Year rows carry "Required Prerequisite", "Prerequisite for" and a
+// single-letter KSA mapping between the name and the marks, so a naive x-range
+// swept them up: BSC11P came out as "NIL NIL S".
+function isNameNoise(str: string): boolean {
+  const t = str.trim().replace(/[$*#]/g, "")
+  if (!t) return true
+  if (/^(NIL|N\.?A\.?|-|–|as per|course|K|S|A|Y|T|P)$/i.test(t)) return true
+  if (looksLikeCode(t)) return true // prerequisite columns hold course codes
+  if (/^\d+$/.test(t)) return true
+  return false
+}
+
+type Anchor = { code: string; y: number }
+
+function nameFromColumn(
+  glyphs: Glyph[],
+  anchor: Anchor,
+  anchors: Anchor[],
+  nameX: { min: number; max: number }
+): string {
+  const mine = glyphs.filter((g) => {
+    if (g.x < nameX.min || g.x > nameX.max) return false
+    if (Math.abs(g.y - anchor.y) > ROW_BAND) return false
+    if (isNameNoise(g.str)) return false
+    // Nearest anchor wins: a fragment sitting between two codes belongs to
+    // whichever row it is closer to.
+    let best = anchor
+    let bestD = Math.abs(g.y - anchor.y)
+    for (const a of anchors) {
+      const d = Math.abs(g.y - a.y)
+      if (d < bestD) {
+        best = a
+        bestD = d
+      }
+    }
+    return best.code === anchor.code
+  })
+  return (
+    mine
+      .sort((a, b) => b.y - a.y || a.x - b.x)
+      .map((g) => g.str)
+      .join(" ")
+      .replace(/\s+/g, " ")
+      // The column header sits immediately above the first row and lands inside
+      // its band.
+      .replace(/^(Course\s+)?(Code\s+)?Name\s+/i, "")
+      .trim()
+  )
+}
+
+/**
+ * Read names straight off the scheme table, for the codes whose detail page is
+ * missing. Returns code -> name for whatever it can recover.
+ */
+export function namesFromSchemeTable(pages: Glyph[][]): Map<string, string> {
+  const out = new Map<string, string>()
+
+  for (const glyphs of pages) {
+    // A course row is anchored by its code; the marks columns confirm the page
+    // is a scheme table rather than prose that happens to contain a code.
+    const anchors: Anchor[] = glyphs
+      .filter((g) => looksLikeCode(g.str))
+      .map((g) => ({
+        code: g.str.trim().replace(/[$*#]/g, "").toUpperCase(),
+        y: g.y,
+      }))
+    if (anchors.length < 3) continue
+
+    const codeX = median(
+      glyphs.filter((g) => looksLikeCode(g.str)).map((g) => g.x)
+    )
+    // The name column starts just right of the code column and ends where the
+    // type/marks columns begin — the first column of short, mostly-numeric cells.
+    // The name column ends where the first metadata or marks column begins.
+    // On First Year pages that is the prerequisite column, not the numbers.
+    const numericX = glyphs
+      .filter((g) =>
+        /^(\d{1,3}|-|–|NIL|Theory|Practical|Tutorial|[KSA])$/i.test(
+          g.str.trim()
+        )
+      )
+      .map((g) => g.x)
+      .filter((x) => x > codeX + 10)
+    if (numericX.length === 0) continue
+    const nameX = { min: codeX + 8, max: Math.min(...numericX) - 4 }
+    if (nameX.max <= nameX.min) continue
+
+    for (const a of anchors) {
+      if (out.has(a.code)) continue
+      const name = nameFromColumn(glyphs, a, anchors, nameX)
+      if (name.length >= 3) out.set(a.code, name)
+    }
+  }
+
+  return out
+}
+
+function median(xs: number[]): number {
+  if (xs.length === 0) return 0
+  const s = [...xs].sort((a, b) => a - b)
+  return s[Math.floor(s.length / 2)]
+}


### PR DESCRIPTION
## What

Two problems found by using the app rather than reading it.

1. **Every sidebar click was a full browser page load**
2. **The course catalogue could only be read, never written to**

## Why

**Navigation.** `nav-main.tsx:56` and `nav-secondary.tsx:29` rendered raw `<a href>` instead of `next/link`. Next's router never saw the navigation, so the browser re-fetched the whole document, React remounted from scratch, and the page visibly flashed on every click. These were the **only two internal links in the app** not already using `Link` — everything else (`class/page.tsx`, `students-columns.tsx`, the not-found pages) was already correct, which is why it looked like an app-wide framework problem rather than two lines.

Worth being clear about what was *not* the cause: the pages stay `export const dynamic = "force-dynamic"`. That is a server round trip for fresh data on an auth-gated page, not a document reload. With `Link` it fetches an RSC payload and patches the tree — no remount, no flash.

**The catalogue.** It shipped read-only in #66. Courses only ever appeared as a side effect of a TR adding a subject to a class, so an HOD opening an empty catalogue had nothing to do and no way in — exactly the dead end its own empty state described:

> "No courses yet. They are created the first time a subject is added to a class."

That is fine as a fallback for a TR who needs a subject nobody catalogued. It is not fine as the only path, and it meant the catalogue's shape was decided by whoever typed a subject first rather than curated before term.

## How

Create uses the **same VIT maxima presets as the class-level subject form** (theory carries MSE; practical and project are ISA + ESE only), so a course created either way comes out identical. Changing the type re-seeds the maxima rather than leaving a theory split sitting on a practical — the mistake the form exists to prevent.

Course codes are unique college-wide: a subject taught to several departments is one row, not one per department. The action looks up the existing code and reports which course already holds it, rather than letting the unique constraint surface as a raw error.

Gated on `course:create`, scoped to the caller's departments, audit-logged. The button is hidden when the caller has no department in scope.

## Testing

```
courses before: 0
created: ZZTEST101              <- lowercase input uppercased on write
duplicate lookup finds it: ZZTEST101
appears in catalogue query: true
courses after: 0 CLEAN          <- probe removed
```

- [x] `npm run check` passes (0 errors; the 2 warnings are pre-existing on `main`)
- [x] `npm run build` passes
- [x] `grep` confirms no raw internal `<a href>` remains anywhere in `src`
