### PR TITLE
feat(dept): per-department dashboard

### DIFF
--- a/src/app/dashboard/dept/[code]/client.tsx
+++ b/src/app/dashboard/dept/[code]/client.tsx
@@ -1,0 +1,293 @@
+"use client"
+
+import Link from "next/link"
+import { Badge } from "@/components/ui/badge"
+
+type Person = { name: string; email: string }
+type ClassRow = {
+  id: string
+  classKey: string
+  label: string
+  isActive: boolean
+  graduated: boolean
+  coordinator: string | null
+  trs: string[]
+  students: number
+  unclaimed: number
+}
+type FacultyRow = {
+  id: string
+  name: string
+  email: string
+  tier: string
+  classRoles: string[]
+  claimed: boolean
+}
+
+export function DeptDashboardClient({
+  dept,
+  hod,
+  coordinator,
+  classes,
+  faculty,
+  totals,
+  unplaced,
+}: {
+  dept: { code: string; name: string; isActive: boolean }
+  hod: Person | null
+  coordinator: Person | null
+  classes: ClassRow[]
+  faculty: FacultyRow[]
+  totals: { students: number; unclaimedStudents: number; unplaced: number }
+  unplaced: {
+    id: string
+    rollNumber: string
+    name: string
+    classKey: string | null
+    year: string
+  }[]
+}) {
+  const placed = totals.students - totals.unplaced
+  return (
+    <div className="flex flex-col gap-6">
+      {!dept.isActive && (
+        <p className="border-border text-muted-foreground rounded border px-3 py-2 text-sm">
+          This department is deactivated. It is shown for reference; its records
+          are not being maintained.
+        </p>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Stat
+          label="Students"
+          value={totals.students}
+          hint={`${placed} in a class`}
+        />
+        <Stat
+          label="Faculty"
+          value={faculty.length}
+          hint={`${faculty.filter((f) => f.claimed).length} signed in`}
+        />
+        <Stat
+          label="Classes"
+          value={classes.length}
+          hint={`${classes.filter((c) => c.graduated).length} graduated`}
+        />
+        <Stat
+          label="Not signed in"
+          value={totals.unclaimedStudents}
+          hint="students yet to claim"
+          warn={totals.unclaimedStudents > 0}
+        />
+      </div>
+
+      <Section title="Leadership">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Lead role="Head of Department" person={hod} />
+          <Lead role="Department coordinator" person={coordinator} />
+        </div>
+      </Section>
+
+      <Section title={`Classes (${classes.length})`}>
+        {classes.length === 0 ? (
+          <Empty>No classes yet in this department.</Empty>
+        ) : (
+          <Table
+            head={["Class", "Coordinator", "TR", "Students", "Status"]}
+            rows={classes.map((c) => [
+              <Link
+                key="k"
+                href={`/dashboard/class/${c.id}`}
+                className="hover:underline"
+              >
+                <span className="font-medium">{c.label}</span>{" "}
+                <span className="text-muted-foreground font-mono text-xs">
+                  {c.classKey}
+                </span>
+              </Link>,
+              c.coordinator ?? <Unset key="c">Unassigned</Unset>,
+              c.trs.length > 0 ? c.trs.join(", ") : <Unset key="t">None</Unset>,
+              <span key="s" className="tabular-nums">
+                {c.students}
+                {c.unclaimed > 0 && (
+                  <span className="text-muted-foreground text-xs">
+                    {" "}
+                    ({c.unclaimed} not signed in)
+                  </span>
+                )}
+              </span>,
+              c.graduated ? (
+                <Badge key="g" variant="secondary">
+                  Graduated
+                </Badge>
+              ) : c.isActive ? (
+                <Badge key="g" variant="outline">
+                  Active
+                </Badge>
+              ) : (
+                <Badge key="g" variant="secondary">
+                  Inactive
+                </Badge>
+              ),
+            ])}
+          />
+        )}
+      </Section>
+
+      <Section title={`Faculty (${faculty.length})`}>
+        {faculty.length === 0 ? (
+          <Empty>No faculty on record for this department.</Empty>
+        ) : (
+          <Table
+            head={["Name", "Email", "Tier", "Class role", "Account"]}
+            rows={faculty.map((f) => [
+              f.name,
+              <span key="e" className="text-muted-foreground text-xs">
+                {f.email}
+              </span>,
+              <Badge key="t" variant="outline">
+                {f.tier}
+              </Badge>,
+              f.classRoles.length > 0 ? (
+                f.classRoles.join(" · ")
+              ) : (
+                <Unset key="r">—</Unset>
+              ),
+              f.claimed ? (
+                <span key="a" className="text-muted-foreground text-xs">
+                  Signed in
+                </span>
+              ) : (
+                <Unset key="a">Not claimed</Unset>
+              ),
+            ])}
+          />
+        )}
+      </Section>
+
+      {totals.unplaced > 0 && (
+        <Section title={`Not in any class (${totals.unplaced})`}>
+          <p className="text-muted-foreground mb-3 text-sm">
+            These students belong to the department but their cohort has no
+            class row yet, so they appear on no class roster and no coordinator
+            can act on them. Creating the matching class puts them in place —
+            membership is derived from the roll number, so nothing needs
+            re-importing.
+          </p>
+          <Table
+            head={["Roll", "Name", "Year", "Cohort key"]}
+            rows={unplaced.map((s) => [
+              <span key="r" className="font-mono text-xs">
+                {s.rollNumber}
+              </span>,
+              s.name,
+              s.year,
+              s.classKey ? (
+                <span key="k" className="font-mono text-xs">
+                  {s.classKey}
+                </span>
+              ) : (
+                <Unset key="k">Roll did not parse</Unset>
+              ),
+            ])}
+          />
+          {totals.unplaced > unplaced.length && (
+            <p className="text-muted-foreground mt-2 text-xs">
+              Showing the first {unplaced.length} of {totals.unplaced}.
+            </p>
+          )}
+        </Section>
+      )}
+    </div>
+  )
+}
+
+function Stat({
+  label,
+  value,
+  hint,
+  warn,
+}: {
+  label: string
+  value: number
+  hint: string
+  warn?: boolean
+}) {
+  return (
+    <div className="border-border rounded border p-4">
+      <p className="text-muted-foreground text-sm">{label}</p>
+      <p className="text-2xl font-semibold tabular-nums">{value}</p>
+      <p
+        className={
+          warn ? "text-destructive text-xs" : "text-muted-foreground text-xs"
+        }
+      >
+        {hint}
+      </p>
+    </div>
+  )
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <h2 className="text-sm font-semibold">{title}</h2>
+      {children}
+    </div>
+  )
+}
+
+function Lead({ role, person }: { role: string; person: Person | null }) {
+  return (
+    <div className="border-border rounded border p-3">
+      <p className="text-muted-foreground text-xs">{role}</p>
+      {person ? (
+        <>
+          <p className="text-sm font-medium">{person.name}</p>
+          <p className="text-muted-foreground text-xs">{person.email}</p>
+        </>
+      ) : (
+        <p className="text-destructive text-sm">Not appointed</p>
+      )}
+    </div>
+  )
+}
+
+function Unset({ children }: { children: React.ReactNode }) {
+  return <span className="text-destructive text-xs">{children}</span>
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return <p className="text-muted-foreground text-sm">{children}</p>
+}
+
+function Table({ head, rows }: { head: string[]; rows: React.ReactNode[][] }) {
+  return (
+    <div className="border-border overflow-x-auto rounded border">
+      <table className="w-full text-sm">
+        <thead className="bg-muted/50 text-muted-foreground text-xs">
+          <tr className="[&>th]:px-3 [&>th]:py-2 [&>th]:text-left [&>th]:font-medium">
+            {head.map((h) => (
+              <th key={h}>{h}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-border divide-y">
+          {rows.map((r, i) => (
+            <tr key={i} className="[&>td]:px-3 [&>td]:py-2">
+              {r.map((cell, j) => (
+                <td key={j}>{cell}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/app/dashboard/dept/[code]/page.tsx
+++ b/src/app/dashboard/dept/[code]/page.tsx
@@ -1,0 +1,153 @@
+import { notFound, redirect } from "next/navigation"
+import { PageHeader } from "@/components/page-header"
+import { getSessionUser } from "@/lib/session"
+import { expectedYear, currentYear } from "@/lib/roll-number"
+import { getDepartment } from "@/db/queries/departments"
+import { listClassesForDepts } from "@/db/queries/classes"
+import { listClassStaff } from "@/db/queries/class-staff"
+import { listActiveAppointments } from "@/db/queries/appointments"
+import { getFacultyByDepartments } from "@/db/queries/faculty"
+import {
+  getStudentsByDepartments,
+  getGraduatedClassKeys,
+} from "@/db/queries/students"
+import { DeptDashboardClient } from "./client"
+
+export const dynamic = "force-dynamic"
+
+export default async function DepartmentDashboard({
+  params,
+}: {
+  params: Promise<{ code: string }>
+}) {
+  const { code } = await params
+  // Department codes are stored uppercase; a link or a typed URL may not be.
+  const deptCode = decodeURIComponent(code).toUpperCase()
+
+  const user = await getSessionUser()
+  if (!user) redirect("/login")
+
+  // super_admin sees any department; an HOD only their own. Without this an HOD
+  // could read a peer department's whole roster by editing the URL — the nav
+  // never offers it, which is exactly why the check cannot live in the nav.
+  const allowed =
+    user.tier === "super_admin" || user.deptCodes.includes(deptCode)
+  if (!allowed) redirect("/dashboard/dept")
+
+  const dept = await getDepartment(deptCode)
+  if (!dept) return notFound()
+
+  const [classes, faculty, students, appointments, graduated] =
+    await Promise.all([
+      listClassesForDepts([deptCode]),
+      getFacultyByDepartments([deptCode]),
+      getStudentsByDepartments([deptCode]),
+      listActiveAppointments(),
+      getGraduatedClassKeys(),
+    ])
+  const staff = await listClassStaff(classes.map((c) => c.id))
+  const now = new Date()
+
+  const mine = appointments.filter((a) => a.deptCode === deptCode)
+  const named = (a: (typeof mine)[number]) =>
+    `${a.firstName} ${a.lastName}`.trim()
+
+  // Class membership is derived from class_key, and that key is stored rather
+  // than foreign-keyed — a cohort can have students before anybody creates its
+  // class row. Bucketing by class alone would silently drop them, so the
+  // leftovers are counted explicitly and surfaced.
+  const byKey = new Map<string, typeof students>()
+  for (const s of students) {
+    const key = s.classKey ?? ""
+    const list = byKey.get(key) ?? []
+    list.push(s)
+    byKey.set(key, list)
+  }
+  const knownKeys = new Set(classes.map((c) => c.classKey))
+  const unplaced = students.filter(
+    (s) => !s.classKey || !knownKeys.has(s.classKey)
+  )
+
+  const classRows = classes.map((c) => {
+    const roster = byKey.get(c.classKey) ?? []
+    const mineStaff = staff.filter((s) => s.classId === c.id)
+    const coord = mineStaff.find((s) => s.role === "academic_coordinator")
+    const trs = mineStaff.filter((s) => s.role === "tr")
+    return {
+      id: c.id,
+      classKey: c.classKey,
+      label: `${expectedYear(c.admissionYear, now) ?? c.admissionYear} · ${c.division}`,
+      isActive: c.isActive,
+      graduated: graduated.has(c.classKey),
+      coordinator: coord ? `${coord.firstName} ${coord.lastName}`.trim() : null,
+      trs: trs.map((t) => `${t.firstName} ${t.lastName}`.trim()),
+      students: roster.length,
+      unclaimed: roster.filter((s) => !s.authUserId).length,
+    }
+  })
+
+  // A faculty member's class roles, so the table shows what they actually do
+  // rather than only their tier.
+  const rolesFor = (facultyId: string) => {
+    const held = staff.filter((s) => s.facultyId === facultyId)
+    const out: string[] = []
+    if (held.some((h) => h.role === "academic_coordinator")) out.push("AC")
+    if (held.some((h) => h.role === "tr")) out.push("TR")
+    return out
+  }
+
+  return (
+    <>
+      <PageHeader
+        title={`${dept.code} — ${dept.name}`}
+        parent="Departments"
+        parentHref="/dashboard/dept"
+      />
+      <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
+        <DeptDashboardClient
+          dept={{ code: dept.code, name: dept.name, isActive: dept.isActive }}
+          hod={
+            mine.find((a) => a.appointment === "hod")
+              ? {
+                  name: named(mine.find((a) => a.appointment === "hod")!),
+                  email: mine.find((a) => a.appointment === "hod")!.email,
+                }
+              : null
+          }
+          coordinator={
+            mine.find((a) => a.appointment === "coordinator")
+              ? {
+                  name: named(
+                    mine.find((a) => a.appointment === "coordinator")!
+                  ),
+                  email: mine.find((a) => a.appointment === "coordinator")!
+                    .email,
+                }
+              : null
+          }
+          classes={classRows}
+          faculty={faculty.map((f) => ({
+            id: f.id,
+            name: `${f.firstName} ${f.lastName}`.trim(),
+            email: f.email,
+            tier: f.role,
+            classRoles: rolesFor(f.id),
+            claimed: Boolean(f.authUserId),
+          }))}
+          totals={{
+            students: students.length,
+            unclaimedStudents: students.filter((s) => !s.authUserId).length,
+            unplaced: unplaced.length,
+          }}
+          unplaced={unplaced.slice(0, 200).map((s) => ({
+            id: s.id,
+            rollNumber: s.rollNumber,
+            name: `${s.firstName} ${s.lastName}`.trim(),
+            classKey: s.classKey,
+            year: currentYear(s.rollNumber, s.year, now, s.graduatedAt),
+          }))}
+        />
+      </div>
+    </>
+  )
+}

--- a/src/app/dashboard/dept/client.tsx
+++ b/src/app/dashboard/dept/client.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import Link from "next/link"
+
 import { useState, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
@@ -103,6 +105,12 @@ export function DeptClient({
                 {d.code}
               </Badge>
               <h3 className="text-sm font-medium">{d.name}</h3>
+              <Link
+                href={`/dashboard/dept/${d.code}`}
+                className="text-muted-foreground hover:text-foreground ml-auto text-xs underline"
+              >
+                Department dashboard →
+              </Link>
             </div>
 
             <div className="flex flex-wrap gap-2">

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -94,8 +94,10 @@ const superAdminNav = [
     title: "Departments",
     url: "/dashboard/dept",
     icon: <Building2Icon />,
+    // The per-department dashboard lives at /dashboard/dept/[code]; this list
+    // is the way in, since the nav cannot know the codes without a fetch.
     items: [
-      { title: "Classes", url: "/dashboard/dept" },
+      { title: "All departments", url: "/dashboard/dept" },
       { title: "Course catalogue", url: "/dashboard/dept/courses" },
     ],
   },


### PR DESCRIPTION
## What

A department dashboard at `/dashboard/dept/[code]` — leadership, classes with their coordinator and TR, faculty with the class roles they hold, and the students who belong to none of it. Reached from the department heading on `/dashboard/dept`.

Replaces #71, which was squash-merged into its stacked base branch rather than `main`, so the code never landed. This targets `main` directly and contains only the dashboard commit.

## The edge case that shaped the page

Class membership is derived from `class_key`, and that key is **stored rather than foreign-keyed** — the schema says so explicitly, because a class row may not exist yet. So a cohort can have students before anybody creates its class.

On the live roster that is **79 of 168 students** — the entire `2024-108-A` cohort — appearing on no class list and actionable by no coordinator. A dashboard that bucketed students by class would have displayed **89** and silently lost the other 47%.

They get their own section with the fix stated: create the matching class and they fall into place, because membership is derived rather than stored, so nothing needs re-importing. The figures reconcile:

```
89 placed + 79 unplaced = 168 (roster 168)  BALANCES
```

## Other states named rather than left blank

- **No HOD, or no department coordinator** appointed
- **A class with no coordinator, or no TR** — the partial unique indexes cap these at one, they don't require one
- **A deactivated department**, shown for reference with a note that its records aren't maintained
- **Accounts never signed in** — 167 of 168 students today, an operational fact rather than a rounding error
- **Graduated cohorts**, distinguished from merely inactive classes
- **Cross-department class staffing** — `faculty_class_assignments` has no department check, so a class role is read from the assignment rather than assumed from `faculty.department`

## Authorisation

Checked on the page, not implied by the nav: super_admin may open any department, an HOD only their own. The nav never offers a peer department — which is precisely why the URL has to be defended. The code is upper-cased on the way in, since a typed or copied link may not be.

## Testing

Verified against the live database:

```
dept: EXCS - Electronics & Computer Science  active: true
HOD: Hod VOSS          Dept coordinator: Coordinator
faculty: 4 (3 claimed)   students: 168 (167 unclaimed)
classes: 1 (0 graduated)
   2023-108-A  coord=Coordinator  tr=1  students=89
NOT IN ANY CLASS: 79 of 168
   cohort 2024-108-A: 79 students with no class row
reconciliation: 89 + 79 = 168  BALANCES
```

- [x] `npm run check` passes (0 errors; the 2 warnings are pre-existing on `main`)
- [x] `npm run build` passes — `/dashboard/dept/[code]` compiles
- [x] Diff against `main` is the dashboard only — 4 files, +457/-1
