### PR TITLE
fix(security): scope every academic write to the caller's own students

### DIFF
--- a/src/app/api/students/import/route.ts
+++ b/src/app/api/students/import/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 import { apiError, apiSuccess } from "@/lib/api-response"
 import { getErrorMessage } from "@/lib/error-utils"
 import { getSessionUser, isStaff } from "@/lib/session"
+import { rollsInScope } from "@/lib/scope"
 import { tryClassKeyFromRoll } from "@/lib/class-key"
 import { createStudent, createAuditLog } from "@/db/queries"
 import { db } from "@/db"
@@ -52,11 +53,39 @@ export async function POST(req: NextRequest) {
     // ── 2. Check DB for already-existing roll numbers ─────────────────────
     const allRollNumbers = rows.map((r) => r.rollNumber)
     const existingInDb = await db
-      .select({ rollNumber: students.rollNumber })
+      .select({
+        rollNumber: students.rollNumber,
+        classKey: students.classKey,
+      })
       .from(students)
       .where(inArray(students.rollNumber, allRollNumbers))
 
     const dbConflicts = new Set(existingInDb.map((s) => s.rollNumber))
+
+    // Being staff says nothing about WHICH roster you may write. Without this a
+    // TR holding one class could post rows creating students for another
+    // department entirely — and Import roster is shown to every faculty user,
+    // so it was not an unreachable path.
+    //
+    // Scope is judged on the roll, never on the department and division sent
+    // beside it: those are descriptive fields the payload controls, while the
+    // roll encodes the cohort and cannot disagree with itself. Where a student
+    // already exists their stored class key wins, because a repeater's roll
+    // cannot express the cohort they actually sit in.
+    const scope = rollsInScope(
+      user!,
+      allRollNumbers,
+      new Map(existingInDb.map((s) => [s.rollNumber.toUpperCase(), s.classKey]))
+    )
+    if (!scope.ok) {
+      // The batch fails whole rather than importing the in-scope part: a
+      // half-applied roster is harder to reason about than a refused one, and a
+      // forged batch should leave a refusal rather than a partial success.
+      return apiError(
+        `${scope.reason}${scope.offending.length ? " " + scope.offending.join(", ") : ""}`,
+        403
+      )
+    }
 
     // ── 3. Classify rows into valid / errored ─────────────────────────────
     type RowError = { row: number; field: string; message: string }

--- a/src/app/dashboard/class/actions.ts
+++ b/src/app/dashboard/class/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache"
 import { getSessionUser, type SessionUser } from "@/lib/session"
 import { authorize } from "@/lib/rbac"
+import { studentsInClass } from "@/lib/scope"
 import { canAllocate, canReopenLock, canWriteOffering } from "@/lib/allocation"
 import { getErrorMessage } from "@/lib/error-utils"
 import { parseRollNumber, expectedYear } from "@/lib/roll-number"
@@ -162,21 +163,27 @@ export async function saveAttendanceAction(input: {
     const { ok, cls } = await classInScope(user!, input.classId)
     if (!ok || !cls) return { error: "That class is not in your scope." }
 
-    // Only students actually in this class can be marked — a forged studentId is
-    // dropped, not written.
+    // Only students actually in this class can be marked. The whole request is
+    // refused rather than the offending rows dropped: a partial write looks
+    // successful, so a forged id would leave no trace and a genuine bug would
+    // look like attendance that quietly went missing.
     const roster = new Set(
       (await getStudentsByClassKeys([cls.classKey])).map((s) => s.id)
     )
-    const entries = input.marks
-      .filter((m) => roster.has(m.studentId))
-      .map((m) => ({
-        studentId: m.studentId,
-        classId: input.classId,
-        sessionDate: input.sessionDate,
-        sessionSlot: input.sessionSlot,
-        status: m.status,
-        recordedByFacultyId: user!.facultyId,
-      }))
+    const attScope = studentsInClass(
+      roster,
+      input.marks.map((m) => m.studentId)
+    )
+    if (!attScope.ok) return { error: attScope.reason }
+
+    const entries = input.marks.map((m) => ({
+      studentId: m.studentId,
+      classId: input.classId,
+      sessionDate: input.sessionDate,
+      sessionSlot: input.sessionSlot,
+      status: m.status,
+      recordedByFacultyId: user!.facultyId,
+    }))
     await upsertAttendance(entries)
 
     await createAuditLog({
@@ -298,6 +305,19 @@ export async function saveMarksAction(input: {
     // Enforced here and not only in the UI: the grid is the polite reminder,
     // this is the actual guarantee — a stale tab or a direct call must not slip
     // a mark past a submitted component.
+    // The caller's authority over the subject says nothing about WHOSE marks
+    // the payload names. Without this, a teacher holding one class could attach
+    // marks from their offering to a student in another — and getMarksForStudent
+    // reads by student id alone, so it would surface in that student's record.
+    const roster = new Set(
+      (await getStudentsByClassKeys([cls.classKey])).map((s) => s.id)
+    )
+    const scope = studentsInClass(
+      roster,
+      input.rows.map((r) => r.studentId)
+    )
+    if (!scope.ok) return { error: scope.reason }
+
     const lockRows = await getLockedComponents(input.offeringId)
     const locked = lockRows.map((l) => l.component)
     const rows = input.rows.map((r) => ({
@@ -475,6 +495,17 @@ export async function assignBatchAction(input: {
     ) {
       return { error: "That subject is allocated to another teacher." }
     }
+
+    // A batch belongs to one offering on one class, so its members must come
+    // from that class. batch_assignments only checks that both rows exist, so
+    // nothing below this would catch a student from another division.
+    const cls2 = await getClassById(offering.classId)
+    if (!cls2) return { error: "No such class." }
+    const roster = new Set(
+      (await getStudentsByClassKeys([cls2.classKey])).map((s) => s.id)
+    )
+    const scope = studentsInClass(roster, input.studentIds)
+    if (!scope.ok) return { error: scope.reason }
 
     await assignStudentsToBatch({
       batchId: input.batchId,

--- a/src/lib/scope.test.ts
+++ b/src/lib/scope.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest"
+import { rollsInScope, studentsInClass, type ImportActor } from "./scope"
+
+describe("studentsInClass", () => {
+  const roster = new Set(["a", "b", "c"])
+
+  it("accepts a payload naming only class members", () => {
+    expect(studentsInClass(roster, ["a", "c"]).ok).toBe(true)
+  })
+
+  it("accepts an empty payload", () => {
+    expect(studentsInClass(roster, []).ok).toBe(true)
+  })
+
+  // The whole point: rejecting, not dropping. A partial write would look
+  // successful and leave a forged id without a trace.
+  it("rejects the request when any id is outside the class", () => {
+    const r = studentsInClass(roster, ["a", "zzz"])
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.offending).toEqual(["zzz"])
+  })
+
+  it("reports each offending id once", () => {
+    const r = studentsInClass(roster, ["zzz", "zzz", "yyy"])
+    if (!r.ok) expect(r.offending.sort()).toEqual(["yyy", "zzz"])
+  })
+})
+
+describe("rollsInScope", () => {
+  const admin: ImportActor = {
+    tier: "super_admin",
+    deptCodes: [],
+    classKeys: [],
+  }
+  const hod: ImportActor = { tier: "hod", deptCodes: ["EXCS"], classKeys: [] }
+  const tr: ImportActor = {
+    tier: "faculty",
+    deptCodes: [],
+    classKeys: ["2023-108-A"],
+  }
+
+  it("lets super_admin import anything", () => {
+    expect(rollsInScope(admin, ["23108A0001", "24101B0002"]).ok).toBe(true)
+  })
+
+  it("holds a TR to the classes they teach", () => {
+    expect(rollsInScope(tr, ["23108A0001"]).ok).toBe(true)
+    // same branch, different division
+    expect(rollsInScope(tr, ["23108B0001"]).ok).toBe(false)
+    // same division, different cohort
+    expect(rollsInScope(tr, ["24108A0001"]).ok).toBe(false)
+  })
+
+  it("holds an HOD to their department across cohorts", () => {
+    expect(rollsInScope(hod, ["23108A0001", "24108B0009"]).ok).toBe(true)
+    expect(rollsInScope(hod, ["23101A0001"]).ok).toBe(false) // IT
+  })
+
+  // 103 is the retired EXCS code; an older cohort still belongs to that HOD.
+  it("recognises the legacy branch code for the same department", () => {
+    expect(rollsInScope(hod, ["21103A0001"]).ok).toBe(true)
+  })
+
+  it("rejects a roll it cannot parse rather than admitting it unscoped", () => {
+    expect(rollsInScope(hod, ["nonsense"]).ok).toBe(false)
+    expect(rollsInScope(admin, ["nonsense"]).ok).toBe(true) // admin is unscoped
+  })
+
+  it("refuses a student or an unbound account outright", () => {
+    const student: ImportActor = {
+      tier: "student",
+      deptCodes: [],
+      classKeys: [],
+    }
+    expect(rollsInScope(student, ["23108A0001"]).ok).toBe(false)
+    expect(
+      rollsInScope({ tier: null, deptCodes: [], classKeys: [] }, ["23108A0001"])
+        .ok
+    ).toBe(false)
+  })
+
+  // A DSY roll folds back a year, so scope must be judged on the folded key.
+  it("scopes a diploma-entry roll to the cohort it actually joins", () => {
+    expect(rollsInScope(tr, ["24108A2001"]).ok).toBe(true)
+  })
+})
+
+// A repeater is admitted a year early and carries an explicit class_key
+// override, which the schema names as the one case a roll cannot express.
+// Judging them by the roll alone would refuse their own teacher's import.
+describe("rollsInScope with a stored class key", () => {
+  const tr: ImportActor = {
+    tier: "faculty",
+    deptCodes: [],
+    classKeys: ["2023-108-A"],
+  }
+
+  it("uses the stored key over the one the roll derives", () => {
+    // 22108A0034 derives 2022-108-A but actually sits in 2023-108-A.
+    expect(rollsInScope(tr, ["22108A0034"]).ok).toBe(false)
+    expect(
+      rollsInScope(tr, ["22108A0034"], new Map([["22108A0034", "2023-108-A"]]))
+        .ok
+    ).toBe(true)
+  })
+
+  it("still refuses a stored key outside scope", () => {
+    expect(
+      rollsInScope(tr, ["22108A0034"], new Map([["22108A0034", "2024-108-A"]]))
+        .ok
+    ).toBe(false)
+  })
+
+  it("falls back to the roll for a student who does not exist yet", () => {
+    expect(rollsInScope(tr, ["23108A0500"], new Map()).ok).toBe(true)
+  })
+})

--- a/src/lib/scope.ts
+++ b/src/lib/scope.ts
@@ -1,0 +1,108 @@
+// The scoped-write boundary.
+//
+// Every academic write names rows the caller did not necessarily choose: a
+// marks payload carries student ids, an import carries roll numbers. Checking
+// that the CALLER may act on the class is not enough — the payload must also
+// only name students who belong to it. Without that, a teacher legitimately
+// holding one class can attach marks, lab batches or roster rows to students in
+// another.
+//
+// Rejecting the whole request beats silently dropping the offending ids.
+// Dropping produces a partial write that looks successful, so a forged payload
+// leaves no trace and a genuine bug looks like data that quietly went missing.
+
+import { classKeyFromRoll } from "@/lib/class-key"
+import { BRANCH_CODES } from "@/lib/roll-number"
+
+export type ScopeResult =
+  | { ok: true }
+  | { ok: false; reason: string; offending: string[] }
+
+/**
+ * Every id must belong to the class. `roster` is the set of student ids derived
+ * from the class key, which is the only definition of membership VERP has.
+ */
+export function studentsInClass(
+  roster: Set<string>,
+  studentIds: string[]
+): ScopeResult {
+  const offending = [...new Set(studentIds)].filter((id) => !roster.has(id))
+  if (offending.length === 0) return { ok: true }
+  return {
+    ok: false,
+    reason:
+      offending.length === 1
+        ? "One of the students is not in this class."
+        : `${offending.length} of the students are not in this class.`,
+    offending,
+  }
+}
+
+export type ImportActor = {
+  tier: "super_admin" | "hod" | "faculty" | "student" | null
+  deptCodes: string[]
+  classKeys: string[]
+}
+
+/**
+ * Which roll numbers this person may create or update.
+ *
+ * The roll is the authority, not the department and division typed alongside
+ * it: those are descriptive columns a forged payload controls, while the roll
+ * encodes the cohort and cannot disagree with itself. Anything that will not
+ * parse is rejected rather than admitted unscoped.
+ */
+export function rollsInScope(
+  user: ImportActor,
+  rollNumbers: string[],
+  /**
+   * roll -> the class_key already stored for that student, where one exists.
+   *
+   * The roll usually derives its own cohort, but not always: a repeater is
+   * admitted a year early and carries an explicit override, which the schema
+   * calls out as the one case the roll cannot express. Judging such a student
+   * only by their roll would put them outside the very class they sit in, and
+   * refuse their own teacher's import. Where a stored key exists it is the
+   * authority; the derived key is the fallback for someone new.
+   */
+  storedKeys: ReadonlyMap<string, string | null> = new Map()
+): ScopeResult {
+  if (user.tier === "super_admin") return { ok: true }
+  if (user.tier !== "hod" && user.tier !== "faculty") {
+    return { ok: false, reason: "You cannot import students.", offending: [] }
+  }
+
+  const offending: string[] = []
+  for (const roll of rollNumbers) {
+    const stored = storedKeys.get(roll.trim().toUpperCase())
+    let key: string
+    if (stored) {
+      key = stored
+    } else {
+      try {
+        key = classKeyFromRoll(roll)
+      } catch {
+        offending.push(roll)
+        continue
+      }
+    }
+    if (user.tier === "faculty") {
+      // A TR may only import into the classes they hold.
+      if (!user.classKeys.includes(key)) offending.push(roll)
+      continue
+    }
+    // An HOD owns a department, so the branch inside the key decides. Read via
+    // BRANCH_CODES rather than the forward map: it also carries the legacy EXCS
+    // code 103, and an old cohort's roll must not fall outside its own HOD.
+    const branch = key.split("-")[1]
+    const dept = branch ? BRANCH_CODES[branch] : undefined
+    if (!dept || !user.deptCodes.includes(dept)) offending.push(roll)
+  }
+
+  if (offending.length === 0) return { ok: true }
+  return {
+    ok: false,
+    reason: `${offending.length} roll number${offending.length === 1 ? " is" : "s are"} outside your scope.`,
+    offending: offending.slice(0, 10),
+  }
+}


### PR DESCRIPTION
## What

Closes both **P0** findings from `research/verp-rbac-ux-audit-2026-08-13.md`. Both were reachable by an ordinary authenticated teacher; I confirmed each against the code before fixing.

## P0-1 — roster import created students anywhere

`api/students/import/route.ts` checked `isStaff(user)` and nothing else (`grep` for `deptCodes|classKeys|classIds` returned **0**), then trusted the `department`, `division` and roll in each row. A TR holding one class could post a payload creating students for another department. **Import roster** is linked for every faculty user, so this wasn't an unreachable path.

Scope is now judged on the **roll number**, never on the department and division sent beside it — those are descriptive fields the payload controls, while the roll encodes the cohort and cannot disagree with itself. super_admin unscoped; HOD held to their department across cohorts; TR to the classes they hold.

## P0-2 — marks and lab batches accepted students from other classes

`saveMarksAction` and `assignBatchAction` verified the caller's authority over the *subject*, then mapped every submitted `studentId` straight into the write. Neither intersected the ids with the class roster, and no DB constraint ties a mark to the offering's class — so a teacher could attach marks from their own subject to a student in another division, where `getMarksForStudent` reads by student id alone and would surface it in that student's record.

Attendance already filtered against the roster, but **dropped forged ids silently**. All three now refuse the whole request: a refusal leaves a trace, a silent drop leaves neither evidence of an attack nor a symptom of a bug.

The rule lives in `lib/scope.ts` with tests, rather than inline — it was already applied inconsistently across the three paths that needed it.

## The bug my own fix introduced

The first draft **rejected a legitimate import**, caught by verifying against real data rather than trusting the tests.

A repeater is admitted a year early and carries an explicit `class_key` override — the schema names this as the one case a roll cannot express. `22108A0034` derives `2022-108-A` but sits in `2023-108-A`, so judging by the roll alone put them outside the very class they're in, and refused their own teacher's import.

Where a student already exists, their **stored key is the authority**; the derived key is the fallback for someone new. The route reuses the roll lookup it was already doing, so this costs no extra query.

## Verification against the live database

```
class 2023-108-A: 89 students, repeater sample 22108A0034

P0-1 roster import
   TR, own class                 ok=true    want true
   TR, repeater in own class     ok=true    want true
   TR, student of another class  ok=false   want false
   TR, another department        ok=false   want false
   HOD, both cohorts             ok=true    want true
   HOD, into IT                  ok=false   want false

P0-2 marks / batch payload
   own students only             ok=true    want true
   outsider smuggled in          ok=false   want false
```

- [x] `npm run check` passes (0 errors; 2 pre-existing warnings) — **94 tests**, 14 new in `scope.test.ts`
- [x] `npm run build` passes

## Not in this PR

The audit's P1s and P2s: coordinator/HOD capability reconciliation, attendance defaulting to 100% present, unscoped dashboard counts, the hydration error, `__all` filter labels, and the docs rewrite. The audit's own ordering puts the scope escapes first, and they shouldn't wait behind the rest.
