### PR TITLE
feat(marks): say where to go when the subject is not in the list

### DIFF
--- a/src/app/dashboard/class/[classId]/marks/import/client.tsx
+++ b/src/app/dashboard/class/[classId]/marks/import/client.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import Link from "next/link"
+
 import { useRef, useState, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
@@ -40,9 +42,11 @@ const fmt = (v: number | null) => (v === null ? "AB" : String(v))
 export function ImportClient({
   classId,
   offerings,
+  canAllocate,
 }: {
   classId: string
   offerings: Offering[]
+  canAllocate: boolean
 }) {
   const router = useRouter()
   const fileRef = useRef<HTMLInputElement>(null)
@@ -150,34 +154,48 @@ export function ImportClient({
         <>
           {/* Step 2 — map columns + pick subject */}
           <div className="border-border flex flex-col gap-4 rounded border p-4">
-            <label className="grid gap-1.5 sm:max-w-sm">
-              <span className="text-muted-foreground text-xs">Subject</span>
-              {offerings.length === 0 ? (
-                <p className="text-muted-foreground text-sm">
-                  No subjects yet.{" "}
-                  <a
-                    href={`/dashboard/class/${classId}/marks`}
+            <div className="grid gap-1.5 sm:max-w-sm">
+              {/* The label wraps only the select. Wrapping the hint too would
+                  put its link inside a label, so clicking it would also drive
+                  the select. */}
+              {offerings.length > 0 && (
+                <label className="grid gap-1.5">
+                  <span className="text-muted-foreground text-xs">Subject</span>
+                  <select
+                    value={offeringId}
+                    onChange={(e) => setOfferingId(e.target.value)}
+                    className="border-border h-9 rounded border bg-transparent px-2 text-sm"
+                  >
+                    <option value="">Select a subject…</option>
+                    {offerings.map((o) => (
+                      <option key={o.id} value={o.id}>
+                        {o.code} — {o.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+
+              {/* Offered whether or not the list is empty: a marksheet for a
+                  subject nobody has added yet looks identical to one for a
+                  subject allocated to a colleague, and both dead-end here
+                  unless the page says where to go. */}
+              <p className="text-muted-foreground text-xs">
+                {offerings.length === 0
+                  ? "No subjects on this class are allocated to you. "
+                  : "Subject not listed? "}
+                {canAllocate ? (
+                  <Link
+                    href={`/dashboard/class/${classId}/subjects`}
                     className="underline"
                   >
-                    Add a subject
-                  </a>{" "}
-                  first.
-                </p>
-              ) : (
-                <select
-                  value={offeringId}
-                  onChange={(e) => setOfferingId(e.target.value)}
-                  className="border-border h-9 rounded border bg-transparent px-2 text-sm"
-                >
-                  <option value="">Select a subject…</option>
-                  {offerings.map((o) => (
-                    <option key={o.id} value={o.id}>
-                      {o.code} — {o.name}
-                    </option>
-                  ))}
-                </select>
-              )}
-            </label>
+                    Add one from the catalogue
+                  </Link>
+                ) : (
+                  "Ask the class coordinator to add it and allocate it to you."
+                )}
+              </p>
+            </div>
 
             <div>
               <p className="mb-2 text-sm font-medium">

--- a/src/app/dashboard/class/[classId]/marks/import/page.tsx
+++ b/src/app/dashboard/class/[classId]/marks/import/page.tsx
@@ -50,6 +50,7 @@ export default async function MarksImportPage({
       <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
         <ImportClient
           classId={classId}
+          canAllocate={canAllocate}
           offerings={offerings.map((o) => ({
             id: o.id,
             code: o.course.courseCode,


### PR DESCRIPTION
## What

The marks importer now always shows where to go when the subject you need isn't in the dropdown.

## Why

The dropdown offers the subjects allocated to you. When the marksheet in your hand is for a subject nobody has added yet, the page said **nothing** — one option and no way forward.

There *was* an empty-state, but it only fired when the list was completely empty, and it linked to `/marks` — where the add form stopped living when subject creation moved to the Subjects page in #74. So the single hint the page offered led nowhere.

## How

The note is always shown, and distinguishes the two cases that look identical from the importer:

- **No subjects allocated to you** — nothing to import against
- **Subject not listed** — it may exist but belong to a colleague, or not exist at all

Whoever can allocate gets a link to add one from the catalogue; everyone else is told to ask the coordinator, since a TR can't mint subjects.

## The underlying cause in your data

The ADC marksheet has nowhere to go because **ADC isn't in the catalogue**:

```
catalogue matches for ADC / communication: 0
subjects on the class: 1  (EC33T Data Analytics & Visualization -> tr@vosslabs.org)
total courses in catalogue: 35
```

Those 35 are the R22 Final Year set (EC33–EC47). "Analog & Digital Communications" is `PCEC14T` from the **R23 Third Year** syllabus, which was never imported. The dropdown was right; the page just never said why.

The full chain each step now names: **course in the catalogue → subject on the class → allocated to a teacher → marks imported.** The Subjects page already handles the far end, linking to the catalogue when nothing is left to add.

## Testing

- [x] `npm run check` passes (0 errors; 2 pre-existing warnings), 80 tests
- [x] `npm run build` passes
