### PR TITLE
feat(subjects): HOD allocates catalogue subjects to teachers

### DIFF
--- a/src/app/dashboard/class/[classId]/marks/client.tsx
+++ b/src/app/dashboard/class/[classId]/marks/client.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import Link from "next/link"
+
 import { useState, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
@@ -10,11 +12,7 @@ import { cn } from "@/lib/utils"
 import { computeMarks, type CourseInfo } from "@/lib/sgpi"
 import { downloadBase64File } from "@/lib/utils"
 import { exportTableCsv, exportTableXlsx } from "@/lib/xlsx-export"
-import {
-  createSubjectAction,
-  saveMarksAction,
-  setMarksLockAction,
-} from "../../actions"
+import { saveMarksAction, setMarksLockAction } from "../../actions"
 
 type Offering = {
   id: string
@@ -24,7 +22,6 @@ type Offering = {
   facultyId: string | null
   facultyName: string | null
 }
-type Staff = { facultyId: string; name: string; role: string }
 type Row = {
   studentId: string
   name: string
@@ -42,18 +39,6 @@ type Grid = {
   locked: LockComponent[]
 }
 
-// VIT defaults per assessment type: theory carries the MSE component, practical
-// and project are ISA + ESE only.
-type CourseType = "theory" | "practical" | "project"
-const CAP_PRESETS: Record<
-  CourseType,
-  { maxIsa: number; maxMse: number; maxEse: number; maxTotal: number }
-> = {
-  theory: { maxIsa: 20, maxMse: 20, maxEse: 60, maxTotal: 100 },
-  practical: { maxIsa: 40, maxMse: 0, maxEse: 60, maxTotal: 100 },
-  project: { maxIsa: 40, maxMse: 0, maxEse: 60, maxTotal: 100 },
-}
-
 const LOCK_LABEL: Record<LockComponent, string> = {
   isa: "ISA",
   mse: "MSE",
@@ -67,7 +52,6 @@ export function MarksClient({
   grid,
   canUnlock,
   canAllocate,
-  staff,
 }: {
   classId: string
   offerings: Offering[]
@@ -75,7 +59,6 @@ export function MarksClient({
   grid: Grid | null
   canUnlock: boolean
   canAllocate: boolean
-  staff: Staff[]
 }) {
   if (grid && selectedId) {
     const offering = offerings.find((o) => o.id === selectedId)!
@@ -93,7 +76,6 @@ export function MarksClient({
       classId={classId}
       offerings={offerings}
       canAllocate={canAllocate}
-      staff={staff}
     />
   )
 }
@@ -102,50 +84,12 @@ function SubjectSetup({
   classId,
   offerings,
   canAllocate,
-  staff,
 }: {
   classId: string
   offerings: Offering[]
   canAllocate: boolean
-  staff: Staff[]
 }) {
   const router = useRouter()
-  const [pending, start] = useTransition()
-  const [courseCode, setCourseCode] = useState("")
-  const [courseName, setCourseName] = useState("")
-  const [courseType, setCourseType] = useState<CourseType>("theory")
-  const [credits, setCredits] = useState(3)
-  const [semester, setSemester] = useState(1)
-  const [caps, setCaps] = useState(CAP_PRESETS.theory)
-  const [teacher, setTeacher] = useState<string>("")
-
-  function pickType(t: CourseType) {
-    setCourseType(t)
-    setCaps(CAP_PRESETS[t])
-  }
-
-  function add() {
-    start(async () => {
-      const res = await createSubjectAction({
-        classId,
-        courseCode,
-        courseName,
-        courseType,
-        credits,
-        semester,
-        facultyId: teacher || null,
-        ...caps,
-      })
-      if (res.error) {
-        toast.error(res.error)
-        return
-      }
-      toast.success("Subject added")
-      setCourseCode("")
-      setCourseName("")
-      router.refresh()
-    })
-  }
 
   return (
     <div className="grid gap-6 lg:grid-cols-[1fr_360px]">
@@ -202,121 +146,25 @@ function SubjectSetup({
       </div>
 
       <div className="border-border flex flex-col gap-3 rounded border p-4">
-        <h2 className="text-sm font-semibold">Add subject</h2>
+        <h2 className="text-sm font-semibold">Adding subjects</h2>
+        <p className="text-muted-foreground text-sm">
+          Subjects are chosen from the department catalogue and allocated to a
+          teacher on the{" "}
+          <Link
+            href={`/dashboard/class/${classId}/subjects`}
+            className="underline"
+          >
+            Subjects
+          </Link>{" "}
+          page. Defining them there once — rather than typing a code into every
+          class — is what keeps credits and the marks split consistent.
+        </p>
         {!canAllocate && (
           <p className="text-muted-foreground text-xs">
-            Only the class coordinator or the HOD can add a subject. Yours
-            appear in the list once they allocate them to you.
+            Your subjects appear on the left once the coordinator or HOD
+            allocates them to you.
           </p>
         )}
-        <Field label="Course code">
-          <Input
-            value={courseCode}
-            onChange={(e) => setCourseCode(e.target.value.toUpperCase())}
-            placeholder="ITC501"
-            className="h-9 font-mono"
-          />
-        </Field>
-        <Field label="Course name">
-          <Input
-            value={courseName}
-            onChange={(e) => setCourseName(e.target.value)}
-            placeholder="Analog & Digital Communication"
-            className="h-9"
-          />
-        </Field>
-        <Field label="Type">
-          <div className="flex overflow-hidden rounded border">
-            {(["theory", "practical", "project"] as const).map((t) => (
-              <button
-                key={t}
-                type="button"
-                onClick={() => pickType(t)}
-                className={cn(
-                  "flex-1 px-2 py-1.5 text-xs font-medium capitalize transition-colors",
-                  courseType === t
-                    ? "bg-primary text-primary-foreground"
-                    : "text-muted-foreground hover:bg-muted"
-                )}
-              >
-                {t}
-              </button>
-            ))}
-          </div>
-        </Field>
-        <div className="grid grid-cols-2 gap-3">
-          <Field label="Credits">
-            <Input
-              type="number"
-              min={0}
-              value={credits}
-              onChange={(e) => setCredits(Number(e.target.value))}
-              className="h-9"
-            />
-          </Field>
-          <Field label="Semester">
-            <Input
-              type="number"
-              min={1}
-              max={8}
-              value={semester}
-              onChange={(e) => setSemester(Number(e.target.value))}
-              className="h-9"
-            />
-          </Field>
-        </div>
-        <Field label="Taught by">
-          <select
-            value={teacher}
-            onChange={(e) => setTeacher(e.target.value)}
-            className="border-input bg-background h-9 rounded border px-2 text-sm"
-          >
-            {/* Unallocated is a real starting state, not a mistake: the subject
-                exists on the timetable before anyone is put in front of it. */}
-            <option value="">Unallocated</option>
-            {staff.map((t) => (
-              <option key={t.facultyId} value={t.facultyId}>
-                {t.name}
-                {t.role === "academic_coordinator" ? " (coordinator)" : ""}
-              </option>
-            ))}
-          </select>
-        </Field>
-        <div className="grid grid-cols-4 gap-2">
-          {(["maxIsa", "maxMse", "maxEse", "maxTotal"] as const).map((k) => (
-            <Field
-              key={k}
-              label={
-                {
-                  maxIsa: "ISA",
-                  maxMse: "MSE",
-                  maxEse: "ESE",
-                  maxTotal: "Total",
-                }[k]
-              }
-            >
-              <Input
-                type="number"
-                min={0}
-                value={caps[k]}
-                onChange={(e) =>
-                  setCaps((c) => ({ ...c, [k]: Number(e.target.value) }))
-                }
-                className="h-9"
-              />
-            </Field>
-          ))}
-        </div>
-        <Button
-          size="sm"
-          className="mt-1"
-          disabled={
-            pending || !canAllocate || !courseCode.trim() || !courseName.trim()
-          }
-          onClick={add}
-        >
-          {pending ? "Adding…" : "Add subject"}
-        </Button>
       </div>
     </div>
   )
@@ -677,21 +525,6 @@ function LockPanel({
           Ask the class coordinator to reopen a locked component.
         </span>
       )}
-    </div>
-  )
-}
-
-function Field({
-  label,
-  children,
-}: {
-  label: string
-  children: React.ReactNode
-}) {
-  return (
-    <div className="grid gap-1.5">
-      <label className="text-muted-foreground text-xs">{label}</label>
-      {children}
     </div>
   )
 }

--- a/src/app/dashboard/class/[classId]/marks/page.tsx
+++ b/src/app/dashboard/class/[classId]/marks/page.tsx
@@ -4,7 +4,6 @@ import { getSessionUser } from "@/lib/session"
 import { can } from "@/lib/rbac"
 import { expectedYear } from "@/lib/roll-number"
 import { getClassById } from "@/db/queries/classes"
-import { listClassStaff } from "@/db/queries/class-staff"
 import { getStudentsByClassKeys } from "@/db/queries/students"
 import { listOfferingsForClass, getOfferingById } from "@/db/queries/offerings"
 import { getMarksForOffering, getLockedComponents } from "@/db/queries/marks"
@@ -41,12 +40,9 @@ export default async function MarksPage({
     (user.tier === "hod" && user.deptCodes.includes(cls.departmentCode)) ||
     user.coordinatorClassIds.includes(classId)
 
-  const [offerings, staff] = await Promise.all([
-    canAllocate
-      ? listOfferingsForClass(classId)
-      : listOfferingsForClass(classId, user.facultyId ?? undefined),
-    listClassStaff([classId]),
-  ])
+  const offerings = canAllocate
+    ? await listOfferingsForClass(classId)
+    : await listOfferingsForClass(classId, user.facultyId ?? undefined)
   const yr = expectedYear(cls.admissionYear, new Date()) ?? cls.admissionYear
   const label = `${yr} · ${cls.departmentCode} · ${cls.division}`
 
@@ -103,11 +99,6 @@ export default async function MarksPage({
             user.coordinatorClassIds.includes(classId)
           }
           canAllocate={canAllocate}
-          staff={staff.map((s) => ({
-            facultyId: s.facultyId,
-            name: `${s.firstName} ${s.lastName}`.trim(),
-            role: s.role,
-          }))}
           offerings={offerings.map((o) => ({
             id: o.id,
             code: o.course.courseCode,

--- a/src/app/dashboard/class/[classId]/page.tsx
+++ b/src/app/dashboard/class/[classId]/page.tsx
@@ -5,6 +5,7 @@ import {
   GraduationCapIcon,
   BarChart3Icon,
   UsersIcon,
+  BookOpenIcon,
 } from "lucide-react"
 import { PageHeader } from "@/components/page-header"
 import { buttonVariants } from "@/components/ui/button"
@@ -63,6 +64,13 @@ export default async function ClassDetailPage({
             >
               <CalendarCheckIcon className="mr-1.5 size-3.5" />
               Take attendance
+            </Link>
+            <Link
+              href={`/dashboard/class/${classId}/subjects`}
+              className={buttonVariants({ variant: "outline", size: "sm" })}
+            >
+              <BookOpenIcon className="mr-1.5 size-3.5" />
+              Subjects
             </Link>
             <Link
               href={`/dashboard/class/${classId}/marks`}

--- a/src/app/dashboard/class/[classId]/subjects/client.tsx
+++ b/src/app/dashboard/class/[classId]/subjects/client.tsx
@@ -1,0 +1,285 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import Link from "next/link"
+import { toast } from "sonner"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { createSubjectAction, assignOfferingFacultyAction } from "../../actions"
+
+type Offering = {
+  id: string
+  code: string
+  name: string
+  semester: number
+  credits: number
+  marks: string
+  facultyId: string | null
+}
+type Staff = { facultyId: string; name: string; role: string }
+type CatalogueCourse = {
+  code: string
+  name: string
+  type: string
+  credits: number
+  year: string | null
+  maxIsa: number
+  maxMse: number
+  maxEse: number
+  maxTotal: number
+}
+
+const UNALLOCATED = "__none__"
+
+export function SubjectsClient({
+  classId,
+  canAllocate,
+  classYear,
+  offerings,
+  staff,
+  catalogue,
+}: {
+  classId: string
+  canAllocate: boolean
+  classYear: string | null
+  offerings: Offering[]
+  staff: Staff[]
+  catalogue: CatalogueCourse[]
+}) {
+  const router = useRouter()
+  const [pending, start] = useTransition()
+  const [query, setQuery] = useState("")
+  const [semester, setSemester] = useState(1)
+
+  function allocate(offeringId: string, facultyId: string) {
+    start(async () => {
+      const res = await assignOfferingFacultyAction({
+        offeringId,
+        facultyId: facultyId === UNALLOCATED ? null : facultyId,
+      })
+      if (res.error) return void toast.error(res.error)
+      toast.success(
+        facultyId === UNALLOCATED ? "Subject unallocated" : "Subject allocated"
+      )
+      router.refresh()
+    })
+  }
+
+  function addFromCatalogue(c: CatalogueCourse) {
+    start(async () => {
+      const res = await createSubjectAction({
+        classId,
+        courseCode: c.code,
+        courseName: c.name,
+        courseType: c.type as "theory" | "practical" | "project",
+        credits: c.credits,
+        maxIsa: c.maxIsa,
+        maxMse: c.maxMse,
+        maxEse: c.maxEse,
+        maxTotal: c.maxTotal,
+        semester,
+        facultyId: null,
+      })
+      if (res.error) return void toast.error(res.error)
+      toast.success(`${c.code} added — allocate it to a teacher`)
+      router.refresh()
+    })
+  }
+
+  const q = query.trim().toLowerCase()
+  // The class's own year first: a BE class is almost never given an FE subject,
+  // but the rest stay reachable rather than hidden, because repeats happen.
+  const shortlist = catalogue
+    .filter((c) => !q || `${c.code} ${c.name}`.toLowerCase().includes(q))
+    .sort((a, b) => {
+      const am = a.year === classYear ? 0 : 1
+      const bm = b.year === classYear ? 0 : 1
+      return am - bm || a.code.localeCompare(b.code)
+    })
+
+  const unallocated = offerings.filter((o) => !o.facultyId).length
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1fr_380px]">
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold">
+            Subjects on this class ({offerings.length})
+          </h2>
+          {unallocated > 0 && (
+            <span className="text-destructive text-xs">
+              {unallocated} not allocated
+            </span>
+          )}
+        </div>
+
+        {offerings.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            No subjects yet.{" "}
+            {canAllocate
+              ? "Add one from the catalogue on the right."
+              : "The class coordinator or HOD adds them."}
+          </p>
+        ) : (
+          <div className="border-border overflow-x-auto rounded border">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 text-muted-foreground text-xs">
+                <tr className="[&>th]:px-3 [&>th]:py-2 [&>th]:text-left [&>th]:font-medium">
+                  <th className="w-24">Code</th>
+                  <th>Subject</th>
+                  <th className="w-14">Sem</th>
+                  <th className="w-14">Cr</th>
+                  <th className="w-28">ISA/MSE/ESE</th>
+                  <th className="w-56">Teacher</th>
+                </tr>
+              </thead>
+              <tbody className="divide-border divide-y">
+                {offerings.map((o) => (
+                  <tr key={o.id} className="[&>td]:px-3 [&>td]:py-2">
+                    <td className="font-mono text-xs">{o.code}</td>
+                    <td>{o.name}</td>
+                    <td className="tabular-nums">{o.semester}</td>
+                    <td className="tabular-nums">{o.credits}</td>
+                    <td className="text-muted-foreground text-xs tabular-nums">
+                      {o.marks}
+                    </td>
+                    <td>
+                      {canAllocate ? (
+                        <select
+                          value={o.facultyId ?? UNALLOCATED}
+                          disabled={pending}
+                          onChange={(e) => allocate(o.id, e.target.value)}
+                          className="border-input bg-background h-8 w-full rounded border px-2 text-sm"
+                        >
+                          <option value={UNALLOCATED}>Unallocated</option>
+                          {staff.map((s) => (
+                            <option key={s.facultyId} value={s.facultyId}>
+                              {s.name}
+                              {s.role === "academic_coordinator" ? " (AC)" : ""}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <span className="text-sm">
+                          {staff.find((s) => s.facultyId === o.facultyId)
+                            ?.name ?? (
+                            <span className="text-destructive text-xs">
+                              Unallocated
+                            </span>
+                          )}
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {offerings.length > 0 && (
+          <p className="text-muted-foreground text-xs">
+            A teacher enters marks for the subjects allocated to them, from{" "}
+            <Link
+              href={`/dashboard/class/${classId}/marks`}
+              className="underline"
+            >
+              Enter marks
+            </Link>
+            . Coordinators and the HOD can write any of them, so an absence is
+            coverable.
+          </p>
+        )}
+      </div>
+
+      {canAllocate && (
+        <div className="border-border flex flex-col gap-3 rounded border p-4">
+          <h2 className="text-sm font-semibold">Add from catalogue</h2>
+          {catalogue.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              Every catalogued subject for this department is already on the
+              class. Import a syllabus or add a course to the{" "}
+              <Link href="/dashboard/dept/courses" className="underline">
+                catalogue
+              </Link>{" "}
+              first.
+            </p>
+          ) : (
+            <>
+              <div className="flex items-end gap-2">
+                <div className="grid flex-1 gap-1.5">
+                  <label className="text-muted-foreground text-xs">
+                    Search
+                  </label>
+                  <Input
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder="Code or name…"
+                    className="h-9"
+                  />
+                </div>
+                <div className="grid w-20 gap-1.5">
+                  <label className="text-muted-foreground text-xs">Sem</label>
+                  <Input
+                    type="number"
+                    min={1}
+                    max={8}
+                    value={semester}
+                    onChange={(e) => setSemester(Number(e.target.value))}
+                    className="h-9"
+                  />
+                </div>
+              </div>
+
+              <div className="border-border divide-border max-h-[28rem] divide-y overflow-y-auto rounded border">
+                {shortlist.map((c) => (
+                  <div
+                    key={c.code}
+                    className="flex items-center justify-between gap-3 px-3 py-2"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <Badge variant="outline" className="font-mono text-xs">
+                          {c.code}
+                        </Badge>
+                        {c.year && (
+                          <span className="text-muted-foreground text-xs">
+                            {c.year}
+                          </span>
+                        )}
+                      </div>
+                      <p className="truncate text-sm">{c.name}</p>
+                      <p className="text-muted-foreground text-xs">
+                        {c.type} · {c.credits} cr · {c.maxIsa}/{c.maxMse}/
+                        {c.maxEse}
+                      </p>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={pending}
+                      onClick={() => addFromCatalogue(c)}
+                    >
+                      Add
+                    </Button>
+                  </div>
+                ))}
+                {shortlist.length === 0 && (
+                  <p className="text-muted-foreground px-3 py-2 text-sm">
+                    Nothing matches that search.
+                  </p>
+                )}
+              </div>
+              <p className="text-muted-foreground text-xs">
+                Credits and the marks split come from the catalogue, so a
+                subject is defined once and taught many times.
+              </p>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/dashboard/class/[classId]/subjects/page.tsx
+++ b/src/app/dashboard/class/[classId]/subjects/page.tsx
@@ -1,0 +1,89 @@
+import { notFound, redirect } from "next/navigation"
+import { PageHeader } from "@/components/page-header"
+import { getSessionUser } from "@/lib/session"
+import { can } from "@/lib/rbac"
+import { expectedYear } from "@/lib/roll-number"
+import { getClassById } from "@/db/queries/classes"
+import { listClassStaff } from "@/db/queries/class-staff"
+import { listOfferingsForClass } from "@/db/queries/offerings"
+import { listCoursesForDepts } from "@/db/queries/courses"
+import { SubjectsClient } from "./client"
+
+export const dynamic = "force-dynamic"
+
+export default async function SubjectsPage({
+  params,
+}: {
+  params: Promise<{ classId: string }>
+}) {
+  const { classId } = await params
+  const user = await getSessionUser()
+  if (!user) redirect("/login")
+  // offering:read, not marks:read — an HOD allocates subjects without ever
+  // entering a mark, and the marks pages are gated on marks:write.
+  if (!can(user, "offering:read")) redirect("/dashboard")
+
+  const cls = await getClassById(classId)
+  if (!cls) return notFound()
+
+  const canAllocate =
+    user.tier === "super_admin" ||
+    (user.tier === "hod" && user.deptCodes.includes(cls.departmentCode)) ||
+    user.coordinatorClassIds.includes(classId)
+  const inScope = canAllocate || user.classIds.includes(classId)
+  if (!inScope) redirect("/dashboard/class")
+
+  const yr = expectedYear(cls.admissionYear, new Date())
+  const [offerings, staff, catalogue] = await Promise.all([
+    listOfferingsForClass(classId),
+    listClassStaff([classId]),
+    listCoursesForDepts([cls.departmentCode]),
+  ])
+
+  const taken = new Set(offerings.map((o) => o.course.courseCode))
+  return (
+    <>
+      <PageHeader
+        title={`Subjects — ${yr ?? cls.admissionYear} · ${cls.departmentCode} · ${cls.division}`}
+        parent="My classes"
+        parentHref={`/dashboard/class/${classId}`}
+      />
+      <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
+        <SubjectsClient
+          classId={classId}
+          canAllocate={canAllocate}
+          classYear={yr ?? null}
+          offerings={offerings.map((o) => ({
+            id: o.id,
+            code: o.course.courseCode,
+            name: o.course.courseName,
+            semester: o.semester,
+            credits: o.course.credits,
+            marks: `${o.course.maxIsa}/${o.course.maxMse}/${o.course.maxEse}`,
+            facultyId: o.faculty?.id ?? null,
+          }))}
+          staff={staff.map((s) => ({
+            facultyId: s.facultyId,
+            name: `${s.firstName} ${s.lastName}`.trim(),
+            role: s.role,
+          }))}
+          // Only what this class could still be given: its own department's
+          // catalogue, minus what it already has.
+          catalogue={catalogue
+            .filter((c) => c.isActive && !taken.has(c.courseCode))
+            .map((c) => ({
+              code: c.courseCode,
+              name: c.courseName,
+              type: c.courseType,
+              credits: c.credits,
+              year: c.year,
+              maxIsa: c.maxIsa,
+              maxMse: c.maxMse,
+              maxEse: c.maxEse,
+              maxTotal: c.maxTotal,
+            }))}
+        />
+      </div>
+    </>
+  )
+}

--- a/src/app/dashboard/class/actions.ts
+++ b/src/app/dashboard/class/actions.ts
@@ -244,7 +244,10 @@ export async function createSubjectAction(input: {
 }): Promise<Result> {
   try {
     const user = await getSessionUser()
-    authorize(user, "marks:write")
+    // offering:create, not marks:write. An HOD allocates subjects and never
+    // enters marks, so gating this on marks:write shut out the one role the
+    // scope check below was written to admit.
+    authorize(user, "offering:create")
     const { ok, cls } = await classInScope(user!, input.classId)
     if (!ok || !cls) return { error: "That class is not in your scope." }
     if (!canAllocate(user!, input.classId, cls.departmentCode)) {
@@ -533,7 +536,7 @@ export async function assignOfferingFacultyAction(input: {
 }): Promise<Result> {
   try {
     const user = await getSessionUser()
-    authorize(user, "marks:write")
+    authorize(user, "offering:update")
     const offering = await getOfferingById(input.offeringId)
     if (!offering) return { error: "No such subject." }
     const { ok, cls } = await classInScope(user!, offering.classId)

--- a/src/app/dashboard/dept/[code]/client.tsx
+++ b/src/app/dashboard/dept/[code]/client.tsx
@@ -93,7 +93,7 @@ export function DeptDashboardClient({
           <Empty>No classes yet in this department.</Empty>
         ) : (
           <Table
-            head={["Class", "Coordinator", "TR", "Students", "Status"]}
+            head={["Class", "Coordinator", "TR", "Students", "Status", ""]}
             rows={classes.map((c) => [
               <Link
                 key="k"


### PR DESCRIPTION
## What

A Subjects page at `/dashboard/class/[classId]/subjects` where an HOD or coordinator picks a course **from the catalogue** and allocates it to a TR. The TR then enters marks only for what they were given.

## Why — two holes left by #70

**The HOD could not reach the allocation UI.** It lived on the marks page, which gates on `marks:write` — a capability the HOD tier deliberately lacks, because an HOD allocates subjects and never enters marks. The one role `canAllocate` was written to admit couldn't open the page at all.

**`assignOfferingFacultyAction` had no UI.** Written in #70, wired to nothing.

**And the catalogue wasn't joined to the classes.** "Add subject" still asked for a course code and name as free text. After importing 35 BE courses, a coordinator would retype `EC34T` and "Big Data Analytics" by hand — the exact duplication the catalogue exists to end.

## How

`createSubjectAction` and `assignOfferingFacultyAction` move from `marks:write` to `offering:create` / `offering:update`, which is what they always were. The page gates on `offering:read` plus the same coordinator/HOD/super_admin scope.

The picker offers the class's own department, **sorted so the class's year comes first without hiding the rest** — a BE class rarely takes an FE subject, but repeats happen. Credits and the marks split come from the catalogue, so a subject is defined once and taught many times.

The marks page's own add form is **removed** and points here instead. Two ways to create a subject is one too many; they would drift.

## Testing

Full chain against the live database:

```
class=2023-108-A  course=EC33P "Data Analytics & Visualization Lab"  tr=Harshal
1. added from catalogue -> 1 offering, faculty = Unallocated
2. allocated            -> TR now sees 1 subject: EC33P
3. marks entered        -> 3 students
4. locked components    -> [ 'isa' ]
before/after counts identical — probe removed
```

- [x] `npm run check` passes — typecheck, lint (0 errors; 2 pre-existing warnings), format, **63 tests**
- [x] `npm run build` passes — `/dashboard/class/[classId]/subjects` compiles
