### PR TITLE
feat(ui): role-specific overview command centre

### DIFF
--- a/src/app/dashboard/overview-cards.tsx
+++ b/src/app/dashboard/overview-cards.tsx
@@ -1,0 +1,141 @@
+import Link from "next/link"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import { buttonVariants } from "@/components/ui/button-variants"
+import { cn } from "@/lib/utils"
+
+/**
+ * The overview's vocabulary.
+ *
+ * Every tile answers "what needs me", so each carries a count, what it means,
+ * and a link to the exact filtered workspace that resolves it. A number with no
+ * action behind it was what the old dashboard offered, and nobody could use it.
+ */
+
+export function Attention({
+  count,
+  label,
+  href,
+  tone = "attention",
+}: {
+  count: number
+  label: string
+  href: string
+  tone?: "attention" | "critical" | "neutral"
+}) {
+  // Colour never carries the meaning alone — the count and the label do.
+  const toneClass =
+    count === 0
+      ? "text-muted-foreground"
+      : tone === "critical"
+        ? "text-destructive"
+        : tone === "attention"
+          ? "text-amber-600"
+          : "text-foreground"
+  return (
+    <Link
+      href={href}
+      className="border-border hover:bg-muted/50 flex items-center justify-between gap-3 rounded border px-3 py-2 transition-colors"
+    >
+      <span className="text-sm">{label}</span>
+      <span className={cn("text-sm font-semibold tabular-nums", toneClass)}>
+        {count}
+      </span>
+    </Link>
+  )
+}
+
+export function Stat({
+  label,
+  value,
+  hint,
+}: {
+  label: string
+  value: string
+  hint?: string
+}) {
+  return (
+    <div className="border-border rounded border p-4">
+      <p className="text-muted-foreground text-sm">{label}</p>
+      <p className="mt-1 text-2xl font-semibold tabular-nums">{value}</p>
+      {hint && <p className="text-muted-foreground mt-0.5 text-xs">{hint}</p>}
+    </div>
+  )
+}
+
+export function WorkCard({
+  title,
+  subtitle,
+  href,
+  action,
+  children,
+}: {
+  title: React.ReactNode
+  subtitle?: string
+  href?: string
+  action?: { label: string; href: string }
+  children?: React.ReactNode
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
+        <div className="min-w-0">
+          <CardTitle className="text-base">
+            {href ? (
+              <Link href={href} className="hover:underline">
+                {title}
+              </Link>
+            ) : (
+              title
+            )}
+          </CardTitle>
+          {subtitle && (
+            <p className="text-muted-foreground mt-0.5 text-xs">{subtitle}</p>
+          )}
+        </div>
+        {action && (
+          <Link
+            href={action.href}
+            className={buttonVariants({ variant: "outline", size: "sm" })}
+          >
+            {action.label}
+          </Link>
+        )}
+      </CardHeader>
+      {children && <CardContent className="pt-0">{children}</CardContent>}
+    </Card>
+  )
+}
+
+/** "63 of 89 marked" — progress a person can act on, not a percentage alone. */
+export function Completion({
+  done,
+  total,
+  noun,
+}: {
+  done: number
+  total: number
+  noun: string
+}) {
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-muted-foreground">
+          {done} of {total} {noun}
+        </span>
+        {total > 0 && done === total ? (
+          <Badge variant="outline">Complete</Badge>
+        ) : (
+          <span className="text-muted-foreground tabular-nums">{pct}%</span>
+        )}
+      </div>
+      <Progress value={pct} className="h-1.5" />
+    </div>
+  )
+}
+
+export function EmptyHint({ children }: { children: React.ReactNode }) {
+  return <p className="text-muted-foreground text-sm">{children}</p>
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,186 +1,290 @@
 import { redirect } from "next/navigation"
-import { sql } from "drizzle-orm"
 import { PageHeader } from "@/components/page-header"
 import { getSessionUser } from "@/lib/session"
+import { expectedYear } from "@/lib/roll-number"
+import { computeMarks, computeSgpi } from "@/lib/sgpi"
 import { getAttendanceSummaryForStudent } from "@/db/queries/attendance"
 import { getMarksForStudent } from "@/db/queries/marks"
-import { computeMarks, computeSgpi } from "@/lib/sgpi"
-import { Badge } from "@/components/ui/badge"
-import { db } from "@/db"
-import * as schema from "@/db/schema"
+import { getClassWork, getDeptHealth } from "@/db/queries/overview"
+import { listDepartments } from "@/db/queries/departments"
+import {
+  Attention,
+  Completion,
+  EmptyHint,
+  Stat,
+  WorkCard,
+} from "./overview-cards"
 
 export const dynamic = "force-dynamic"
 
-// Honest overview. Real counts, no fabricated numbers, no demo chart — the
-// role-specific dashboards (console / dept / class / student) replace this as
-// each ships. The layout already redirects unbound users to the pending screen.
 export default async function DashboardPage() {
   const user = await getSessionUser()
   if (!user) redirect("/login")
 
-  const staff =
-    user.tier === "super_admin" ||
-    user.tier === "hod" ||
-    user.tier === "faculty"
+  const now = new Date()
+  // The college's date, not UTC: toISOString() rolls over at 05:30 IST and
+  // would open tomorrow's register during an early-morning lecture.
+  const today = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Kolkata",
+  }).format(now)
 
-  const active = sql`is_active`
-  const c = sql<number>`count(*)::int`
-  const cards = staff
-    ? await Promise.all([
-        db
-          .select({ c })
-          .from(schema.departments)
-          .where(active)
-          .then((r) => ({ label: "Departments", value: r[0]?.c ?? 0 })),
-        db
-          .select({ c })
-          .from(schema.classes)
-          .where(active)
-          .then((r) => ({ label: "Classes", value: r[0]?.c ?? 0 })),
-        db
-          .select({ c })
-          .from(schema.students)
-          .where(active)
-          .then((r) => ({ label: "Students", value: r[0]?.c ?? 0 })),
-        db
-          .select({ c })
-          .from(schema.faculty)
-          .where(active)
-          .then((r) => ({ label: "Faculty", value: r[0]?.c ?? 0 })),
-      ])
-    : []
+  if (user.tier === "student") {
+    return <StudentOverview userId={user.studentId} name={user.name} />
+  }
 
-  // A student sees their own attendance.
-  const att =
-    user.tier === "student" && user.studentId
-      ? await getAttendanceSummaryForStudent(user.studentId)
-      : null
-  const attPct =
-    att && att.total > 0 ? Math.round((att.present / att.total) * 100) : null
+  const isAdmin = user.tier === "super_admin"
+  const deptCodes = isAdmin
+    ? (await listDepartments()).filter((d) => d.isActive).map((d) => d.code)
+    : user.deptCodes
 
-  // A student's marks across every subject, with per-subject grade and SGPI.
-  const marksRows =
-    user.tier === "student" && user.studentId
-      ? await getMarksForStudent(user.studentId)
-      : []
-  const marks = marksRows.map((m) => {
-    const course = m.courseOffering.course
-    return { mark: m, course, computed: computeMarks(m, course) }
-  })
-  const sgpi = computeSgpi(
-    marks.map(({ mark, course }) => ({ marks: mark, course }))
-  )
+  // A TR sees the classes they hold; an HOD sees their department's health.
+  // Neither is shown a number covering ground they cannot act on.
+  const [work, health] = await Promise.all([
+    getClassWork(user.classIds, user.facultyId, today),
+    deptCodes.length ? getDeptHealth(deptCodes) : Promise.resolve([]),
+  ])
+
+  const label = (c: {
+    admissionYear: number
+    departmentCode: string
+    division: string
+  }) =>
+    `${expectedYear(c.admissionYear, now) ?? c.admissionYear} · ${c.departmentCode} · ${c.division}`
 
   return (
     <>
-      <PageHeader title="Dashboard" />
+      <PageHeader title="Overview" />
       <div className="@container/main flex flex-1 flex-col gap-6 p-4 lg:p-6">
         <div>
           <h2 className="text-lg font-semibold tracking-tight">
-            Welcome, {user.name || user.email}
+            {user.name || user.email}
           </h2>
           <p className="text-muted-foreground mt-1 text-sm">
-            {staff
-              ? "Your workspace across VERP."
-              : "Your attendance and marks."}
+            {work.length > 0
+              ? "Your teaching work for today."
+              : health.length > 0
+                ? "Your department's academic health."
+                : "Nothing is assigned to you yet."}
           </p>
         </div>
 
-        {staff && (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            {cards.map((c) => (
-              <div
-                key={c.label}
-                className="border-border bg-card rounded border p-5"
-              >
-                <p className="text-muted-foreground text-sm">{c.label}</p>
-                <p className="mt-2 text-3xl font-bold tracking-tight">
-                  {c.value}
-                </p>
-              </div>
-            ))}
-          </div>
+        {health.length > 0 && (
+          <section className="flex flex-col gap-3">
+            <h3 className="text-sm font-semibold">
+              {isAdmin ? "Departments" : "My department"}
+            </h3>
+            <div className="grid gap-4 lg:grid-cols-2">
+              {health.map((d) => (
+                <WorkCard
+                  key={d.code}
+                  title={`${d.code} — ${d.name}`}
+                  subtitle={d.hod ? `HOD: ${d.hod}` : "No HOD appointed"}
+                  href={`/dashboard/dept/${d.code}`}
+                  action={{ label: "Open", href: `/dashboard/dept/${d.code}` }}
+                >
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <Attention
+                      count={d.classesWithoutCoordinator}
+                      label="Classes without a coordinator"
+                      href="/dashboard/dept"
+                      tone="critical"
+                    />
+                    <Attention
+                      count={d.unallocatedSubjects}
+                      label="Subjects with no teacher"
+                      href="/dashboard/dept/appoint"
+                    />
+                    <Attention
+                      count={d.unclaimedStudents}
+                      label="Students yet to sign in"
+                      href="/dashboard/students"
+                      tone="neutral"
+                    />
+                    <Attention
+                      count={d.classes}
+                      label="Active classes"
+                      href="/dashboard/dept"
+                      tone="neutral"
+                    />
+                  </div>
+                </WorkCard>
+              ))}
+            </div>
+          </section>
         )}
 
-        {user.tier === "student" && (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <div className="border-border bg-card rounded border p-5">
-              <p className="text-muted-foreground text-sm">Attendance</p>
-              {attPct === null ? (
-                <p className="text-muted-foreground mt-2 text-sm">
-                  No sessions recorded yet.
-                </p>
-              ) : (
-                <>
-                  <p className="mt-2 text-3xl font-bold tracking-tight">
-                    {attPct}%
-                  </p>
-                  <p className="text-muted-foreground mt-1 text-xs">
-                    {att!.present} of {att!.total} sessions present
-                  </p>
-                </>
-              )}
-            </div>
-            <div className="border-border bg-card rounded border p-5">
-              <p className="text-muted-foreground text-sm">SGPI</p>
-              {sgpi.sgpi === null ? (
-                <p className="text-muted-foreground mt-2 text-sm">
-                  Appears once your marks are recorded.
-                </p>
-              ) : (
-                <>
-                  <p className="mt-2 text-3xl font-bold tracking-tight">
-                    {sgpi.hasFail ? "—" : sgpi.sgpi.toFixed(2)}
-                  </p>
-                  <p className="text-muted-foreground mt-1 text-xs">
-                    {sgpi.hasFail
-                      ? "Held — clear all subjects to compute"
-                      : `${sgpi.totalCredits} credits`}
-                  </p>
-                </>
-              )}
-            </div>
-          </div>
-        )}
-
-        {user.tier === "student" && marks.length > 0 && (
-          <div className="border-border bg-card overflow-x-auto rounded border">
-            <table className="w-full text-sm">
-              <thead className="bg-muted/50 text-muted-foreground text-xs">
-                <tr className="[&>th]:px-4 [&>th]:py-2.5 [&>th]:text-left [&>th]:font-medium">
-                  <th>Code</th>
-                  <th>Subject</th>
-                  <th className="w-16">Total</th>
-                  <th className="w-16">%</th>
-                  <th className="w-16">Grade</th>
-                </tr>
-              </thead>
-              <tbody className="divide-border divide-y">
-                {marks.map(({ mark, course, computed }) => (
-                  <tr key={mark.id} className="[&>td]:px-4 [&>td]:py-2.5">
-                    <td className="font-mono text-xs">{course.courseCode}</td>
-                    <td>{course.courseName}</td>
-                    <td className="tabular-nums">
-                      {computed.total} / {course.maxTotal}
-                    </td>
-                    <td className="text-muted-foreground tabular-nums">
-                      {computed.percentage ?? "—"}
-                    </td>
-                    <td>
-                      {computed.gradePoint == null ? (
-                        <span className="text-muted-foreground">—</span>
-                      ) : computed.gradePoint === "Fail" ? (
-                        <Badge variant="destructive">Fail</Badge>
-                      ) : (
-                        <Badge variant="outline">{computed.gradePoint}</Badge>
+        {work.length > 0 && (
+          <section className="flex flex-col gap-3">
+            <h3 className="text-sm font-semibold">My classes</h3>
+            <div className="grid gap-4 lg:grid-cols-2">
+              {work.map((c) => (
+                <WorkCard
+                  key={c.classId}
+                  title={label(c)}
+                  subtitle={
+                    c.role === "academic_coordinator"
+                      ? `Coordinator · ${c.classKey}`
+                      : `Teacher · ${c.classKey}`
+                  }
+                  href={`/dashboard/class/${c.classId}`}
+                  action={{
+                    label: "Take attendance",
+                    href: `/dashboard/class/${c.classId}/attendance`,
+                  }}
+                >
+                  <div className="flex flex-col gap-3">
+                    <Completion
+                      done={c.markedToday}
+                      total={c.students}
+                      noun="marked today"
+                    />
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      <Attention
+                        count={c.pendingRequests}
+                        label="Enrolment requests"
+                        href={`/dashboard/class/${c.classId}`}
+                      />
+                      {c.role === "academic_coordinator" && (
+                        <Attention
+                          count={c.unallocatedSubjects}
+                          label="Subjects with no teacher"
+                          href={`/dashboard/class/${c.classId}/subjects`}
+                        />
                       )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                    </div>
+
+                    {c.mySubjects.length === 0 ? (
+                      <EmptyHint>
+                        No subjects allocated to you on this class.
+                      </EmptyHint>
+                    ) : (
+                      <div className="flex flex-col gap-1.5">
+                        <p className="text-muted-foreground text-xs">
+                          My subjects
+                        </p>
+                        {c.mySubjects.map((s) => (
+                          <div
+                            key={s.id}
+                            className="flex items-center justify-between gap-2 text-sm"
+                          >
+                            <span className="truncate">
+                              <span className="font-mono text-xs">
+                                {s.code}
+                              </span>{" "}
+                              {s.name}
+                            </span>
+                            <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+                              {s.entered} of {c.students} entered
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </WorkCard>
+              ))}
+            </div>
+          </section>
         )}
+
+        {work.length === 0 && health.length === 0 && (
+          <EmptyHint>
+            No classes are assigned to you. Ask your HOD to add you to a class.
+          </EmptyHint>
+        )}
+      </div>
+    </>
+  )
+}
+
+async function StudentOverview({
+  userId,
+  name,
+}: {
+  userId: string | null
+  name: string
+}) {
+  const att = userId ? await getAttendanceSummaryForStudent(userId) : null
+  const attPct =
+    att && att.total > 0 ? Math.round((att.present / att.total) * 100) : null
+
+  const rows = userId ? await getMarksForStudent(userId) : []
+  const marks = rows.map((m) => ({
+    mark: m,
+    course: m.courseOffering.course,
+    computed: computeMarks(m, m.courseOffering.course),
+  }))
+  const sgpi = computeSgpi(
+    marks.map(({ mark, course }) => ({ marks: mark, course }))
+  )
+  // A subject with no grade yet is in progress, not zero. The old dashboard
+  // showed 0/75 for the same subject My marks showed as "—".
+  const graded = marks.filter((m) => m.computed.gradePoint != null).length
+
+  return (
+    <>
+      <PageHeader title="Overview" />
+      <div className="@container/main flex flex-1 flex-col gap-6 p-4 lg:p-6">
+        <div>
+          <h2 className="text-lg font-semibold tracking-tight">{name}</h2>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Your attendance and results.
+          </p>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-3">
+          <Stat
+            label="Attendance"
+            value={attPct === null ? "—" : `${attPct}%`}
+            hint={
+              att && att.total > 0
+                ? `${att.present} of ${att.total} sessions present`
+                : "No sessions recorded yet"
+            }
+          />
+          <Stat
+            label="SGPI"
+            value={
+              sgpi.sgpi === null || sgpi.hasFail ? "—" : sgpi.sgpi.toFixed(2)
+            }
+            hint={
+              sgpi.hasFail
+                ? "Held until every subject is cleared"
+                : sgpi.sgpi === null
+                  ? "Appears once results are complete"
+                  : `${sgpi.totalCredits} credits`
+            }
+          />
+          <Stat
+            label="Subjects"
+            value={String(marks.length)}
+            hint={
+              marks.length === 0
+                ? "None yet"
+                : `${graded} graded · ${marks.length - graded} in progress`
+            }
+          />
+        </div>
+
+        <WorkCard
+          title="My marks"
+          subtitle="Component breakdown for every subject"
+          href="/dashboard/my-marks"
+          action={{ label: "Open", href: "/dashboard/my-marks" }}
+        >
+          {marks.length === 0 ? (
+            <EmptyHint>
+              No marks recorded yet. They appear here once your teachers enter
+              them.
+            </EmptyHint>
+          ) : (
+            <Completion
+              done={graded}
+              total={marks.length}
+              noun="subjects graded"
+            />
+          )}
+        </WorkCard>
       </div>
     </>
   )

--- a/src/db/queries/overview.ts
+++ b/src/db/queries/overview.ts
@@ -1,0 +1,302 @@
+// Scoped data for the role-specific overview.
+//
+// The dashboard used to run four unscoped counts — departments, classes,
+// students, faculty — and show the same institution-wide totals to everyone. A
+// TR who can open one class was told there are 168 students, which is both a
+// scope leak and useless: a number nobody can act on is not information.
+//
+// Everything here is filtered by the caller's own scope and answers "what needs
+// me today" rather than "how big is the college".
+
+import { and, eq, inArray, isNull, sql } from "drizzle-orm"
+import { db } from "@/db"
+import {
+  classes,
+  courseOfferings,
+  courses,
+  enrollmentRequests,
+  faculty,
+  facultyClassAssignments,
+  attendance as attendanceTable,
+  marks as marksTable,
+  students,
+  departments,
+  deptAppointments,
+} from "@/db/schema"
+
+export type ClassWork = {
+  classId: string
+  classKey: string
+  admissionYear: number
+  division: string
+  departmentCode: string
+  role: "academic_coordinator" | "tr" | "hod" | "admin"
+  students: number
+  pendingRequests: number
+  markedToday: number
+  mySubjects: { id: string; code: string; name: string; entered: number }[]
+  unallocatedSubjects: number
+}
+
+/**
+ * The classes this person is responsible for, each with the work outstanding on
+ * it. `facultyId` null means an unscoped viewer (super-admin) and the caller is
+ * expected to have narrowed `classIds` already.
+ */
+export async function getClassWork(
+  classIds: string[],
+  facultyId: string | null,
+  today: string
+): Promise<ClassWork[]> {
+  if (classIds.length === 0) return []
+
+  const rows = await db
+    .select()
+    .from(classes)
+    .where(inArray(classes.id, classIds))
+
+  const [staff, offerings, requests] = await Promise.all([
+    db
+      .select({
+        classId: facultyClassAssignments.classId,
+        facultyId: facultyClassAssignments.facultyId,
+        role: facultyClassAssignments.role,
+      })
+      .from(facultyClassAssignments)
+      .where(
+        and(
+          inArray(facultyClassAssignments.classId, classIds),
+          eq(facultyClassAssignments.isActive, true)
+        )
+      ),
+    db
+      .select({
+        id: courseOfferings.id,
+        classId: courseOfferings.classId,
+        facultyId: courseOfferings.facultyId,
+        code: courses.courseCode,
+        name: courses.courseName,
+      })
+      .from(courseOfferings)
+      .innerJoin(courses, eq(courseOfferings.courseId, courses.id))
+      .where(
+        and(
+          inArray(courseOfferings.classId, classIds),
+          eq(courseOfferings.isActive, true)
+        )
+      ),
+    db
+      .select({
+        classId: enrollmentRequests.classId,
+        n: sql<number>`count(*)::int`,
+      })
+      .from(enrollmentRequests)
+      .where(
+        and(
+          inArray(enrollmentRequests.classId, classIds),
+          eq(enrollmentRequests.status, "pending")
+        )
+      )
+      .groupBy(enrollmentRequests.classId),
+  ])
+
+  const offeringIds = offerings.map((o) => o.id)
+  const [rosterCounts, markCounts, todayMarked] = await Promise.all([
+    db
+      .select({ classKey: students.classKey, n: sql<number>`count(*)::int` })
+      .from(students)
+      .where(
+        and(
+          eq(students.isActive, true),
+          inArray(
+            students.classKey,
+            rows.map((r) => r.classKey)
+          )
+        )
+      )
+      .groupBy(students.classKey),
+    offeringIds.length
+      ? db
+          .select({
+            offeringId: marksTable.courseOfferingId,
+            n: sql<number>`count(*)::int`,
+          })
+          .from(marksTable)
+          .where(inArray(marksTable.courseOfferingId, offeringIds))
+          .groupBy(marksTable.courseOfferingId)
+      : Promise.resolve([]),
+    db
+      .select({
+        classId: attendanceTable.classId,
+        n: sql<number>`count(*)::int`,
+      })
+      .from(attendanceTable)
+      .where(
+        and(
+          inArray(attendanceTable.classId, classIds),
+          eq(attendanceTable.sessionDate, today)
+        )
+      )
+      .groupBy(attendanceTable.classId),
+  ])
+
+  const num = <T extends { n: number }>(
+    list: T[],
+    pick: (t: T) => string | null
+  ) => new Map(list.map((x) => [pick(x) ?? "", x.n]))
+  const roster = num(rosterCounts, (r) => r.classKey)
+  const marked = num(todayMarked, (r) => r.classId)
+  const pending = num(requests, (r) => r.classId)
+  const entered = num(markCounts, (r) => r.offeringId)
+
+  return rows.map((c) => {
+    const mine = offerings.filter(
+      (o) =>
+        o.classId === c.id && (facultyId === null || o.facultyId === facultyId)
+    )
+    const isCoord = staff.some(
+      (s) =>
+        s.classId === c.id &&
+        s.facultyId === facultyId &&
+        s.role === "academic_coordinator"
+    )
+    return {
+      classId: c.id,
+      classKey: c.classKey,
+      admissionYear: c.admissionYear,
+      division: c.division,
+      departmentCode: c.departmentCode,
+      role:
+        facultyId === null ? "admin" : isCoord ? "academic_coordinator" : "tr",
+      students: roster.get(c.classKey) ?? 0,
+      pendingRequests: pending.get(c.id) ?? 0,
+      markedToday: marked.get(c.id) ?? 0,
+      mySubjects: mine.map((o) => ({
+        id: o.id,
+        code: o.code,
+        name: o.name,
+        entered: entered.get(o.id) ?? 0,
+      })),
+      unallocatedSubjects: offerings.filter(
+        (o) => o.classId === c.id && o.facultyId === null
+      ).length,
+    }
+  })
+}
+
+export type DeptHealth = {
+  code: string
+  name: string
+  hod: string | null
+  classes: number
+  classesWithoutCoordinator: number
+  faculty: number
+  students: number
+  unclaimedStudents: number
+  unallocatedSubjects: number
+}
+
+/** Department health for an HOD or super-admin, scoped to the codes given. */
+export async function getDeptHealth(
+  deptCodes: string[]
+): Promise<DeptHealth[]> {
+  if (deptCodes.length === 0) return []
+
+  const [depts, cls, fac, stu, appts] = await Promise.all([
+    db.select().from(departments).where(inArray(departments.code, deptCodes)),
+    db
+      .select()
+      .from(classes)
+      .where(
+        and(
+          inArray(classes.departmentCode, deptCodes),
+          eq(classes.isActive, true)
+        )
+      ),
+    db
+      .select({ department: faculty.department, n: sql<number>`count(*)::int` })
+      .from(faculty)
+      .where(
+        and(inArray(faculty.department, deptCodes), eq(faculty.isActive, true))
+      )
+      .groupBy(faculty.department),
+    db
+      .select({
+        department: students.department,
+        n: sql<number>`count(*)::int`,
+        unclaimed: sql<number>`count(*) filter (where ${students.authUserId} is null)::int`,
+      })
+      .from(students)
+      .where(
+        and(
+          inArray(students.department, deptCodes),
+          eq(students.isActive, true)
+        )
+      )
+      .groupBy(students.department),
+    db
+      .select({
+        deptCode: deptAppointments.deptCode,
+        first: faculty.firstName,
+        last: faculty.lastName,
+      })
+      .from(deptAppointments)
+      .innerJoin(faculty, eq(deptAppointments.facultyId, faculty.id))
+      .where(
+        and(
+          inArray(deptAppointments.deptCode, deptCodes),
+          eq(deptAppointments.appointment, "hod"),
+          eq(deptAppointments.isActive, true)
+        )
+      ),
+  ])
+
+  const classIds = cls.map((c) => c.id)
+  const [coords, unallocated] = await Promise.all([
+    classIds.length
+      ? db
+          .select({ classId: facultyClassAssignments.classId })
+          .from(facultyClassAssignments)
+          .where(
+            and(
+              inArray(facultyClassAssignments.classId, classIds),
+              eq(facultyClassAssignments.role, "academic_coordinator"),
+              eq(facultyClassAssignments.isActive, true)
+            )
+          )
+      : Promise.resolve([]),
+    classIds.length
+      ? db
+          .select({ classId: courseOfferings.classId })
+          .from(courseOfferings)
+          .where(
+            and(
+              inArray(courseOfferings.classId, classIds),
+              eq(courseOfferings.isActive, true),
+              isNull(courseOfferings.facultyId)
+            )
+          )
+      : Promise.resolve([]),
+  ])
+
+  const withCoord = new Set(coords.map((c) => c.classId))
+  return depts.map((d) => {
+    const mine = cls.filter((c) => c.departmentCode === d.code)
+    const s = stu.find((x) => x.department === d.code)
+    const a = appts.find((x) => x.deptCode === d.code)
+    return {
+      code: d.code,
+      name: d.name,
+      hod: a ? `${a.first} ${a.last}`.trim() : null,
+      classes: mine.length,
+      classesWithoutCoordinator: mine.filter((c) => !withCoord.has(c.id))
+        .length,
+      faculty: fac.find((x) => x.department === d.code)?.n ?? 0,
+      students: s?.n ?? 0,
+      unclaimedStudents: s?.unclaimed ?? 0,
+      unallocatedSubjects: unallocated.filter((u) =>
+        mine.some((c) => c.id === u.classId)
+      ).length,
+    }
+  })
+}


### PR DESCRIPTION
## What

Phase 2a of the redesign: `/dashboard` becomes a different operational home per persona, per spec §6.3. Also closes the audit's P1 on unscoped counts.

## Why

The dashboard ran **four unscoped counts** — departments, classes, students, faculty — and served the same institution-wide totals to every staff tier. A TR who can open one class was told there are 168 students. That's a scope leak, and useless besides: a number nobody can act on isn't information.

## How

Every tile carries a count, what it means, and a link to the workspace that resolves it.

- **Teacher** — classes they hold, today's attendance progress, enrolment queue, and each subject allocated to them with how many students have marks
- **Coordinator** — the same, plus subjects on their class with no teacher
- **HOD / super-admin** — department health: classes with no coordinator, subjects with no teacher, students yet to sign in
- **Student** — attendance, SGPI, and how many subjects are graded versus in progress

Built on the vendored shadcn `Card`, `Badge` and `Progress`. Colour never carries meaning alone — the count and label do (spec §3.2).

## Two corrections that fall out of it

**Today is computed in the college's timezone**, not from `toISOString()` — which rolls over at 05:30 IST and would have opened tomorrow's register during an early-morning lecture. (Audit P1.)

**A subject with no grade reads "in progress"**, not the `0 / 75` the old dashboard showed for the same subject `My marks` rendered as `—`. (Audit P2, spec §6.22.)

## Verified against the live database

```
tr@vosslabs.org    classes=1  2023-108-A  role=tr           students=89  mySubjects=1 (EC33T, 89 entered)
ac@vosslabs.org    classes=1  2023-108-A  role=coordinator  students=89  mySubjects=0
dept health: EXCS  classes=1  withoutCoordinator=0  unallocatedSubjects=0  students=168  unclaimed=165
```

Each figure sits inside the viewer's own scope.

- [x] `npm run check` passes (0 errors; 2 pre-existing warnings), 104 tests
- [x] `npm run build` passes
