### PR TITLE
feat(rbac): give an HOD cover authority over attendance and marks

### DIFF
--- a/src/lib/rbac.test.ts
+++ b/src/lib/rbac.test.ts
@@ -97,9 +97,21 @@ describe("tier defaults", () => {
     expect(ROLE_DEFAULTS.faculty).not.toContain("permission:manage")
   })
 
-  // An HOD runs the department; they do not enter its marks.
-  it("gives an HOD read over marks, not write", () => {
+  // An HOD runs the department rather than teaching it, but holds cover
+  // authority: when a teacher is absent mid-term somebody senior must be able
+  // to finish the work. Scope still bounds it to their own department, which is
+  // enforced separately in allocation.ts.
+  it("gives an HOD cover authority over attendance and marks", () => {
     expect(ROLE_DEFAULTS.hod).toContain("marks:read")
-    expect(ROLE_DEFAULTS.hod).not.toContain("marks:write")
+    expect(ROLE_DEFAULTS.hod).toContain("marks:write")
+    expect(ROLE_DEFAULTS.hod).toContain("marks:lock")
+    expect(ROLE_DEFAULTS.hod).toContain("attendance:write")
+  })
+
+  // Cover is not administration: an HOD still cannot rewrite the permission
+  // model or read the institution-wide audit trail.
+  it("does not give an HOD institution-level authority", () => {
+    expect(ROLE_DEFAULTS.hod).not.toContain("permission:manage")
+    expect(ROLE_DEFAULTS.hod).not.toContain("audit:read")
   })
 })

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -179,6 +179,19 @@ export const ROLE_DEFAULTS: Record<
     "onboarding:read",
     "attendance:read",
     "marks:read",
+    // Cover authority. An HOD does not routinely enter marks or take a
+    // register — allocation is their job — but when a teacher is absent
+    // mid-term somebody senior has to be able to finish the work, and the
+    // department head is who the college holds responsible for it.
+    //
+    // This was previously read-only, which left the product contradicting
+    // itself: allocation.ts already let an HOD write any subject in their
+    // department, the Subjects page told users "Coordinators and the HOD can
+    // write any of them", and the capability table then redirected them away.
+    // Scope still bounds it to their own department.
+    "attendance:write",
+    "marks:write",
+    "marks:lock",
   ],
   faculty: [
     "class:read",


### PR DESCRIPTION
## What

Adds `attendance:write`, `marks:write` and `marks:lock` to the HOD defaults, per spec §2.1 and the audit's P1.

## Why

**The product contradicted itself.** `allocation.ts` already let an HOD write any subject in their department. The Subjects page told users *"Coordinators and the HOD can write any of them"*. And the capability table then redirected them away from the pages that copy describes.

The audit found the same disagreement from the other side: legitimate controls rendered, then refused by the server.

Resolved in favour of the workflow the spec states and the code already assumed.

## What it does and doesn't grant

An HOD doesn't routinely take a register or enter marks — allocation is their job. But when a teacher is absent mid-term, somebody senior has to finish the work, and the department head is who the college holds responsible.

**Cover is not administration.** `permission:manage` and `audit:read` stay out, and scope still bounds every write to their own department — enforced separately in `allocation.ts`, not by the capability alone.

```
HOD capabilities        marks:read true   marks:write true   marks:lock true
                        attendance:write true
                        permission:manage false   audit:read false

class tabs              Overview | Subjects | Attendance | Marks | Batches | Results

cover over a subject allocated to another teacher
   HOD of EXCS   true    (their department)
   HOD of CMPN   false   (scope still bounds it)
```

The Marks and Batches tabs now appear for an HOD, closing the gap #84 made visible.

## Test change worth noting

`rbac.test.ts` asserted `ROLE_DEFAULTS.hod` did **not** contain `marks:write` — it encoded the old decision. It now states the new one, and I added a companion test that cover authority doesn't leak into institution-level authority, so the boundary is pinned rather than implied.

- [x] `npm run check` passes (0 errors; 2 pre-existing warnings) — **105 tests**
- [x] `npm run build` passes
