### PR TITLE
feat(ui): department workspace sections and a shared record drawer

### DIFF
--- a/src/app/dashboard/dept/[code]/client.tsx
+++ b/src/app/dashboard/dept/[code]/client.tsx
@@ -14,6 +14,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { assignSubjectToTeacherAction } from "../actions"
+import { DeptTabs } from "./dept-tabs"
 import { Badge } from "@/components/ui/badge"
 
 type Person = { name: string; email: string }
@@ -41,6 +42,7 @@ type Course = { id: string; code: string; name: string; year: string | null }
 type ClassOption = { id: string; label: string }
 
 export function DeptDashboardClient({
+  section,
   canAssign,
   courses,
   classOptions,
@@ -52,6 +54,7 @@ export function DeptDashboardClient({
   totals,
   unplaced,
 }: {
+  section: string
   canAssign: boolean
   courses: Course[]
   classOptions: ClassOption[]
@@ -71,8 +74,24 @@ export function DeptDashboardClient({
 }) {
   const [assigning, setAssigning] = useState<FacultyRow | null>(null)
   const placed = totals.students - totals.unplaced
+  // Sections rather than one long scroll. A real department puts leadership,
+  // classes, faculty and the unplaced list on the same page, and the thing you
+  // came for is never in view.
+  const sections = [
+    { key: "overview", label: "Overview" },
+    {
+      key: "classes",
+      label: "Classes",
+      badge: classes.filter((c) => !c.coordinator).length,
+    },
+    { key: "faculty", label: "Faculty" },
+    { key: "students", label: "Students", badge: totals.unplaced },
+  ]
+  const show = (k: string) => section === k
   return (
     <div className="flex flex-col gap-6">
+      <DeptTabs sections={sections} code={dept.code} />
+
       {!dept.isActive && (
         <p className="border-border text-muted-foreground rounded border px-3 py-2 text-sm">
           This department is deactivated. It is shown for reference; its records
@@ -80,120 +99,132 @@ export function DeptDashboardClient({
         </p>
       )}
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Stat
-          label="Students"
-          value={totals.students}
-          hint={`${placed} in a class`}
-        />
-        <Stat
-          label="Faculty"
-          value={faculty.length}
-          hint={`${faculty.filter((f) => f.claimed).length} signed in`}
-        />
-        <Stat
-          label="Classes"
-          value={classes.length}
-          hint={`${classes.filter((c) => c.graduated).length} graduated`}
-        />
-        <Stat
-          label="Not signed in"
-          value={totals.unclaimedStudents}
-          hint="students yet to claim"
-          warn={totals.unclaimedStudents > 0}
-        />
-      </div>
-
-      <Section title="Leadership">
-        <div className="grid gap-3 sm:grid-cols-2">
-          <Lead role="Head of Department" person={hod} />
-          <Lead role="Department coordinator" person={coordinator} />
+      {show("overview") && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <Stat
+            label="Students"
+            value={totals.students}
+            hint={`${placed} in a class`}
+          />
+          <Stat
+            label="Faculty"
+            value={faculty.length}
+            hint={`${faculty.filter((f) => f.claimed).length} signed in`}
+          />
+          <Stat
+            label="Classes"
+            value={classes.length}
+            hint={`${classes.filter((c) => c.graduated).length} graduated`}
+          />
+          <Stat
+            label="Not signed in"
+            value={totals.unclaimedStudents}
+            hint="students yet to claim"
+            warn={totals.unclaimedStudents > 0}
+          />
         </div>
-      </Section>
+      )}
 
-      <Section title={`Classes (${classes.length})`}>
-        {classes.length === 0 ? (
-          <Empty>No classes yet in this department.</Empty>
-        ) : (
-          <Table
-            head={["Class", "Coordinator", "TR", "Students", "Status", ""]}
-            rows={classes.map((c) => [
-              <Link
-                key="k"
-                href={`/dashboard/class/${c.id}`}
-                className="hover:underline"
-              >
-                <span className="font-medium">{c.label}</span>{" "}
-                <span className="text-muted-foreground font-mono text-xs">
-                  {c.classKey}
-                </span>
-              </Link>,
-              c.coordinator ?? <Unset key="c">Unassigned</Unset>,
-              c.trs.length > 0 ? c.trs.join(", ") : <Unset key="t">None</Unset>,
-              <span key="s" className="tabular-nums">
-                {c.students}
-                {c.unclaimed > 0 && (
-                  <span className="text-muted-foreground text-xs">
-                    {" "}
-                    ({c.unclaimed} not signed in)
+      {show("overview") && (
+        <Section title="Leadership">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Lead role="Head of Department" person={hod} />
+            <Lead role="Department coordinator" person={coordinator} />
+          </div>
+        </Section>
+      )}
+
+      {(show("overview") || show("classes")) && (
+        <Section title={`Classes (${classes.length})`}>
+          {classes.length === 0 ? (
+            <Empty>No classes yet in this department.</Empty>
+          ) : (
+            <Table
+              head={["Class", "Coordinator", "TR", "Students", "Status", ""]}
+              rows={classes.map((c) => [
+                <Link
+                  key="k"
+                  href={`/dashboard/class/${c.id}`}
+                  className="hover:underline"
+                >
+                  <span className="font-medium">{c.label}</span>{" "}
+                  <span className="text-muted-foreground font-mono text-xs">
+                    {c.classKey}
                   </span>
-                )}
-              </span>,
-              c.graduated ? (
-                <Badge key="g" variant="secondary">
-                  Graduated
-                </Badge>
-              ) : c.isActive ? (
-                <Badge key="g" variant="outline">
-                  Active
-                </Badge>
-              ) : (
-                <Badge key="g" variant="secondary">
-                  Inactive
-                </Badge>
-              ),
-            ])}
-          />
-        )}
-      </Section>
+                </Link>,
+                c.coordinator ?? <Unset key="c">Unassigned</Unset>,
+                c.trs.length > 0 ? (
+                  c.trs.join(", ")
+                ) : (
+                  <Unset key="t">None</Unset>
+                ),
+                <span key="s" className="tabular-nums">
+                  {c.students}
+                  {c.unclaimed > 0 && (
+                    <span className="text-muted-foreground text-xs">
+                      {" "}
+                      ({c.unclaimed} not signed in)
+                    </span>
+                  )}
+                </span>,
+                c.graduated ? (
+                  <Badge key="g" variant="secondary">
+                    Graduated
+                  </Badge>
+                ) : c.isActive ? (
+                  <Badge key="g" variant="outline">
+                    Active
+                  </Badge>
+                ) : (
+                  <Badge key="g" variant="secondary">
+                    Inactive
+                  </Badge>
+                ),
+              ])}
+            />
+          )}
+        </Section>
+      )}
 
-      <Section title={`Faculty (${faculty.length})`}>
-        {faculty.length === 0 ? (
-          <Empty>No faculty on record for this department.</Empty>
-        ) : (
-          <Table
-            head={[
-              "Name",
-              "Email",
-              "Tier",
-              "Class role",
-              "Account",
-              ...(canAssign ? [""] : []),
-            ]}
-            rows={faculty.map((f) => [
-              f.name,
-              <span key="e" className="text-muted-foreground text-xs">
-                {f.email}
-              </span>,
-              <Badge key="t" variant="outline">
-                {f.tier}
-              </Badge>,
-              f.classRoles.length > 0 ? (
-                f.classRoles.join(" · ")
-              ) : (
-                <Unset key="r">—</Unset>
-              ),
-              f.claimed ? (
-                <span key="a" className="text-muted-foreground text-xs">
-                  Signed in
-                </span>
-              ) : (
-                <Unset key="a">Not claimed</Unset>
-              ),
-            ])}
-          />
-        )}
-      </Section>
+      {(show("overview") || show("faculty")) && (
+        <Section title={`Faculty (${faculty.length})`}>
+          {faculty.length === 0 ? (
+            <Empty>No faculty on record for this department.</Empty>
+          ) : (
+            <Table
+              head={[
+                "Name",
+                "Email",
+                "Tier",
+                "Class role",
+                "Account",
+                ...(canAssign ? [""] : []),
+              ]}
+              rows={faculty.map((f) => [
+                f.name,
+                <span key="e" className="text-muted-foreground text-xs">
+                  {f.email}
+                </span>,
+                <Badge key="t" variant="outline">
+                  {f.tier}
+                </Badge>,
+                f.classRoles.length > 0 ? (
+                  f.classRoles.join(" · ")
+                ) : (
+                  <Unset key="r">—</Unset>
+                ),
+                f.claimed ? (
+                  <span key="a" className="text-muted-foreground text-xs">
+                    Signed in
+                  </span>
+                ) : (
+                  <Unset key="a">Not claimed</Unset>
+                ),
+              ])}
+            />
+          )}
+        </Section>
+      )}
 
       {assigning && (
         <AssignSubjectDialog
@@ -204,7 +235,7 @@ export function DeptDashboardClient({
         />
       )}
 
-      {totals.unplaced > 0 && (
+      {(show("overview") || show("students")) && totals.unplaced > 0 && (
         <Section title={`Not in any class (${totals.unplaced})`}>
           <p className="text-muted-foreground mb-3 text-sm">
             These students belong to the department but their cohort has no

--- a/src/app/dashboard/dept/[code]/dept-tabs.tsx
+++ b/src/app/dashboard/dept/[code]/dept-tabs.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname, useSearchParams } from "next/navigation"
+import { cn } from "@/lib/utils"
+
+/**
+ * Department workspace sections (spec 6.9).
+ *
+ * The department page had grown into one column holding leadership, classes,
+ * faculty and the unplaced-student list at once — on a real department that is
+ * a very long scroll where the thing you came for is never in view.
+ *
+ * These are query-string sections rather than routes: every section reads from
+ * the same scoped queries the page already runs, so splitting them into routes
+ * would mean repeating those reads per section for no gain.
+ */
+export type DeptSection = { key: string; label: string; badge?: number }
+
+export function DeptTabs({
+  sections,
+  code,
+}: {
+  sections: DeptSection[]
+  code: string
+}) {
+  const pathname = usePathname()
+  const params = useSearchParams()
+  const current = params.get("tab") ?? sections[0]?.key
+
+  return (
+    <nav
+      aria-label="Department sections"
+      className="border-border -mb-px flex gap-1 overflow-x-auto border-b"
+    >
+      {sections.map((s) => {
+        const active = current === s.key
+        const href =
+          s.key === sections[0]?.key
+            ? `/dashboard/dept/${code}`
+            : `${pathname}?tab=${s.key}`
+        return (
+          <Link
+            key={s.key}
+            href={href}
+            aria-current={active ? "page" : undefined}
+            className={cn(
+              "flex shrink-0 items-center gap-1.5 border-b-2 px-3 py-2 text-sm transition-colors",
+              active
+                ? "border-foreground text-foreground font-medium"
+                : "text-muted-foreground hover:text-foreground border-transparent"
+            )}
+          >
+            {s.label}
+            {s.badge != null && s.badge > 0 && (
+              <span className="bg-attention text-attention-foreground rounded-full px-1.5 py-0.5 text-[0.6875rem] leading-none tabular-nums">
+                {s.badge}
+              </span>
+            )}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/app/dashboard/dept/[code]/page.tsx
+++ b/src/app/dashboard/dept/[code]/page.tsx
@@ -18,9 +18,12 @@ export const dynamic = "force-dynamic"
 
 export default async function DepartmentDashboard({
   params,
+  searchParams,
 }: {
   params: Promise<{ code: string }>
+  searchParams: Promise<{ tab?: string }>
 }) {
+  const { tab } = await searchParams
   const { code } = await params
   // Department codes are stored uppercase; a link or a typed URL may not be.
   const deptCode = decodeURIComponent(code).toUpperCase()
@@ -101,12 +104,14 @@ export default async function DepartmentDashboard({
   return (
     <>
       <PageHeader
+        trail={[{ label: "VIT" }, { label: dept.code }]}
         title={`${dept.code} — ${dept.name}`}
         parent="Departments"
         parentHref="/dashboard/dept"
       />
       <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
         <DeptDashboardClient
+          section={tab ?? "overview"}
           canAssign={
             user.tier === "super_admin" || user.deptCodes.includes(deptCode)
           }

--- a/src/components/record-drawer.tsx
+++ b/src/components/record-drawer.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+
+/**
+ * The shared record drawer (spec 5.2).
+ *
+ * Inspecting a person or a course used to mean leaving the table, losing the
+ * filters and the scroll position, and navigating back. A drawer keeps the list
+ * behind it, so comparing two records is two clicks rather than four page loads.
+ *
+ * Deliberately presentational: it takes facts, badges and actions rather than
+ * fetching. A drawer that queried on open would make every table page depend on
+ * a client data path, which is what the server-scoped queries exist to avoid.
+ */
+
+export type DrawerFact = {
+  label: string
+  value: React.ReactNode
+  mono?: boolean
+}
+
+export function RecordDrawer({
+  open,
+  onClose,
+  title,
+  subtitle,
+  badges,
+  facts,
+  children,
+  footer,
+}: {
+  open: boolean
+  onClose: () => void
+  title: string
+  subtitle?: string
+  badges?: { label: string; tone?: "default" | "warn" | "critical" }[]
+  facts?: DrawerFact[]
+  children?: React.ReactNode
+  footer?: React.ReactNode
+}) {
+  return (
+    <Sheet open={open} onOpenChange={(o) => !o && onClose()}>
+      <SheetContent className="flex w-full flex-col gap-0 overflow-y-auto sm:max-w-md">
+        <SheetHeader className="gap-1">
+          <SheetTitle className="text-base">{title}</SheetTitle>
+          {subtitle && (
+            <p className="text-muted-foreground text-xs">{subtitle}</p>
+          )}
+          {badges && badges.length > 0 && (
+            <div className="mt-1 flex flex-wrap gap-1.5">
+              {badges.map((b) => (
+                <Badge
+                  key={b.label}
+                  variant={b.tone === "critical" ? "destructive" : "outline"}
+                  className={b.tone === "warn" ? "text-attention" : undefined}
+                >
+                  {b.label}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </SheetHeader>
+
+        <div className="flex flex-col gap-5 px-4 pb-4">
+          {facts && facts.length > 0 && (
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-3">
+              {facts.map((f) => (
+                <div key={f.label}>
+                  <dt className="text-muted-foreground text-xs">{f.label}</dt>
+                  <dd
+                    className={
+                      f.mono
+                        ? "identifier mt-0.5"
+                        : "mt-0.5 text-sm font-medium"
+                    }
+                  >
+                    {f.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          )}
+          {children}
+        </div>
+
+        {footer && (
+          <div className="border-border mt-auto border-t px-4 py-3">
+            {footer}
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+/** A titled block inside a drawer — assignments, activity, related records. */
+export function DrawerSection({
+  title,
+  empty,
+  children,
+}: {
+  title: string
+  empty?: string
+  children?: React.ReactNode
+}) {
+  const isEmpty =
+    !children || (Array.isArray(children) && children.length === 0)
+  return (
+    <section className="flex flex-col gap-2">
+      <h3 className="text-xs font-semibold">{title}</h3>
+      {isEmpty ? (
+        <p className="text-muted-foreground text-xs">
+          {empty ?? "Nothing yet."}
+        </p>
+      ) : (
+        children
+      )}
+    </section>
+  )
+}


### PR DESCRIPTION
## What

Completes Phase 2b (tabbed workspaces) and lands the drawer primitive Phase 2c's record tables need.

## Department workspace

The page had grown into **one column** holding leadership, statistics, classes, faculty and the unplaced-student list at once. On a real department that's a very long scroll where the thing you came for is never in view — and the badge that matters most, **79 students in no class**, sat below four screens of other content.

Now Overview · Classes · Faculty · Students, with counts on the tabs carrying work:

```
Overview   leadership, stats, then everything below
Classes    1 class,  badge = 0 without a coordinator
Faculty    4 faculty
Students   badge = 79 not in any class
header trail: VIT / EXCS
```

**Query-string sections rather than routes**, deliberately: every section reads from the same scoped queries the page already runs, so splitting into routes would repeat those reads per section for no gain. The class workspace uses real routes for the opposite reason — each of its surfaces loads its own scoped data.

## Record drawer

Inspecting a person or a course meant leaving the table, losing the filters and scroll position, and navigating back. `RecordDrawer` (shadcn `Sheet`) keeps the list behind it, so comparing two records is two clicks rather than four page loads (spec §5.2).

**Deliberately presentational** — it takes facts, badges and actions rather than fetching. A drawer that queried on open would make every table page depend on a client data path, which is what the server-scoped queries exist to avoid.

## Testing

- [x] `npm run check` passes (0 errors; 2 pre-existing warnings), 105 tests
- [x] `npm run build` passes
- [x] Section badges verified against the live database
