### PR TITLE
fix(marks): let the teacher who locked a component reopen it, and show students their component marks

### DIFF
--- a/src/app/dashboard/class/[classId]/marks/client.tsx
+++ b/src/app/dashboard/class/[classId]/marks/client.tsx
@@ -32,11 +32,13 @@ type Row = {
   ese: number | null
 }
 type LockComponent = "isa" | "mse" | "ese"
+/** A frozen component, and whether this viewer may reopen it. */
+type Lock = { component: LockComponent; canUnlock: boolean }
 type Grid = {
   offeringId: string
   course: CourseInfo
   rows: Row[]
-  locked: LockComponent[]
+  locked: Lock[]
 }
 
 const LOCK_LABEL: Record<LockComponent, string> = {
@@ -50,26 +52,17 @@ export function MarksClient({
   offerings,
   selectedId,
   grid,
-  canUnlock,
   canAllocate,
 }: {
   classId: string
   offerings: Offering[]
   selectedId: string | null
   grid: Grid | null
-  canUnlock: boolean
   canAllocate: boolean
 }) {
   if (grid && selectedId) {
     const offering = offerings.find((o) => o.id === selectedId)!
-    return (
-      <MarksGrid
-        classId={classId}
-        offering={offering}
-        grid={grid}
-        canUnlock={canUnlock}
-      />
-    )
+    return <MarksGrid classId={classId} offering={offering} grid={grid} />
   }
   return (
     <SubjectSetup
@@ -174,12 +167,10 @@ function MarksGrid({
   classId,
   offering,
   grid,
-  canUnlock,
 }: {
   classId: string
   offering: Offering
   grid: Grid
-  canUnlock: boolean
 }) {
   const router = useRouter()
   const [pending, start] = useTransition()
@@ -187,7 +178,9 @@ function MarksGrid({
   const { course } = grid
   const hasMse = course.maxMse > 0
   const locked = grid.locked
-  const isLocked = (c: LockComponent) => locked.includes(c)
+  const isLocked = (c: LockComponent) => locked.some((l) => l.component === c)
+  const mayUnlock = (c: LockComponent) =>
+    locked.find((l) => l.component === c)?.canUnlock ?? false
   // Nothing left to enter: every component this course has is frozen.
   const allLocked =
     isLocked("isa") && isLocked("ese") && (!hasMse || isLocked("mse"))
@@ -338,7 +331,7 @@ function MarksGrid({
       <LockPanel
         hasMse={hasMse}
         isLocked={isLocked}
-        canUnlock={canUnlock}
+        mayUnlock={mayUnlock}
         pending={pending}
         onToggle={toggleLock}
       />
@@ -468,13 +461,13 @@ function MarkInput({
 function LockPanel({
   hasMse,
   isLocked,
-  canUnlock,
+  mayUnlock,
   pending,
   onToggle,
 }: {
   hasMse: boolean
   isLocked: (c: LockComponent) => boolean
-  canUnlock: boolean
+  mayUnlock: (c: LockComponent) => boolean
   pending: boolean
   onToggle: (c: LockComponent, next: boolean) => void
 }) {
@@ -495,7 +488,7 @@ function LockPanel({
               {locked ? " · locked" : ""}
             </Badge>
             {locked ? (
-              canUnlock ? (
+              mayUnlock(c) ? (
                 <Button
                   variant="ghost"
                   size="sm"
@@ -520,9 +513,9 @@ function LockPanel({
           </div>
         )
       })}
-      {!canUnlock && (
+      {components.some((c) => isLocked(c) && !mayUnlock(c)) && (
         <span className="text-muted-foreground ml-auto text-xs">
-          Ask the class coordinator to reopen a locked component.
+          Ask the class coordinator to reopen a component somebody else locked.
         </span>
       )}
     </div>

--- a/src/app/dashboard/class/[classId]/marks/page.tsx
+++ b/src/app/dashboard/class/[classId]/marks/page.tsx
@@ -61,7 +61,15 @@ export default async function MarksPage({
     const byStudent = Object.fromEntries(existing.map((m) => [m.studentId, m]))
     grid = {
       offeringId: selected.id,
-      locked,
+      // Per component, because the right to reopen depends on who locked that
+      // one — not on a single permission for the whole page.
+      locked: locked.map((l) => ({
+        component: l.component,
+        canUnlock:
+          canAllocate ||
+          (l.lockedByFacultyId != null &&
+            l.lockedByFacultyId === user.facultyId),
+      })),
       course: {
         courseType: selected.course.courseType,
         credits: selected.course.credits,
@@ -92,12 +100,6 @@ export default async function MarksPage({
       <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
         <MarksClient
           classId={classId}
-          canUnlock={
-            user.tier === "super_admin" ||
-            (user.tier === "hod" &&
-              user.deptCodes.includes(cls.departmentCode)) ||
-            user.coordinatorClassIds.includes(classId)
-          }
           canAllocate={canAllocate}
           offerings={offerings.map((o) => ({
             id: o.id,

--- a/src/app/dashboard/class/actions.ts
+++ b/src/app/dashboard/class/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache"
 import { getSessionUser, type SessionUser } from "@/lib/session"
 import { authorize } from "@/lib/rbac"
-import { canAllocate, canWriteOffering } from "@/lib/allocation"
+import { canAllocate, canReopenLock, canWriteOffering } from "@/lib/allocation"
 import { getErrorMessage } from "@/lib/error-utils"
 import { parseRollNumber, expectedYear } from "@/lib/roll-number"
 import { createAuditLog } from "@/db/queries"
@@ -298,7 +298,8 @@ export async function saveMarksAction(input: {
     // Enforced here and not only in the UI: the grid is the polite reminder,
     // this is the actual guarantee — a stale tab or a direct call must not slip
     // a mark past a submitted component.
-    const locked = await getLockedComponents(input.offeringId)
+    const lockRows = await getLockedComponents(input.offeringId)
+    const locked = lockRows.map((l) => l.component)
     const rows = input.rows.map((r) => ({
       courseOfferingId: input.offeringId,
       studentId: r.studentId,
@@ -367,13 +368,22 @@ export async function setMarksLockAction(input: {
     const { ok, cls } = await classInScope(user!, offering.classId)
     if (!ok || !cls) return { error: "That class is not in your scope." }
 
-    if (
-      !input.locked &&
-      !canUnlock(user!, offering.classId, cls.departmentCode)
-    ) {
-      return {
-        error:
-          "Only the class coordinator, the HOD, or an admin can reopen locked marks.",
+    if (!input.locked) {
+      const held = (await getLockedComponents(input.offeringId)).find(
+        (l) => l.component === component
+      )
+      if (
+        !canReopenLock(
+          user!,
+          offering.classId,
+          cls.departmentCode,
+          held?.lockedByFacultyId ?? null
+        )
+      ) {
+        return {
+          error:
+            "Only the teacher who locked this, the class coordinator, or the HOD can reopen it.",
+        }
       }
     }
 
@@ -398,13 +408,6 @@ export async function setMarksLockAction(input: {
 }
 
 /** Reopening is coordinator-and-above; teaching the class is not enough. */
-function canUnlock(user: SessionUser, classId: string, deptCode: string) {
-  return (
-    user.tier === "super_admin" ||
-    (user.tier === "hod" && user.deptCodes.includes(deptCode)) ||
-    user.coordinatorClassIds.includes(classId)
-  )
-}
 
 // ── practical batches ──────────────────────────────────────────────────────
 

--- a/src/app/dashboard/my-marks/client.tsx
+++ b/src/app/dashboard/my-marks/client.tsx
@@ -1,6 +1,8 @@
 "use client"
 
+import { useState } from "react"
 import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { computeMarks, type CgpaResult, type CourseInfo } from "@/lib/sgpi"
 
@@ -89,36 +91,13 @@ export function MyMarksClient({
                       <th className="w-16">Total</th>
                       <th className="w-14">%</th>
                       <th className="w-16">Grade</th>
+                      <th className="w-8"></th>
                     </tr>
                   </thead>
                   <tbody className="divide-border divide-y">
-                    {sem.subjects.map((s) => {
-                      const c = computeMarks(s.marks, s.course)
-                      return (
-                        <tr key={s.code} className="[&>td]:px-2 [&>td]:py-1.5">
-                          <td className="font-mono text-xs">{s.code}</td>
-                          <td>{s.name}</td>
-                          <td className="tabular-nums">{s.credits}</td>
-                          <td className="tabular-nums">
-                            {c.percentage == null
-                              ? "—"
-                              : `${c.total}/${s.course.maxTotal}`}
-                          </td>
-                          <td className="text-muted-foreground tabular-nums">
-                            {c.percentage ?? "—"}
-                          </td>
-                          <td>
-                            {c.gradePoint == null ? (
-                              <span className="text-muted-foreground">—</span>
-                            ) : c.gradePoint === "Fail" ? (
-                              <Badge variant="destructive">Fail</Badge>
-                            ) : (
-                              <Badge variant="outline">{c.gradePoint}</Badge>
-                            )}
-                          </td>
-                        </tr>
-                      )
-                    })}
+                    {sem.subjects.map((s) => (
+                      <SubjectRow key={s.code} subject={s} />
+                    ))}
                   </tbody>
                 </table>
               </div>
@@ -144,6 +123,136 @@ function Stat({
       <p className="text-muted-foreground text-sm">{label}</p>
       <p className="text-2xl font-semibold tabular-nums">{value}</p>
       <p className="text-muted-foreground text-xs">{hint}</p>
+    </div>
+  )
+}
+
+/**
+ * A subject, expandable to the component marks behind its total.
+ *
+ * A student checking against their own answer sheet needs ISA, both MSEs and
+ * the ESE separately — a single total says what they scored but not where, and
+ * "why is my total 62" is the actual question. Collapsed by default so a full
+ * semester still reads at a glance, and only expandable once something has been
+ * entered, since an empty breakdown answers nothing.
+ */
+function SubjectRow({ subject }: { subject: Subject }) {
+  const [open, setOpen] = useState(false)
+  const c = computeMarks(subject.marks, subject.course)
+  const hasMse = subject.course.maxMse > 0
+  const entered =
+    subject.marks.isa != null ||
+    subject.marks.mse1 != null ||
+    subject.marks.mse2 != null ||
+    subject.marks.ese != null
+
+  return (
+    <>
+      <tr
+        className={cn(
+          "[&>td]:px-2 [&>td]:py-1.5",
+          entered && "hover:bg-muted/50 cursor-pointer"
+        )}
+        onClick={() => entered && setOpen((o) => !o)}
+      >
+        <td className="font-mono text-xs">{subject.code}</td>
+        <td>{subject.name}</td>
+        <td className="tabular-nums">{subject.credits}</td>
+        <td className="tabular-nums">
+          {c.percentage == null ? "—" : `${c.total}/${subject.course.maxTotal}`}
+        </td>
+        <td className="text-muted-foreground tabular-nums">
+          {c.percentage ?? "—"}
+        </td>
+        <td>
+          {c.gradePoint == null ? (
+            <span className="text-muted-foreground">—</span>
+          ) : c.gradePoint === "Fail" ? (
+            <Badge variant="destructive">Fail</Badge>
+          ) : (
+            <Badge variant="outline">{c.gradePoint}</Badge>
+          )}
+        </td>
+        <td className="text-muted-foreground text-xs">
+          {entered ? (open ? "▾" : "▸") : ""}
+        </td>
+      </tr>
+
+      {open && (
+        <tr className="bg-muted/30">
+          <td colSpan={7} className="px-2 py-3">
+            <div className="flex flex-wrap items-start gap-6 text-xs">
+              <Part
+                label="ISA"
+                value={subject.marks.isa}
+                max={subject.course.maxIsa}
+              />
+              {hasMse && (
+                <>
+                  <Part
+                    label="MSE 1"
+                    value={subject.marks.mse1}
+                    max={subject.course.maxMse}
+                  />
+                  <Part
+                    label="MSE 2"
+                    value={subject.marks.mse2}
+                    max={subject.course.maxMse}
+                  />
+                  {/* The two MSEs average into one component, so the figure that
+                      actually enters the total is shown rather than leaving the
+                      arithmetic looking wrong. */}
+                  <Part
+                    label="MSE counted"
+                    value={c.finalMse}
+                    max={subject.course.maxMse}
+                  />
+                </>
+              )}
+              <Part
+                label="ESE"
+                value={subject.marks.ese}
+                max={subject.course.maxEse}
+              />
+              <div className="ml-auto text-right">
+                <p className="text-muted-foreground">Total</p>
+                <p className="font-medium tabular-nums">
+                  {c.total}/{subject.course.maxTotal}
+                </p>
+              </div>
+            </div>
+            {c.percentage == null && (
+              <p className="text-muted-foreground mt-3">
+                Not every component is in yet, so no grade is calculated. This
+                is what your teachers have entered so far.
+              </p>
+            )}
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}
+
+function Part({
+  label,
+  value,
+  max,
+}: {
+  label: string
+  value: number | null
+  max: number
+}) {
+  return (
+    <div>
+      <p className="text-muted-foreground">{label}</p>
+      <p className="font-medium tabular-nums">
+        {value == null ? (
+          <span className="text-muted-foreground font-normal">not entered</span>
+        ) : (
+          `${value}/${max}`
+        )}
+      </p>
     </div>
   )
 }

--- a/src/db/queries/marks.ts
+++ b/src/db/queries/marks.ts
@@ -71,17 +71,37 @@ export function isLockComponent(v: string): v is LockComponent {
   return (LOCKABLE_COMPONENTS as readonly string[]).includes(v)
 }
 
-/** Locked components for one offering. Absent row = never locked = open. */
+export type MarksLock = {
+  component: LockComponent
+  /** Who froze it. Null for a lock recorded before this was tracked. */
+  lockedByFacultyId: string | null
+}
+
+/**
+ * Locked components for one offering, with who locked each. Absent row = never
+ * locked = open.
+ *
+ * The owner is returned, not just the component name, because reopening is
+ * allowed to the person who submitted as well as to the coordinator — undoing
+ * your own submission is a correction, not an override.
+ */
 export async function getLockedComponents(
   courseOfferingId: string
-): Promise<LockComponent[]> {
+): Promise<MarksLock[]> {
   const rows = await db
-    .select({ component: marksLocks.component, isLocked: marksLocks.isLocked })
+    .select({
+      component: marksLocks.component,
+      isLocked: marksLocks.isLocked,
+      lockedByFacultyId: marksLocks.lockedByFacultyId,
+    })
     .from(marksLocks)
     .where(eq(marksLocks.courseOfferingId, courseOfferingId))
   return rows
     .filter((r) => r.isLocked && isLockComponent(r.component))
-    .map((r) => r.component as LockComponent)
+    .map((r) => ({
+      component: r.component as LockComponent,
+      lockedByFacultyId: r.lockedByFacultyId,
+    }))
 }
 
 /**

--- a/src/lib/allocation.test.ts
+++ b/src/lib/allocation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   canAllocate,
+  canReopenLock,
   canWriteOffering,
   type AllocationActor,
 } from "./allocation"
@@ -143,5 +144,51 @@ describe("division isolation", () => {
     }
     expect(canWriteOffering(coordA, "f-x", DIV_A, "CMPN")).toBe(true)
     expect(canWriteOffering(coordA, "f-y", DIV_B, "CMPN")).toBe(false)
+  })
+})
+
+describe("canReopenLock", () => {
+  const CLASS2 = "class-1"
+  const DEPT2 = "EXCS"
+  const teacherA: AllocationActor = {
+    tier: "faculty",
+    facultyId: "f-a",
+    deptCodes: [],
+    coordinatorClassIds: [],
+  }
+  const teacherB: AllocationActor = { ...teacherA, facultyId: "f-b" }
+
+  // The whole point of the change: locking your own marks must not require
+  // somebody else to undo it.
+  it("lets the teacher who locked it reopen it", () => {
+    expect(canReopenLock(teacherA, CLASS2, DEPT2, "f-a")).toBe(true)
+  })
+
+  it("still refuses a different teacher", () => {
+    expect(canReopenLock(teacherB, CLASS2, DEPT2, "f-a")).toBe(false)
+  })
+
+  it("lets the coordinator and the HOD reopen anybody's lock", () => {
+    const coord: AllocationActor = {
+      ...teacherB,
+      coordinatorClassIds: [CLASS2],
+    }
+    const hod2: AllocationActor = {
+      tier: "hod",
+      facultyId: "f-hod",
+      deptCodes: [DEPT2],
+      coordinatorClassIds: [],
+    }
+    expect(canReopenLock(coord, CLASS2, DEPT2, "f-a")).toBe(true)
+    expect(canReopenLock(hod2, CLASS2, DEPT2, "f-a")).toBe(true)
+  })
+
+  // Locks recorded before the owner was tracked carry null, and a teacher whose
+  // own facultyId is null must not match them.
+  it("does not let a null actor claim an unowned lock", () => {
+    expect(
+      canReopenLock({ ...teacherA, facultyId: null }, CLASS2, DEPT2, null)
+    ).toBe(false)
+    expect(canReopenLock(teacherA, CLASS2, DEPT2, null)).toBe(false)
   })
 })

--- a/src/lib/allocation.ts
+++ b/src/lib/allocation.ts
@@ -44,3 +44,24 @@ export function canWriteOffering(
   if (canAllocate(user, classId, deptCode)) return true
   return offeringFacultyId != null && offeringFacultyId === user.facultyId
 }
+
+/**
+ * Who may reopen a frozen marks component.
+ *
+ * The coordinator, the HOD and super_admin can, because reopening undoes a
+ * submission somebody else may already have acted on.
+ *
+ * So can whoever locked it. Freezing your own marks and then needing another
+ * person to undo it is friction with no safeguard behind it — correcting your
+ * own submission is not overriding anyone else's. What the rule protects
+ * against is teacher A reopening teacher B's work, and that still cannot happen.
+ */
+export function canReopenLock(
+  user: AllocationActor,
+  classId: string,
+  deptCode: string,
+  lockedByFacultyId: string | null
+): boolean {
+  if (canAllocate(user, classId, deptCode)) return true
+  return lockedByFacultyId != null && lockedByFacultyId === user.facultyId
+}


### PR DESCRIPTION
## Two fixes

### 1. If you locked it, you can unlock it

Locking was open to anyone who could enter marks; reopening was the coordinator's, HOD's or admin's alone. So a teacher who froze their own ISA a moment too early had to find somebody else to undo it — the panel just said *"Ask the class coordinator"* with no button.

That's friction with no safeguard behind it. **Correcting your own submission isn't overriding anyone else's**, and what the rule actually protects against — teacher A reopening teacher B's work — is untouched.

`marks_locks` already recorded `lockedByFacultyId`; `getLockedComponents` was discarding it. It now returns the owner per component, so the right to reopen is decided **per component** rather than once for the page: your own lock shows Unlock, someone else's shows the explanation.

Verified against the live database:

```
ISA locked by ac@vosslabs.org (owner recorded)
  ac@vosslabs.org   (locked it)   true    want true
  tr2@vosslabs.org  (other TR)    false   want false
  coordinator                     true    want true
  hod of EXCS                     true    want true
```

The rule moves to `lib/allocation.ts` beside the others and is tested — including the case where a lock predates owner tracking and carries `null`, so a teacher whose own `facultyId` is null can't match it.

### 2. Students can open a subject and see the marks behind the total

`My marks` showed a total, a percentage and a grade. A student checking against their own answer sheet needs the components — ISA, both MSEs, ESE, each against its maximum. *"Why is my total 62"* was unanswerable on the page that exists to answer it.

Each subject now expands to that breakdown, including the **averaged MSE figure that actually enters the total**, so the arithmetic reads correctly instead of looking wrong. Collapsed by default; only expandable once something is entered, since an empty breakdown answers nothing. A missing component says "not entered" rather than showing a zero the student would read as a mark.

## Testing

- [x] `npm run check` passes (0 errors; 2 pre-existing warnings) — **80 tests**, 4 new for the reopen rule
- [x] `npm run build` passes
