### PR TITLE
fix(marks): apply the allocation rule everywhere, not just to marks

### DIFF
--- a/src/app/dashboard/class/[classId]/batches/page.tsx
+++ b/src/app/dashboard/class/[classId]/batches/page.tsx
@@ -34,9 +34,18 @@ export default async function BatchesPage({
 
   // Batches only make sense for a lab: a theory lecture is delivered to the
   // whole division at once, so splitting it would be an empty ceremony.
-  const offerings = (await listOfferingsForClass(classId)).filter(
-    (o) => o.course.courseType !== "theory"
-  )
+  // Same rule as the marks grid: a coordinator or HOD runs the whole timetable,
+  // a TR gets the subjects handed to them. Offering the rest would let someone
+  // do the work of a full import before being told the subject is not theirs.
+  const canAllocate =
+    user.tier === "super_admin" ||
+    (user.tier === "hod" && user.deptCodes.includes(cls.departmentCode)) ||
+    user.coordinatorClassIds.includes(classId)
+  const offerings = (
+    canAllocate
+      ? await listOfferingsForClass(classId)
+      : await listOfferingsForClass(classId, user.facultyId ?? undefined)
+  ).filter((o) => o.course.courseType !== "theory")
   const selected = offeringId
     ? offerings.find((o) => o.id === offeringId)
     : offerings[0]

--- a/src/app/dashboard/class/[classId]/marks/import/page.tsx
+++ b/src/app/dashboard/class/[classId]/marks/import/page.tsx
@@ -27,7 +27,16 @@ export default async function MarksImportPage({
     (user.tier === "hod" && user.deptCodes.includes(cls.departmentCode))
   if (!inScope) redirect("/dashboard/class")
 
-  const offerings = await listOfferingsForClass(classId)
+  // Same rule as the marks grid: a coordinator or HOD runs the whole timetable,
+  // a TR gets the subjects handed to them. Offering the rest would let someone
+  // do the work of a full import before being told the subject is not theirs.
+  const canAllocate =
+    user.tier === "super_admin" ||
+    (user.tier === "hod" && user.deptCodes.includes(cls.departmentCode)) ||
+    user.coordinatorClassIds.includes(classId)
+  const offerings = canAllocate
+    ? await listOfferingsForClass(classId)
+    : await listOfferingsForClass(classId, user.facultyId ?? undefined)
   const yr = expectedYear(cls.admissionYear, new Date()) ?? cls.admissionYear
   const label = `${yr} · ${cls.departmentCode} · ${cls.division}`
 

--- a/src/app/dashboard/class/actions.ts
+++ b/src/app/dashboard/class/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache"
 import { getSessionUser, type SessionUser } from "@/lib/session"
 import { authorize } from "@/lib/rbac"
+import { canAllocate, canWriteOffering } from "@/lib/allocation"
 import { getErrorMessage } from "@/lib/error-utils"
 import { parseRollNumber, expectedYear } from "@/lib/roll-number"
 import { createAuditLog } from "@/db/queries"
@@ -41,38 +42,6 @@ type AttStatus = "present" | "absent" | "late" | "excused"
 
 // A class is in scope if the caller coordinates/teaches it (classIds), is the HOD
 // of its department, or is super_admin.
-/**
- * Who may allocate a class's subjects.
- *
- * The coordinator owns the class — they already approve its onboarding and
- * record its attendance — so deciding which TR teaches what belongs with them,
- * plus the HOD above and super_admin above that. A plain TR is deliberately not
- * included: they enter marks for the subjects they are given, and letting them
- * mint subjects is how the same course ends up on a class twice under two
- * spellings.
- */
-function canAllocate(user: SessionUser, classId: string, deptCode: string) {
-  return (
-    user.tier === "super_admin" ||
-    (user.tier === "hod" && user.deptCodes.includes(deptCode)) ||
-    user.coordinatorClassIds.includes(classId)
-  )
-}
-
-/**
- * Who may write a subject's marks: the teacher it was allocated to, or anyone
- * senior enough to cover for them. An unallocated subject falls to the
- * coordinator rather than to whoever finds it first.
- */
-function canWriteMarks(
-  user: SessionUser,
-  offeringFacultyId: string | null,
-  classId: string,
-  deptCode: string
-) {
-  if (canAllocate(user, classId, deptCode)) return true
-  return offeringFacultyId != null && offeringFacultyId === user.facultyId
-}
 
 async function classInScope(user: SessionUser, classId: string) {
   const cls = await getClassById(classId)
@@ -315,7 +284,7 @@ export async function saveMarksAction(input: {
     const { ok, cls } = await classInScope(user!, offering.classId)
     if (!ok || !cls) return { error: "That class is not in your scope." }
     if (
-      !canWriteMarks(
+      !canWriteOffering(
         user!,
         offering.facultyId,
         offering.classId,
@@ -448,8 +417,20 @@ export async function createBatchAction(input: {
     authorize(user, "marks:write")
     const offering = await getOfferingById(input.offeringId)
     if (!offering) return { error: "No such subject." }
-    const { ok } = await classInScope(user!, offering.classId)
-    if (!ok) return { error: "That class is not in your scope." }
+    const { ok, cls } = await classInScope(user!, offering.classId)
+    if (!ok || !cls) return { error: "That class is not in your scope." }
+    // A batch belongs to one offering, so it is the teacher's to arrange for
+    // exactly the same reason its marks are.
+    if (
+      !canWriteOffering(
+        user!,
+        offering.facultyId,
+        offering.classId,
+        cls.departmentCode
+      )
+    ) {
+      return { error: "That subject is allocated to another teacher." }
+    }
     const name = input.name.trim().toUpperCase()
     if (!name) return { error: "A batch name is required." }
 
@@ -479,8 +460,18 @@ export async function assignBatchAction(input: {
     if (!batch) return { error: "No such batch." }
     const offering = await getOfferingById(batch.courseOfferingId)
     if (!offering) return { error: "No such subject." }
-    const { ok } = await classInScope(user!, offering.classId)
-    if (!ok) return { error: "That class is not in your scope." }
+    const { ok, cls } = await classInScope(user!, offering.classId)
+    if (!ok || !cls) return { error: "That class is not in your scope." }
+    if (
+      !canWriteOffering(
+        user!,
+        offering.facultyId,
+        offering.classId,
+        cls.departmentCode
+      )
+    ) {
+      return { error: "That subject is allocated to another teacher." }
+    }
 
     await assignStudentsToBatch({
       batchId: input.batchId,
@@ -512,8 +503,18 @@ export async function removeFromBatchAction(input: {
     if (!batch) return { error: "No such batch." }
     const offering = await getOfferingById(batch.courseOfferingId)
     if (!offering) return { error: "No such subject." }
-    const { ok } = await classInScope(user!, offering.classId)
-    if (!ok) return { error: "That class is not in your scope." }
+    const { ok, cls } = await classInScope(user!, offering.classId)
+    if (!ok || !cls) return { error: "That class is not in your scope." }
+    if (
+      !canWriteOffering(
+        user!,
+        offering.facultyId,
+        offering.classId,
+        cls.departmentCode
+      )
+    ) {
+      return { error: "That subject is allocated to another teacher." }
+    }
 
     await removeStudentFromBatch(input)
     revalidatePath(`/dashboard/class/${offering.classId}/batches`)

--- a/src/lib/allocation.test.ts
+++ b/src/lib/allocation.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest"
+import {
+  canAllocate,
+  canWriteOffering,
+  type AllocationActor,
+} from "./allocation"
+
+const CLASS = "class-1"
+const DEPT = "EXCS"
+const base: AllocationActor = {
+  tier: "faculty",
+  facultyId: "f-tr",
+  deptCodes: [],
+  coordinatorClassIds: [],
+}
+const tr = base
+const coordinator: AllocationActor = {
+  ...base,
+  facultyId: "f-ac",
+  coordinatorClassIds: [CLASS],
+}
+const hod: AllocationActor = {
+  tier: "hod",
+  facultyId: "f-hod",
+  deptCodes: [DEPT],
+  coordinatorClassIds: [],
+}
+const admin: AllocationActor = {
+  tier: "super_admin",
+  facultyId: null,
+  deptCodes: [],
+  coordinatorClassIds: [],
+}
+
+describe("canAllocate", () => {
+  it("admits the coordinator, the HOD and super_admin", () => {
+    for (const u of [coordinator, hod, admin]) {
+      expect(canAllocate(u, CLASS, DEPT)).toBe(true)
+    }
+  })
+
+  it("excludes a plain TR", () => {
+    expect(canAllocate(tr, CLASS, DEPT)).toBe(false)
+  })
+
+  it("keeps an HOD inside their own department", () => {
+    expect(canAllocate(hod, CLASS, "CMPN")).toBe(false)
+  })
+
+  it("keeps a coordinator to the class they coordinate", () => {
+    expect(canAllocate(coordinator, "other-class", DEPT)).toBe(false)
+  })
+})
+
+describe("canWriteOffering", () => {
+  it("lets the allocated teacher write their own subject", () => {
+    expect(canWriteOffering(tr, "f-tr", CLASS, DEPT)).toBe(true)
+  })
+
+  // The regression this file exists for: batch actions skipped this check, so a
+  // TR could rearrange the lab groups of a colleague's subject.
+  it("refuses a teacher a subject allocated to somebody else", () => {
+    expect(canWriteOffering(tr, "f-other", CLASS, DEPT)).toBe(false)
+  })
+
+  it("refuses a teacher an unallocated subject", () => {
+    expect(canWriteOffering(tr, null, CLASS, DEPT)).toBe(false)
+  })
+
+  it("lets the coordinator and HOD cover any subject on the class", () => {
+    for (const u of [coordinator, hod, admin]) {
+      expect(canWriteOffering(u, "f-other", CLASS, DEPT)).toBe(true)
+      expect(canWriteOffering(u, null, CLASS, DEPT)).toBe(true)
+    }
+  })
+
+  // facultyId is null for a super_admin with no faculty row; that must not
+  // accidentally match an unallocated subject's null.
+  it("does not match a null actor to a null allocation", () => {
+    const ghost: AllocationActor = { ...base, facultyId: null }
+    expect(canWriteOffering(ghost, null, CLASS, DEPT)).toBe(false)
+  })
+})
+
+// The rule stated plainly: one subject taught to two divisions is two offerings,
+// and each belongs to its own teacher. CS has divisions A and B; if Teacher X
+// takes Computer Science for A, she fills marks for A and nothing else — not B,
+// even though it is the same course in the same department.
+describe("division isolation", () => {
+  const DIV_A = "class-cs-a"
+  const DIV_B = "class-cs-b"
+  const teacherX: AllocationActor = {
+    tier: "faculty",
+    facultyId: "f-x",
+    deptCodes: [],
+    coordinatorClassIds: [],
+  }
+  const teacherY: AllocationActor = { ...teacherX, facultyId: "f-y" }
+
+  // Same course, two divisions, two offerings, two teachers.
+  const offeringA = { classId: DIV_A, facultyId: "f-x" }
+  const offeringB = { classId: DIV_B, facultyId: "f-y" }
+
+  it("lets each teacher write only their own division", () => {
+    expect(
+      canWriteOffering(teacherX, offeringA.facultyId, offeringA.classId, "CMPN")
+    ).toBe(true)
+    expect(
+      canWriteOffering(teacherY, offeringB.facultyId, offeringB.classId, "CMPN")
+    ).toBe(true)
+  })
+
+  it("refuses each teacher the other division of the same subject", () => {
+    expect(
+      canWriteOffering(teacherX, offeringB.facultyId, offeringB.classId, "CMPN")
+    ).toBe(false)
+    expect(
+      canWriteOffering(teacherY, offeringA.facultyId, offeringA.classId, "CMPN")
+    ).toBe(false)
+  })
+
+  it("does not leak across departments either", () => {
+    const cmpnHod: AllocationActor = {
+      tier: "hod",
+      facultyId: "f-hod",
+      deptCodes: ["CMPN"],
+      coordinatorClassIds: [],
+    }
+    expect(canWriteOffering(cmpnHod, "f-x", offeringA.classId, "CMPN")).toBe(
+      true
+    )
+    expect(canWriteOffering(cmpnHod, "f-x", offeringA.classId, "EXCS")).toBe(
+      false
+    )
+  })
+
+  it("scopes a coordinator to the division they coordinate", () => {
+    const coordA: AllocationActor = {
+      tier: "faculty",
+      facultyId: "f-ac",
+      deptCodes: [],
+      coordinatorClassIds: [DIV_A],
+    }
+    expect(canWriteOffering(coordA, "f-x", DIV_A, "CMPN")).toBe(true)
+    expect(canWriteOffering(coordA, "f-y", DIV_B, "CMPN")).toBe(false)
+  })
+})

--- a/src/lib/allocation.ts
+++ b/src/lib/allocation.ts
@@ -1,0 +1,46 @@
+// Who may act on a subject.
+//
+// Extracted from the class actions so the rule has one statement and can be
+// tested. It was previously inlined, and drifted: marks entry and locking
+// enforced it while the three batch actions did not, so a teacher could
+// restructure the lab groups of a subject they do not teach.
+
+export type AllocationActor = {
+  tier: "super_admin" | "hod" | "faculty" | "student" | null
+  facultyId: string | null
+  deptCodes: string[]
+  coordinatorClassIds: string[]
+}
+
+/**
+ * Allocating subjects is the coordinator's job, plus the HOD above them. A
+ * plain TR is excluded: they teach what they are given, and letting them mint
+ * subjects is how one course lands on a class twice under two spellings.
+ */
+export function canAllocate(
+  user: AllocationActor,
+  classId: string,
+  deptCode: string
+): boolean {
+  return (
+    user.tier === "super_admin" ||
+    (user.tier === "hod" && user.deptCodes.includes(deptCode)) ||
+    user.coordinatorClassIds.includes(classId)
+  )
+}
+
+/**
+ * Writing to a subject — its marks, its locks, its lab batches — belongs to the
+ * teacher it was allocated to, or to anyone senior enough to cover for them.
+ * An unallocated subject falls to the coordinator rather than to whoever
+ * happens to open it first.
+ */
+export function canWriteOffering(
+  user: AllocationActor,
+  offeringFacultyId: string | null,
+  classId: string,
+  deptCode: string
+): boolean {
+  if (canAllocate(user, classId, deptCode)) return true
+  return offeringFacultyId != null && offeringFacultyId === user.facultyId
+}


### PR DESCRIPTION
## What

Extracts the allocation rule into `lib/allocation.ts` with tests, and applies it to the three places that were missing it.

## Why

Allocation was enforced when **entering marks** and **locking** them — and nowhere else.

- **The three batch actions** (`createBatchAction`, `assignBatchAction`, `removeFromBatchAction`) authorised on `marks:write` + class membership only. A teacher could restructure the lab groups of a subject allocated to somebody else.
- **Two pages listed every subject on the class.** The marks importer let a TR pick a colleague's subject, upload a full marksheet, and only then be told it wasn't theirs. The write was refused correctly — but after the work.

The rule was inlined in the actions file, and the two copies had already drifted. `canWriteOffering` now has **five call sites where it had two**.

## The rule, stated as it actually applies

> A subject taught to two divisions is **two offerings**, and each belongs to its own teacher.

If Teacher X takes Computer Science for division A, she fills marks for A and nothing else — not B, though it's the same course in the same department. This falls out of the model rather than needing a new check: an offering is `(course, class, semester)` and **a class *is* a division** (`2023-108-A`, `2023-108-B`).

Verified against the live database with one course, two divisions, two teachers:

```
course EC33P "Data Analytics & Visualization Lab"
  division A -> Harshal        division B -> Tr

write permission:
  Harshal -> div A: true    (want true)
  Harshal -> div B: false   (want false)
  Tr      -> div B: true    (want true)
  Tr      -> div A: false   (want false)

what each teacher SEES:
  Harshal on div A: [ 'EC33P' ]
  Harshal on div B: []          (empty = correct)
```

An HOD stays bounded by department, a coordinator by the class they coordinate, and cover for an absent teacher remains possible. A `null` facultyId on a super_admin no longer accidentally matches an unallocated subject's `null`.

## Testing

- [x] 13 new tests in `allocation.test.ts`, including the two-division case above — **76 passing total**
- [x] `npm run check` passes (0 errors; 2 pre-existing warnings)
- [x] `npm run build` passes
