### PR TITLE
feat(ui): context trail, status tokens, tabbed class workspace

### DIFF
--- a/src/app/dashboard/class/[classId]/attendance/page.tsx
+++ b/src/app/dashboard/class/[classId]/attendance/page.tsx
@@ -1,5 +1,7 @@
 import { notFound, redirect } from "next/navigation"
 import { PageHeader } from "@/components/page-header"
+import { ClassTabs } from "../class-tabs"
+import { classTabs, classTrail } from "../class-context"
 import { getSessionUser } from "@/lib/session"
 import { can } from "@/lib/rbac"
 import { expectedYear } from "@/lib/roll-number"
@@ -27,6 +29,10 @@ export default async function AttendancePage({
 
   const cls = await getClassById(classId)
   if (!cls) return notFound()
+  const canAllocate =
+    user.tier === "super_admin" ||
+    (user.tier === "hod" && user.deptCodes.includes(cls.departmentCode)) ||
+    user.coordinatorClassIds.includes(classId)
   const inScope =
     user.tier === "super_admin" ||
     user.classIds.includes(classId) ||
@@ -50,10 +56,12 @@ export default async function AttendancePage({
     <>
       <PageHeader
         title={`Attendance — ${label}`}
+        trail={classTrail(cls, label)}
         parent="My classes"
         parentHref={`/dashboard/class/${classId}`}
       />
       <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
+        <ClassTabs tabs={classTabs(classId, user, { canAllocate })} />
         <AttendanceClient
           classId={classId}
           date={date}

--- a/src/app/dashboard/class/[classId]/batches/page.tsx
+++ b/src/app/dashboard/class/[classId]/batches/page.tsx
@@ -1,5 +1,7 @@
 import { notFound, redirect } from "next/navigation"
 import { PageHeader } from "@/components/page-header"
+import { ClassTabs } from "../class-tabs"
+import { classTabs, classTrail } from "../class-context"
 import { getSessionUser } from "@/lib/session"
 import { can } from "@/lib/rbac"
 import { expectedYear } from "@/lib/roll-number"
@@ -56,14 +58,17 @@ export default async function BatchesPage({
   ])
 
   const yr = expectedYear(cls.admissionYear, new Date()) ?? cls.admissionYear
+  const label = `${yr} · ${cls.departmentCode} · ${cls.division}`
   return (
     <>
       <PageHeader
         title={`Batches — ${yr} · ${cls.departmentCode} · ${cls.division}`}
+        trail={classTrail(cls, label)}
         parent="My classes"
         parentHref={`/dashboard/class/${classId}`}
       />
       <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
+        <ClassTabs tabs={classTabs(classId, user, { canAllocate })} />
         <BatchesClient
           classId={classId}
           offerings={offerings.map((o) => ({

--- a/src/app/dashboard/class/[classId]/class-context.ts
+++ b/src/app/dashboard/class/[classId]/class-context.ts
@@ -1,0 +1,88 @@
+import "server-only"
+import { notFound, redirect } from "next/navigation"
+import { expectedYear } from "@/lib/roll-number"
+import { getClassById } from "@/db/queries/classes"
+import { getSessionUser, type SessionUser } from "@/lib/session"
+import { can } from "@/lib/rbac"
+import type { TrailSegment } from "@/components/page-header"
+import type { ClassTab } from "./class-tabs"
+
+/**
+ * One resolution of "which class, and what may this person do in it".
+ *
+ * Every page under /dashboard/class/[classId] repeated the same four steps:
+ * resolve the session, load the class, recompute the same scope expression, and
+ * rebuild the same label. The expression drifted — the marks page and the
+ * subjects page spelled the coordinator check differently — so it lives here
+ * once and every surface reads the same answer.
+ */
+export async function requireClassContext(classId: string) {
+  const user = await getSessionUser()
+  if (!user) redirect("/login")
+
+  const cls = await getClassById(classId)
+  if (!cls) notFound()
+
+  const canAllocate =
+    user.tier === "super_admin" ||
+    (user.tier === "hod" && user.deptCodes.includes(cls.departmentCode)) ||
+    user.coordinatorClassIds.includes(classId)
+  const inScope = canAllocate || user.classIds.includes(classId)
+  if (!inScope) redirect("/dashboard/class")
+
+  const year = expectedYear(cls.admissionYear, new Date()) ?? cls.admissionYear
+  const label = `${year} · ${cls.departmentCode} · ${cls.division}`
+
+  return { user, cls, canAllocate, year, label }
+}
+
+/** VIT / EXCS / BE A — the scope this page operates in, spelled out. */
+export function classTrail(
+  cls: {
+    departmentCode: string
+  },
+  label: string
+): TrailSegment[] {
+  return [
+    { label: "VIT" },
+    {
+      label: cls.departmentCode,
+      href: `/dashboard/dept/${cls.departmentCode}`,
+    },
+    { label },
+  ]
+}
+
+export function classTabs(
+  classId: string,
+  user: SessionUser,
+  opts: { canAllocate: boolean; pendingRequests?: number }
+): ClassTab[] {
+  const tabs: ClassTab[] = [
+    {
+      label: "Overview",
+      href: `/dashboard/class/${classId}`,
+      badge: opts.pendingRequests,
+    },
+  ]
+  if (can(user, "offering:read")) {
+    tabs.push({
+      label: "Subjects",
+      href: `/dashboard/class/${classId}/subjects`,
+    })
+  }
+  if (can(user, "attendance:write") || can(user, "attendance:read")) {
+    tabs.push({
+      label: "Attendance",
+      href: `/dashboard/class/${classId}/attendance`,
+    })
+  }
+  if (can(user, "marks:write")) {
+    tabs.push({ label: "Marks", href: `/dashboard/class/${classId}/marks` })
+    tabs.push({ label: "Batches", href: `/dashboard/class/${classId}/batches` })
+  }
+  if (can(user, "marks:read")) {
+    tabs.push({ label: "Results", href: `/dashboard/class/${classId}/results` })
+  }
+  return tabs
+}

--- a/src/app/dashboard/class/[classId]/class-tabs.tsx
+++ b/src/app/dashboard/class/[classId]/class-tabs.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { cn } from "@/lib/utils"
+
+/**
+ * The class workspace's tab strip (spec 6.16).
+ *
+ * These were five outline buttons in a row that looked like actions rather than
+ * places, so nothing told you where you already were. Real routes rather than
+ * client tab state, because each surface loads its own scoped data on the
+ * server and a shared tab component would have to fetch all of it up front.
+ *
+ * A tab the viewer cannot open is omitted, not disabled: they have no way to
+ * gain the capability from here, so showing it is only a locked door.
+ */
+export type ClassTab = { label: string; href: string; badge?: number }
+
+export function ClassTabs({ tabs }: { tabs: ClassTab[] }) {
+  const pathname = usePathname()
+  return (
+    <nav
+      aria-label="Class sections"
+      className="border-border -mb-px flex gap-1 overflow-x-auto border-b"
+    >
+      {tabs.map((t) => {
+        // The overview is the class root, so it must match exactly or every
+        // child route would light it up too.
+        const active =
+          pathname === t.href ||
+          (t.href.split("/").length > 4 && pathname.startsWith(t.href))
+        return (
+          <Link
+            key={t.href}
+            href={t.href}
+            aria-current={active ? "page" : undefined}
+            className={cn(
+              "flex shrink-0 items-center gap-1.5 border-b-2 px-3 py-2 text-sm transition-colors",
+              active
+                ? "border-foreground text-foreground font-medium"
+                : "text-muted-foreground hover:text-foreground border-transparent"
+            )}
+          >
+            {t.label}
+            {t.badge != null && t.badge > 0 && (
+              <span className="bg-attention text-attention-foreground rounded-full px-1.5 py-0.5 text-[0.6875rem] leading-none tabular-nums">
+                {t.badge}
+              </span>
+            )}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/app/dashboard/class/[classId]/marks/page.tsx
+++ b/src/app/dashboard/class/[classId]/marks/page.tsx
@@ -1,5 +1,7 @@
 import { notFound, redirect } from "next/navigation"
 import { PageHeader } from "@/components/page-header"
+import { ClassTabs } from "../class-tabs"
+import { classTabs, classTrail } from "../class-context"
 import { getSessionUser } from "@/lib/session"
 import { can } from "@/lib/rbac"
 import { expectedYear } from "@/lib/roll-number"
@@ -94,10 +96,12 @@ export default async function MarksPage({
     <>
       <PageHeader
         title={`Marks — ${label}`}
+        trail={classTrail(cls, label)}
         parent="My classes"
         parentHref={`/dashboard/class/${classId}`}
       />
       <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
+        <ClassTabs tabs={classTabs(classId, user, { canAllocate })} />
         <MarksClient
           classId={classId}
           canAllocate={canAllocate}

--- a/src/app/dashboard/class/[classId]/page.tsx
+++ b/src/app/dashboard/class/[classId]/page.tsx
@@ -1,109 +1,161 @@
-import Link from "next/link"
-import { notFound, redirect } from "next/navigation"
-import {
-  CalendarCheckIcon,
-  GraduationCapIcon,
-  BarChart3Icon,
-  UsersIcon,
-  BookOpenIcon,
-} from "lucide-react"
 import { PageHeader } from "@/components/page-header"
-import { buttonVariants } from "@/components/ui/button-variants"
-import { getSessionUser } from "@/lib/session"
-import { expectedYear } from "@/lib/roll-number"
-import { getClassById } from "@/db/queries/classes"
 import { listPendingRequestsForClass } from "@/db/queries/onboarding"
+import { listClassStaff } from "@/db/queries/class-staff"
+import { getStudentsByClassKeys } from "@/db/queries/students"
+import { listOfferingsForClass } from "@/db/queries/offerings"
 import { QueueClient } from "./queue-client"
+import { ClassTabs } from "./class-tabs"
+import { classTabs, classTrail, requireClassContext } from "./class-context"
+import { Attention, Completion, EmptyHint } from "../../overview-cards"
 
 export const dynamic = "force-dynamic"
 
-export default async function ClassDetailPage({
+export default async function ClassOverviewPage({
   params,
 }: {
   params: Promise<{ classId: string }>
 }) {
   const { classId } = await params
-  const user = await getSessionUser()
-  if (!user) redirect("/login")
+  const { user, cls, canAllocate, label } = await requireClassContext(classId)
 
-  const cls = await getClassById(classId)
-  if (!cls) return notFound()
+  const [requests, staff, roster, offerings] = await Promise.all([
+    listPendingRequestsForClass(classId),
+    listClassStaff([classId]),
+    getStudentsByClassKeys([cls.classKey]),
+    listOfferingsForClass(classId),
+  ])
 
-  const inScope =
-    user.tier === "super_admin" ||
-    user.classIds.includes(classId) ||
-    (user.tier === "hod" && user.deptCodes.includes(cls.departmentCode))
-  if (!inScope) redirect("/dashboard/class")
-
-  const requests = await listPendingRequestsForClass(classId)
-  const yr = expectedYear(cls.admissionYear, new Date()) ?? cls.admissionYear
-  const label = `${yr} · ${cls.departmentCode} · ${cls.division}`
+  const coordinator = staff.find((s) => s.role === "academic_coordinator")
+  const teachers = staff.filter((s) => s.role === "tr")
+  const unallocated = offerings.filter((o) => !o.faculty).length
+  const unclaimed = roster.filter((s) => !s.authUserId).length
 
   return (
     <>
       <PageHeader
         title={label}
+        trail={classTrail(cls, label)}
         parent="My classes"
         parentHref="/dashboard/class"
       />
       <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <h3 className="text-sm font-medium">
-              Enrolment requests ({requests.length})
-            </h3>
-            <p className="text-muted-foreground mt-1 text-xs leading-relaxed">
+        <ClassTabs
+          tabs={classTabs(classId, user, {
+            canAllocate,
+            pendingRequests: requests.length,
+          })}
+        />
+
+        {/* Who runs this class, stated before the work it needs. */}
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Fact label="Class key" value={cls.classKey} mono />
+          <Fact
+            label="Coordinator"
+            value={
+              coordinator
+                ? `${coordinator.firstName} ${coordinator.lastName}`.trim()
+                : "Unassigned"
+            }
+            warn={!coordinator}
+          />
+          <Fact
+            label="Teachers"
+            value={teachers.length ? String(teachers.length) : "None"}
+            warn={teachers.length === 0}
+          />
+          <Fact
+            label="Students"
+            value={String(roster.length)}
+            hint={unclaimed > 0 ? `${unclaimed} not signed in` : undefined}
+          />
+        </div>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-sm font-semibold">Needs attention</h2>
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            <Attention
+              count={requests.length}
+              label="Enrolment requests"
+              href={`/dashboard/class/${classId}`}
+            />
+            <Attention
+              count={unallocated}
+              label="Subjects with no teacher"
+              href={`/dashboard/class/${classId}/subjects`}
+              tone={canAllocate ? "attention" : "neutral"}
+            />
+            <Attention
+              count={unclaimed}
+              label="Students yet to sign in"
+              href="/dashboard/students"
+              tone="neutral"
+            />
+          </div>
+          {offerings.length > 0 && (
+            <Completion
+              done={offerings.filter((o) => o.faculty).length}
+              total={offerings.length}
+              noun="subjects allocated"
+            />
+          )}
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-sm font-semibold">
+            Enrolment requests ({requests.length})
+          </h2>
+          {requests.length === 0 ? (
+            <EmptyHint>
+              No students are waiting to be approved for {label}.
+            </EmptyHint>
+          ) : (
+            <p className="text-muted-foreground text-xs leading-relaxed">
               Students who claimed a roll number in {label}. Check each against
               your attendance sheet, then approve to link them.
             </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <Link
-              href={`/dashboard/class/${classId}/attendance`}
-              className={buttonVariants({ variant: "outline", size: "sm" })}
-            >
-              <CalendarCheckIcon className="mr-1.5 size-3.5" />
-              Take attendance
-            </Link>
-            <Link
-              href={`/dashboard/class/${classId}/subjects`}
-              className={buttonVariants({ variant: "outline", size: "sm" })}
-            >
-              <BookOpenIcon className="mr-1.5 size-3.5" />
-              Subjects
-            </Link>
-            <Link
-              href={`/dashboard/class/${classId}/marks`}
-              className={buttonVariants({ variant: "outline", size: "sm" })}
-            >
-              <GraduationCapIcon className="mr-1.5 size-3.5" />
-              Enter marks
-            </Link>
-            <Link
-              href={`/dashboard/class/${classId}/batches`}
-              className={buttonVariants({ variant: "outline", size: "sm" })}
-            >
-              <UsersIcon className="mr-1.5 size-3.5" />
-              Lab batches
-            </Link>
-            <Link
-              href={`/dashboard/class/${classId}/results`}
-              className={buttonVariants({ variant: "outline", size: "sm" })}
-            >
-              <BarChart3Icon className="mr-1.5 size-3.5" />
-              Results
-            </Link>
-          </div>
-        </div>
-        <QueueClient
-          requests={requests.map((r) => ({
-            id: r.id,
-            rollNumber: r.rollNumber,
-            name: `${r.firstName} ${r.lastName}`.trim(),
-            email: r.email,
-          }))}
-        />
+          )}
+          <QueueClient
+            requests={requests.map((r) => ({
+              id: r.id,
+              rollNumber: r.rollNumber,
+              name: `${r.firstName} ${r.lastName}`.trim(),
+              email: r.email,
+            }))}
+          />
+        </section>
       </div>
     </>
+  )
+}
+
+function Fact({
+  label,
+  value,
+  hint,
+  mono,
+  warn,
+}: {
+  label: string
+  value: string
+  hint?: string
+  mono?: boolean
+  warn?: boolean
+}) {
+  return (
+    <div className="border-border rounded border p-3">
+      <p className="text-muted-foreground text-xs">{label}</p>
+      <p
+        className={[
+          "mt-0.5 text-sm font-medium",
+          mono ? "identifier" : "",
+          warn ? "text-destructive" : "",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+      >
+        {value}
+      </p>
+      {hint && <p className="text-muted-foreground mt-0.5 text-xs">{hint}</p>}
+    </div>
   )
 }

--- a/src/app/dashboard/class/[classId]/results/page.tsx
+++ b/src/app/dashboard/class/[classId]/results/page.tsx
@@ -1,5 +1,7 @@
 import { notFound, redirect } from "next/navigation"
 import { PageHeader } from "@/components/page-header"
+import { ClassTabs } from "../class-tabs"
+import { classTabs, classTrail } from "../class-context"
 import { getSessionUser } from "@/lib/session"
 import { can } from "@/lib/rbac"
 import { expectedYear } from "@/lib/roll-number"
@@ -23,6 +25,10 @@ export default async function ResultsPage({
 
   const cls = await getClassById(classId)
   if (!cls) return notFound()
+  const canAllocate =
+    user.tier === "super_admin" ||
+    (user.tier === "hod" && user.deptCodes.includes(cls.departmentCode)) ||
+    user.coordinatorClassIds.includes(classId)
   const inScope =
     user.tier === "super_admin" ||
     user.classIds.includes(classId) ||
@@ -87,14 +93,17 @@ export default async function ResultsPage({
   })
 
   const yr = expectedYear(cls.admissionYear, new Date()) ?? cls.admissionYear
+  const label = `${yr} · ${cls.departmentCode} · ${cls.division}`
   return (
     <>
       <PageHeader
         title={`Results — ${yr} · ${cls.departmentCode} · ${cls.division}`}
+        trail={classTrail(cls, label)}
         parent="My classes"
         parentHref={`/dashboard/class/${classId}`}
       />
       <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
+        <ClassTabs tabs={classTabs(classId, user, { canAllocate })} />
         <ResultsClient rows={table} classLabel={`${cls.classKey}`} />
       </div>
     </>

--- a/src/app/dashboard/class/[classId]/subjects/page.tsx
+++ b/src/app/dashboard/class/[classId]/subjects/page.tsx
@@ -1,5 +1,7 @@
 import { notFound, redirect } from "next/navigation"
 import { PageHeader } from "@/components/page-header"
+import { ClassTabs } from "../class-tabs"
+import { classTabs, classTrail } from "../class-context"
 import { getSessionUser } from "@/lib/session"
 import { can } from "@/lib/rbac"
 import { expectedYear } from "@/lib/roll-number"
@@ -34,6 +36,7 @@ export default async function SubjectsPage({
   if (!inScope) redirect("/dashboard/class")
 
   const yr = expectedYear(cls.admissionYear, new Date())
+  const label = `${yr} · ${cls.departmentCode} · ${cls.division}`
   const [offerings, staff, catalogue] = await Promise.all([
     listOfferingsForClass(classId),
     listClassStaff([classId]),
@@ -45,10 +48,12 @@ export default async function SubjectsPage({
     <>
       <PageHeader
         title={`Subjects — ${yr ?? cls.admissionYear} · ${cls.departmentCode} · ${cls.division}`}
+        trail={classTrail(cls, label)}
         parent="My classes"
         parentHref={`/dashboard/class/${classId}`}
       />
       <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
+        <ClassTabs tabs={classTabs(classId, user, { canAllocate })} />
         <SubjectsClient
           classId={classId}
           canAllocate={canAllocate}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,6 +26,10 @@
   --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-attention: var(--attention);
+  --color-attention-foreground: var(--attention-foreground);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -73,6 +77,14 @@
   --accent: oklch(0.955 0.008 260);
   --accent-foreground: oklch(0.22 0.03 260);
   --destructive: oklch(0.55 0.22 25);
+  /* Workflow status. destructive already covered "critical"; complete and
+     pending were being written as raw green-600 / amber-600 at each call site,
+     which drifted and could not be themed. Status must always carry text or an
+     icon too — colour alone never conveys meaning (spec 3.2). */
+  --success: oklch(0.52 0.15 150);
+  --success-foreground: oklch(0.985 0 0);
+  --attention: oklch(0.6 0.14 65);
+  --attention-foreground: oklch(0.985 0 0);
   --border: oklch(0.91 0.008 260);
   --input: oklch(0.91 0.008 260);
   /* Deep saturated blue - the brand */
@@ -110,6 +122,10 @@
   --card-foreground: oklch(0.96 0 0);
   --popover: oklch(0.19 0.015 260);
   --popover-foreground: oklch(0.96 0 0);
+  --success: oklch(0.62 0.15 150);
+  --success-foreground: oklch(0.14 0.01 260);
+  --attention: oklch(0.7 0.14 65);
+  --attention-foreground: oklch(0.14 0.01 260);
   --primary: oklch(0.92 0 0);
   --primary-foreground: oklch(0.19 0.015 260);
   --secondary: oklch(0.25 0.015 260);
@@ -171,4 +187,15 @@
       box-shadow 0.2s ease,
       border-color 0.2s ease;
   }
+}
+
+/* Academic identifiers — roll numbers, course codes, class keys, employee IDs.
+   They are compared column-to-column far more often than they are read as
+   prose, so they get the mono face and tabular figures wherever they appear
+   (spec 3.3). */
+.identifier {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.8125rem;
+  letter-spacing: -0.01em;
 }

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -14,14 +14,27 @@ import { Badge } from "@/components/ui/badge"
 import { useSessionUser } from "@/components/session-provider"
 import { contextualRole } from "@/lib/navigation"
 
+/**
+ * A segment of the academic context trail: VIT / EXCS / BE A / Data Analytics.
+ *
+ * The trail is the product's structural signature (spec 3.4). It answers "what
+ * scope am I operating in" on every protected page, which a page title alone
+ * never did — "Marks" is the same word whether you are looking at one division
+ * or another. A segment is a link when the user may move to it and plain text
+ * when it is only context.
+ */
+export type TrailSegment = { label: string; href?: string }
+
 export function PageHeader({
   title,
   parent,
   parentHref,
+  trail,
 }: {
   title: string
   parent?: string
   parentHref?: string
+  trail?: TrailSegment[]
 }) {
   const session = useSessionUser()
   // The responsibility, not the database tier: a faculty member coordinating a
@@ -43,6 +56,18 @@ export function PageHeader({
         />
         <Breadcrumb>
           <BreadcrumbList>
+            {trail?.map((seg) => (
+              <span key={seg.label} className="contents">
+                <BreadcrumbItem className="hidden md:block">
+                  {seg.href ? (
+                    <BreadcrumbLink href={seg.href}>{seg.label}</BreadcrumbLink>
+                  ) : (
+                    <span className="text-muted-foreground">{seg.label}</span>
+                  )}
+                </BreadcrumbItem>
+                <BreadcrumbSeparator className="hidden md:block" />
+              </span>
+            ))}
             {parent && (
               <>
                 <BreadcrumbItem className="hidden md:block">


### PR DESCRIPTION
## What

Phase 1b (spec §3.2–3.4) and the class half of Phase 2b (§6.16).

## Academic context trail

Every protected page can carry `VIT / EXCS / BE A` in the header, each segment a link where the user may move to it. A page title alone never said which scope it belonged to — **"Marks" reads identically whether you're looking at one division or another**, which is the confusion the spec's signature element exists to remove.

## Status tokens

`destructive` already covered critical, but *complete* and *pending* were written as raw `green-600` / `amber-600` at each call site — they drifted between pages and couldn't be themed. `success` and `attention` are now tokens in both palettes. Colour still never carries meaning alone; every status shows a count or a word beside it (§3.2).

Roll numbers, course codes and class keys get the mono face and tabular figures via one `.identifier` class — they're compared column-to-column far more often than read as prose (§3.3).

## Tabbed class workspace

The class page offered **five outline buttons in a row that looked like actions rather than places**, and nothing indicated where you already were. Now a tab strip: Overview · Subjects · Attendance · Marks · Batches · Results.

Built from capabilities — a tab the viewer can't open is **omitted, not disabled**: they have no way to gain the capability from here, and a locked door isn't information.

```
ac@vosslabs.org    Overview | Subjects | Attendance | Marks | Batches | Results
hod@vosslabs.org   Overview | Subjects | Attendance | Results
tr@vosslabs.org    Overview | Subjects | Attendance | Marks | Batches | Results
(super_admin)      Overview | Subjects | Attendance | Marks | Batches | Results
```

The overview stops being an enrolment queue with buttons above it: it leads with **who runs the class** — coordinator, teachers, roster, how many haven't signed in — then what needs attention, then the queue.

## One duplication removed

`class-context.ts` resolves "which class, and what may this person do in it" once. All six pages repeated those four steps, and **the scope expression had already drifted** — the marks page and the subjects page spelled the coordinator check differently. Every surface now reads the same answer.

## Note for your pending decision

The HOD row above shows **Subjects, Attendance, Results but not Marks** — the capability contradiction the audit raised, now visible in the nav rather than only as a redirect. Granting HOD cover authority would add Marks and Batches there.

## Testing

- [x] `npm run check` passes (0 errors; 2 pre-existing warnings), 104 tests
- [x] `npm run build` passes
- [x] Tab visibility verified per role against the live database
