### PR TITLE
fix: class page 500 — buttonVariants called from a Server Component

### DIFF
--- a/src/app/dashboard/class/[classId]/page.tsx
+++ b/src/app/dashboard/class/[classId]/page.tsx
@@ -8,7 +8,7 @@ import {
   BookOpenIcon,
 } from "lucide-react"
 import { PageHeader } from "@/components/page-header"
-import { buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button-variants"
 import { getSessionUser } from "@/lib/session"
 import { expectedYear } from "@/lib/roll-number"
 import { getClassById } from "@/db/queries/classes"

--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -1,0 +1,47 @@
+// Extracted from button.tsx so Server Components can use it.
+//
+// button.tsx is a client module, and calling an export of one from a server
+// component is a runtime error React cannot catch at build time — it took the
+// class page down for anyone who opened it. cva() has no client dependency, so
+// the styles live here and the component stays where it is.
+
+import { cva, type VariantProps } from "class-variance-authority"
+
+export const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        outline:
+          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+        destructive:
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default:
+          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
+        icon: "size-8",
+        "icon-xs":
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm":
+          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-lg": "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export type ButtonVariants = VariantProps<typeof buttonVariants>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,7 +6,6 @@ import { type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button-variants"
 
-
 function Button({
   className,
   variant = "default",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,46 +1,11 @@
 "use client"
 
 import { Button as ButtonPrimitive } from "@base-ui/react/button"
-import { cva, type VariantProps } from "class-variance-authority"
+import { type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button-variants"
 
-const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
-        outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
-        ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
-        destructive:
-          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
-        icon: "size-8",
-        "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
-        "icon-lg": "size-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
 
 function Button({
   className,


### PR DESCRIPTION
## What

`/dashboard/class/[classId]` returned **500 for every user**. This fixes it.

## The actual error

```
Attempted to call buttonVariants() from the server but buttonVariants is on the
client. It's not possible to invoke a client function from the server.
  at ClassDetailPage (src/app/dashboard/class/[classId]/page.tsx:63)
```

`buttonVariants` is exported from `components/ui/button.tsx`, which is a `"use client"` module. Calling an export of one from a Server Component is a **runtime** error React can't catch at build time.

That's the important part: `npm run typecheck`, `npm run lint` and `next build` **all pass**, and the page still dies on request. Which is exactly why it survived four separate edits to this file since Phase 5 first introduced the call — and why I couldn't find it by reading the code or running its queries.

## How

`cva()` has no client dependency — no hooks, no browser API, just a string builder. It moves to `components/ui/button-variants.ts`, which carries no directive and can be imported from either side. `button.tsx` imports and re-exports it, so **every existing client import is untouched**.

The class page was the only Server Component calling it. The other five call sites are all client components and were never affected:

```
app/dashboard/students/client.tsx        client (ok)
app/dashboard/audit/client.tsx           client (ok)
app/dashboard/class/[classId]/page.tsx   SERVER  <-- the bug
app/dashboard/dept/courses/client.tsx    client (ok)
components/data-table-view.tsx           client (ok)
components/ui/calendar.tsx               client (ok)
```

## Testing

Reproduced and verified against the live database with a real signed session (created for the test, removed afterwards — zero debug sessions remain):

```
before fix:  /dashboard/class/<id>  ->  500
after fix:   /dashboard/class/<id>  ->  200
             /dashboard/class       ->  200
             /dashboard             ->  200
buttonVariants errors in server log: 0
```

- [x] `npm run check` passes (0 errors; 2 pre-existing warnings), 76 tests
- [x] `npm run build` passes

## Worth following up

Nothing in CI catches a client-export-called-from-server. A smoke test that requests the main routes with a session would have caught this on the first push — worth adding once the VOSS credentials question is settled.
