### PR TITLE
feat(dept): assign a subject to a teacher from the department dashboard

### DIFF
--- a/src/app/dashboard/dept/[code]/client.tsx
+++ b/src/app/dashboard/dept/[code]/client.tsx
@@ -1,6 +1,19 @@
 "use client"
 
+import { useState, useTransition } from "react"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { assignSubjectToTeacherAction } from "../actions"
 import { Badge } from "@/components/ui/badge"
 
 type Person = { name: string; email: string }
@@ -24,7 +37,13 @@ type FacultyRow = {
   claimed: boolean
 }
 
+type Course = { id: string; code: string; name: string; year: string | null }
+type ClassOption = { id: string; label: string }
+
 export function DeptDashboardClient({
+  canAssign,
+  courses,
+  classOptions,
   dept,
   hod,
   coordinator,
@@ -33,6 +52,9 @@ export function DeptDashboardClient({
   totals,
   unplaced,
 }: {
+  canAssign: boolean
+  courses: Course[]
+  classOptions: ClassOption[]
   dept: { code: string; name: string; isActive: boolean }
   hod: Person | null
   coordinator: Person | null
@@ -47,6 +69,7 @@ export function DeptDashboardClient({
     year: string
   }[]
 }) {
+  const [assigning, setAssigning] = useState<FacultyRow | null>(null)
   const placed = totals.students - totals.unplaced
   return (
     <div className="flex flex-col gap-6">
@@ -139,7 +162,14 @@ export function DeptDashboardClient({
           <Empty>No faculty on record for this department.</Empty>
         ) : (
           <Table
-            head={["Name", "Email", "Tier", "Class role", "Account"]}
+            head={[
+              "Name",
+              "Email",
+              "Tier",
+              "Class role",
+              "Account",
+              ...(canAssign ? [""] : []),
+            ]}
             rows={faculty.map((f) => [
               f.name,
               <span key="e" className="text-muted-foreground text-xs">
@@ -164,6 +194,15 @@ export function DeptDashboardClient({
           />
         )}
       </Section>
+
+      {assigning && (
+        <AssignSubjectDialog
+          teacher={assigning}
+          courses={courses}
+          classOptions={classOptions}
+          onClose={() => setAssigning(null)}
+        />
+      )}
 
       {totals.unplaced > 0 && (
         <Section title={`Not in any class (${totals.unplaced})`}>
@@ -289,5 +328,146 @@ function Table({ head, rows }: { head: string[]; rows: React.ReactNode[][] }) {
         </tbody>
       </table>
     </div>
+  )
+}
+
+function AssignSubjectDialog({
+  teacher,
+  courses,
+  classOptions,
+  onClose,
+}: {
+  teacher: FacultyRow
+  courses: Course[]
+  classOptions: ClassOption[]
+  onClose: () => void
+}) {
+  const router = useRouter()
+  const [pending, start] = useTransition()
+  const [classId, setClassId] = useState(classOptions[0]?.id ?? "")
+  const [courseId, setCourseId] = useState("")
+  const [semester, setSemester] = useState(1)
+  const [query, setQuery] = useState("")
+
+  const q = query.trim().toLowerCase()
+  const shortlist = courses.filter(
+    (c) => !q || `${c.code} ${c.name}`.toLowerCase().includes(q)
+  )
+
+  function save() {
+    start(async () => {
+      const res = await assignSubjectToTeacherAction({
+        classId,
+        facultyId: teacher.id,
+        courseId,
+        semester,
+      })
+      if (res.error) return void toast.error(res.error)
+      toast.success(`Assigned to ${teacher.name}`)
+      onClose()
+      router.refresh()
+    })
+  }
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Assign a subject to {teacher.name}</DialogTitle>
+        </DialogHeader>
+
+        {classOptions.length === 0 || courses.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            {classOptions.length === 0
+              ? "This department has no active classes yet."
+              : "This department has no catalogued courses yet."}
+          </p>
+        ) : (
+          <div className="grid gap-3">
+            <div className="grid grid-cols-2 gap-3">
+              <label className="grid gap-1.5">
+                <span className="text-muted-foreground text-xs">Division</span>
+                <select
+                  value={classId}
+                  onChange={(e) => setClassId(e.target.value)}
+                  className="border-input bg-background h-9 rounded border px-2 text-sm"
+                >
+                  {classOptions.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="grid gap-1.5">
+                <span className="text-muted-foreground text-xs">Semester</span>
+                <Input
+                  type="number"
+                  min={1}
+                  max={8}
+                  value={semester}
+                  onChange={(e) => setSemester(Number(e.target.value))}
+                  className="h-9"
+                />
+              </label>
+            </div>
+
+            <label className="grid gap-1.5">
+              <span className="text-muted-foreground text-xs">Subject</span>
+              <Input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search the catalogue…"
+                className="h-9"
+              />
+            </label>
+
+            <div className="border-border divide-border max-h-64 divide-y overflow-y-auto rounded border">
+              {shortlist.map((c) => (
+                <button
+                  key={c.id}
+                  type="button"
+                  onClick={() => setCourseId(c.id)}
+                  className={
+                    "hover:bg-muted flex w-full items-center gap-2 px-3 py-2 text-left text-sm " +
+                    (courseId === c.id ? "bg-muted" : "")
+                  }
+                >
+                  <Badge variant="outline" className="font-mono text-xs">
+                    {c.code}
+                  </Badge>
+                  <span className="truncate">{c.name}</span>
+                  {c.year && (
+                    <span className="text-muted-foreground ml-auto text-xs">
+                      {c.year}
+                    </span>
+                  )}
+                </button>
+              ))}
+              {shortlist.length === 0 && (
+                <p className="text-muted-foreground px-3 py-2 text-sm">
+                  Nothing matches that search.
+                </p>
+              )}
+            </div>
+
+            <p className="text-muted-foreground text-xs">
+              They are put on the division as a TR if they are not already, then
+              given this subject. Only they can enter its marks.
+            </p>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            size="sm"
+            disabled={pending || !classId || !courseId}
+            onClick={save}
+          >
+            {pending ? "Assigning…" : "Assign"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/src/app/dashboard/dept/[code]/page.tsx
+++ b/src/app/dashboard/dept/[code]/page.tsx
@@ -6,6 +6,7 @@ import { getDepartment } from "@/db/queries/departments"
 import { listClassesForDepts } from "@/db/queries/classes"
 import { listClassStaff } from "@/db/queries/class-staff"
 import { listActiveAppointments } from "@/db/queries/appointments"
+import { listCoursesForDepts } from "@/db/queries/courses"
 import { getFacultyByDepartments } from "@/db/queries/faculty"
 import {
   getStudentsByDepartments,
@@ -37,13 +38,14 @@ export default async function DepartmentDashboard({
   const dept = await getDepartment(deptCode)
   if (!dept) return notFound()
 
-  const [classes, faculty, students, appointments, graduated] =
+  const [classes, faculty, students, appointments, graduated, catalogue] =
     await Promise.all([
       listClassesForDepts([deptCode]),
       getFacultyByDepartments([deptCode]),
       getStudentsByDepartments([deptCode]),
       listActiveAppointments(),
       getGraduatedClassKeys(),
+      listCoursesForDepts([deptCode]),
     ])
   const staff = await listClassStaff(classes.map((c) => c.id))
   const now = new Date()
@@ -105,6 +107,23 @@ export default async function DepartmentDashboard({
       />
       <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
         <DeptDashboardClient
+          canAssign={
+            user.tier === "super_admin" || user.deptCodes.includes(deptCode)
+          }
+          courses={catalogue
+            .filter((c) => c.isActive)
+            .map((c) => ({
+              id: c.id,
+              code: c.courseCode,
+              name: c.courseName,
+              year: c.year,
+            }))}
+          classOptions={classes
+            .filter((c) => c.isActive)
+            .map((c) => ({
+              id: c.id,
+              label: `${expectedYear(c.admissionYear, now) ?? c.admissionYear} · ${c.division}`,
+            }))}
           dept={{ code: dept.code, name: dept.name, isActive: dept.isActive }}
           hod={
             mine.find((a) => a.appointment === "hod")

--- a/src/app/dashboard/dept/actions.ts
+++ b/src/app/dashboard/dept/actions.ts
@@ -16,6 +16,12 @@ import {
 } from "@/db/queries/courses"
 import { graduateClassKey, ungraduateClassKey } from "@/db/queries/students"
 import {
+  createOffering,
+  listOfferingsForClass,
+  setOfferingFaculty,
+} from "@/db/queries/offerings"
+import { getFacultyById } from "@/db/queries/faculty"
+import {
   createClass,
   getClassByKey,
   getClassById,
@@ -23,7 +29,7 @@ import {
   listUnroutedRequests,
   routeRequestsToClass,
 } from "@/db/queries/classes"
-import { assignClassRole } from "@/db/queries/class-staff"
+import { assignClassRole, removeClassRole } from "@/db/queries/class-staff"
 import { createFaculty, getFacultyByEmail } from "@/db/queries/faculty"
 
 type Result = { error: string | null }
@@ -589,5 +595,122 @@ export async function bulkCreateCoursesAction(input: {
     }
   } catch (err) {
     return { error: getErrorMessage(err, "Could not import the courses") }
+  }
+}
+
+/**
+ * Give a teacher a subject on a specific division, in one step.
+ *
+ * Teacher-first, where the Subjects page is subject-first — the HOD is looking
+ * at their faculty and deciding what each of them takes. Both end at the same
+ * place, so neither is a second way of recording it.
+ *
+ * Appointing to the class is folded in because it is a precondition rather than
+ * a decision: allocating a subject to somebody not on the class was simply
+ * refused, which made the obvious action fail for a reason the HOD had to go to
+ * another page to fix.
+ */
+export async function assignSubjectToTeacherAction(input: {
+  classId: string
+  facultyId: string
+  courseId: string
+  semester: number
+}): Promise<Result> {
+  try {
+    const user = await getSessionUser()
+    authorize(user, "offering:create")
+    const cls = await getClassById(input.classId)
+    if (!cls) return { error: "No such class." }
+    if (!inDeptScope(user!, cls.departmentCode))
+      return { error: "That class is not in your scope." }
+
+    const course = await getCourseById(input.courseId)
+    if (!course) return { error: "No such course." }
+    if (course.departmentCode && course.departmentCode !== cls.departmentCode) {
+      return { error: "That course belongs to another department." }
+    }
+
+    const teacher = await getFacultyById(input.facultyId)
+    if (!teacher) return { error: "No such faculty member." }
+    if (teacher.department !== cls.departmentCode) {
+      // Cross-department teaching is real, but it should be a deliberate act on
+      // the class's staff list rather than a side effect of allocating a subject.
+      return {
+        error: `${teacher.firstName} is not in ${cls.departmentCode}. Add them to the class first.`,
+      }
+    }
+
+    // One offering per (course, class): if the subject is already on the class,
+    // this reallocates it rather than creating a duplicate.
+    const existing = (await listOfferingsForClass(input.classId)).find(
+      (o) => o.course.id === course.id
+    )
+
+    await assignClassRole(input.classId, input.facultyId, "tr", user!.facultyId)
+
+    if (existing) {
+      await setOfferingFaculty(existing.id, input.facultyId)
+    } else {
+      await createOffering({
+        courseId: course.id,
+        classId: input.classId,
+        facultyId: input.facultyId,
+        semester: input.semester,
+      })
+    }
+
+    await createAuditLog({
+      action: existing ? "offering.allocated" : "offering.created",
+      actorId: user!.id,
+      targetType: "class",
+      targetId: input.classId,
+      details: {
+        courseCode: course.courseCode,
+        facultyId: input.facultyId,
+        classKey: cls.classKey,
+      },
+    })
+    revalidatePath(`/dashboard/dept/${cls.departmentCode}`)
+    revalidatePath(`/dashboard/class/${input.classId}/subjects`)
+    return { error: null }
+  } catch (err) {
+    return { error: getErrorMessage(err, "Could not assign the subject") }
+  }
+}
+
+/** Take a teacher off a class entirely. Their subjects become unallocated. */
+export async function removeClassRoleAction(input: {
+  classId: string
+  facultyId: string
+  role: "academic_coordinator" | "tr"
+}): Promise<Result> {
+  try {
+    const user = await getSessionUser()
+    authorize(user, "assignment:remove")
+    const cls = await getClassById(input.classId)
+    if (!cls) return { error: "No such class." }
+    if (!inDeptScope(user!, cls.departmentCode))
+      return { error: "That class is not in your scope." }
+
+    // Their subjects are released rather than left pointing at someone who is
+    // no longer on the class — an unallocated subject is visible and fixable,
+    // a ghost allocation is not.
+    const theirs = (await listOfferingsForClass(input.classId)).filter(
+      (o) => o.faculty?.id === input.facultyId
+    )
+    for (const o of theirs) await setOfferingFaculty(o.id, null)
+    await removeClassRole(input.classId, input.facultyId, input.role)
+
+    await createAuditLog({
+      action: "class.staff_removed",
+      actorId: user!.id,
+      targetType: "class",
+      targetId: input.classId,
+      details: { facultyId: input.facultyId, released: theirs.length },
+    })
+    revalidatePath(`/dashboard/dept/${cls.departmentCode}`)
+    return { error: null }
+  } catch (err) {
+    return { error: getErrorMessage(err, "Could not remove them") }
   }
 }

--- a/src/db/migrations/0003_multi_tr_per_class.sql
+++ b/src/db/migrations/0003_multi_tr_per_class.sql
@@ -1,0 +1,23 @@
+-- Several TRs per class.
+--
+-- A class is taught by as many teachers as it has subjects, and each subject
+-- carries its own teacher. The previous rule retired the incumbent TR whenever
+-- another was appointed, which silently unstaffed them. Only the coordinator is
+-- one-per-class, and that is already enforced by class_coordinator_live_uniq.
+--
+-- Adds the pair uniqueness the reactivating upsert needs. Duplicates are folded
+-- first, keeping the newest row of each (class, faculty, role) and retiring the
+-- rest, so the index can be created on existing data.
+WITH ranked AS (
+  SELECT id,
+         row_number() OVER (
+           PARTITION BY class_id, faculty_id, role
+           ORDER BY is_active DESC, created_at DESC
+         ) AS rn
+  FROM faculty_class_assignments
+)
+DELETE FROM faculty_class_assignments
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+CREATE UNIQUE INDEX IF NOT EXISTS class_faculty_role_uniq
+  ON faculty_class_assignments (class_id, faculty_id, role);

--- a/src/db/queries/class-staff.ts
+++ b/src/db/queries/class-staff.ts
@@ -9,11 +9,59 @@ type ClassRole = "academic_coordinator" | "tr"
  * so the current holder of that role is retired before the new one is written.
  * Ordered statements — no transaction on neon-http, fine for an admin/HOD action.
  */
+/**
+ * Put a faculty member on a class.
+ *
+ * The coordinator is one per class and replacing them retires the incumbent —
+ * the database enforces that with a partial unique index, so the retirement has
+ * to happen first or the insert fails.
+ *
+ * TRs accumulate. A class is taught by as many teachers as it has subjects, and
+ * each subject carries its own teacher, so retiring the previous TR on every
+ * appointment silently unstaffed whoever was already there. That rule was
+ * written before subjects were allocated per teacher; the schema never asked
+ * for it, and only the coordinator index does.
+ */
 export async function assignClassRole(
   classId: string,
   facultyId: string,
   role: ClassRole,
   assignedBy: string | null
+) {
+  if (role === "academic_coordinator") {
+    await db
+      .update(facultyClassAssignments)
+      .set({ isActive: false, updatedAt: new Date() })
+      .where(
+        and(
+          eq(facultyClassAssignments.classId, classId),
+          eq(facultyClassAssignments.role, role),
+          eq(facultyClassAssignments.isActive, true)
+        )
+      )
+  }
+
+  // Re-appointing someone already on the class reactivates their row rather
+  // than adding a second: the pair is unique, and a duplicate would show them
+  // twice on every roster.
+  await db
+    .insert(facultyClassAssignments)
+    .values({ classId, facultyId, role, assignedBy })
+    .onConflictDoUpdate({
+      target: [
+        facultyClassAssignments.classId,
+        facultyClassAssignments.facultyId,
+        facultyClassAssignments.role,
+      ],
+      set: { isActive: true, assignedBy, updatedAt: new Date() },
+    })
+}
+
+/** Take a faculty member off a class. Soft, so the history survives. */
+export async function removeClassRole(
+  classId: string,
+  facultyId: string,
+  role: ClassRole
 ) {
   await db
     .update(facultyClassAssignments)
@@ -21,13 +69,10 @@ export async function assignClassRole(
     .where(
       and(
         eq(facultyClassAssignments.classId, classId),
-        eq(facultyClassAssignments.role, role),
-        eq(facultyClassAssignments.isActive, true)
+        eq(facultyClassAssignments.facultyId, facultyId),
+        eq(facultyClassAssignments.role, role)
       )
     )
-  await db
-    .insert(facultyClassAssignments)
-    .values({ classId, facultyId, role, assignedBy })
 }
 
 /** Active staff across the given classes, with faculty names — for the console. */

--- a/src/db/schema/assignments.ts
+++ b/src/db/schema/assignments.ts
@@ -42,6 +42,10 @@ export const facultyClassAssignments = pgTable(
     uniqueIndex("class_coordinator_live_uniq")
       .on(t.classId)
       .where(sql`role = 'academic_coordinator' AND is_active`),
+    // One row per (class, faculty, role) so re-appointing reactivates rather
+    // than duplicating. TRs are deliberately NOT capped at one per class: a
+    // class has as many teachers as it has subjects.
+    uniqueIndex("class_faculty_role_uniq").on(t.classId, t.facultyId, t.role),
     index("assignments_faculty_idx").on(t.facultyId, t.isActive),
     index("assignments_class_idx").on(t.classId, t.isActive),
   ]


### PR DESCRIPTION
## What

An **Assign subject** action on the department dashboard's faculty rows: pick the division and the subject, and the teacher is put on that class as a TR if they aren't already, then given that subject.

Plus the change that had to come first — **several TRs per class**.

## Why

Appointing a TR meant a CSV import or the class dropdown on one page; allocating them a subject meant another. The faculty are already listed on the dashboard, so that's where the action belongs. Teacher-first, where the Subjects page is subject-first — both end at the same offering, so neither is a second way of recording it.

Appointing to the class is folded in because it's a **precondition, not a decision**. Allocating a subject to somebody not on the class was simply refused, which made the obvious action fail for a reason the HOD had to visit another page to fix.

## The blocker: one TR per class

`assignClassRole` retired the incumbent TR on every appointment — so appointing the second teacher **silently unstaffed the first**.

That was #61's rule, written when a class had one TR responsible for everything. It doesn't survive subjects carrying their own teacher: a class with six subjects needs six teachers. Only the *coordinator* is one-per-class, and the database already enforces that with `class_coordinator_live_uniq`. Nothing ever asked the same of TRs — it was application logic alone.

Migration `0003` folds any duplicate `(class, faculty, role)` rows and adds the pair uniqueness the reactivating upsert needs, so re-appointing somebody reactivates their row rather than listing them twice.

Verified on the live database:

```
after appointing Coordinator   TRs on class: Coordinator, Tr
after appointing Harshal       TRs on class: Coordinator, Harshal, Tr
re-appointing the first        TRs on class: Coordinator, Harshal, Tr   (no duplicate)
removing one                   TRs on class: Harshal, Tr
cleanup: active count back to 2  CLEAN
```

## Removing staff

There was **no way to take a faculty member off a class** — `assignment:remove` existed as a capability with nothing behind it. Removal now releases their subjects back to unallocated rather than leaving offerings pointing at somebody no longer on the class: an unallocated subject is visible and fixable, a ghost allocation is not.

## Guards worth reviewing

- A course from another department is refused, as is a teacher from another department — cross-department teaching is real, but it should be a deliberate act on the class's staff list, not a side effect of allocating a subject.
- If the subject is already on the class, it **reallocates** rather than creating a duplicate offering.

## Testing

- [x] `npm run check` passes (0 errors; 2 pre-existing warnings), **76 tests**
- [x] `npm run build` passes
- [x] `db:migrate` applied `0003`; status reports 3 applied, 0 pending
