### PR TITLE
feat(marks): publication as a governed state

### DIFF
--- a/src/app/dashboard/class/[classId]/marks/client.tsx
+++ b/src/app/dashboard/class/[classId]/marks/client.tsx
@@ -12,7 +12,11 @@ import { cn } from "@/lib/utils"
 import { computeMarks, type CourseInfo } from "@/lib/sgpi"
 import { downloadBase64File } from "@/lib/utils"
 import { exportTableCsv, exportTableXlsx } from "@/lib/xlsx-export"
-import { saveMarksAction, setMarksLockAction } from "../../actions"
+import {
+  saveMarksAction,
+  setMarksLockAction,
+  setPublishedAction,
+} from "../../actions"
 
 type Offering = {
   id: string
@@ -36,6 +40,8 @@ type LockComponent = "isa" | "mse" | "ese"
 type Lock = { component: LockComponent; canUnlock: boolean }
 type Grid = {
   offeringId: string
+  published: boolean
+  canPublish: boolean
   course: CourseInfo
   rows: Row[]
   locked: Lock[]
@@ -185,6 +191,18 @@ function MarksGrid({
   const allLocked =
     isLocked("isa") && isLocked("ese") && (!hasMse || isLocked("mse"))
 
+  function togglePublished(next: boolean) {
+    start(async () => {
+      const res = await setPublishedAction({
+        offeringId: offering.id,
+        published: next,
+      })
+      if (res.error) return void toast.error(res.error)
+      toast.success(next ? "Results published" : "Results withdrawn")
+      router.refresh()
+    })
+  }
+
   function toggleLock(component: LockComponent, next: boolean) {
     start(async () => {
       const res = await setMarksLockAction({
@@ -326,6 +344,37 @@ function MarksGrid({
             {pending ? "Saving…" : "Save marks"}
           </Button>
         </div>
+      </div>
+
+      {/* Publication is the last step, and reads as one: locking each component
+          says the figures are final, publishing says the student may see them. */}
+      <div className="border-border flex flex-wrap items-center gap-3 rounded border px-3 py-2">
+        <span className="text-muted-foreground text-xs font-medium">
+          Results
+        </span>
+        <Badge variant={grid.published ? "outline" : "secondary"}>
+          {grid.published ? "Published" : "Not published"}
+        </Badge>
+        <span className="text-muted-foreground text-xs">
+          {grid.published
+            ? "Students can see their grade for this subject."
+            : "Students cannot see a grade for this subject yet."}
+        </span>
+        {grid.canPublish ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="ml-auto"
+            disabled={pending}
+            onClick={() => togglePublished(!grid.published)}
+          >
+            {grid.published ? "Withdraw" : "Publish results"}
+          </Button>
+        ) : (
+          <span className="text-muted-foreground ml-auto text-xs">
+            The class coordinator publishes results.
+          </span>
+        )}
       </div>
 
       <LockPanel

--- a/src/app/dashboard/class/[classId]/marks/page.tsx
+++ b/src/app/dashboard/class/[classId]/marks/page.tsx
@@ -63,6 +63,8 @@ export default async function MarksPage({
     const byStudent = Object.fromEntries(existing.map((m) => [m.studentId, m]))
     grid = {
       offeringId: selected.id,
+      published: selected.publishedAt != null,
+      canPublish: canAllocate,
       // Per component, because the right to reopen depends on who locked that
       // one — not on a single permission for the whole page.
       locked: locked.map((l) => ({

--- a/src/app/dashboard/class/actions.ts
+++ b/src/app/dashboard/class/actions.ts
@@ -22,6 +22,7 @@ import {
   createOffering,
   getOfferingById,
   setOfferingFaculty,
+  setOfferingPublished,
 } from "@/db/queries/offerings"
 import {
   createBatch,
@@ -607,5 +608,70 @@ export async function assignOfferingFacultyAction(input: {
     return { error: null }
   } catch (err) {
     return { error: getErrorMessage(err, "Could not reallocate the subject") }
+  }
+}
+
+/**
+ * Publish a subject's results, or withdraw them.
+ *
+ * Every component the course actually has must be locked first. That is what
+ * makes the sequence mean anything: locking is the teacher saying the figures
+ * are final, publishing is the coordinator saying the student may see them. A
+ * publish that skipped locking would collapse the two into one button and leave
+ * "final" meaning nothing.
+ *
+ * A course with no MSE component is not asked to lock one.
+ */
+export async function setPublishedAction(input: {
+  offeringId: string
+  published: boolean
+}): Promise<Result> {
+  try {
+    const user = await getSessionUser()
+    authorize(user, "marks:lock")
+    const offering = await getOfferingById(input.offeringId)
+    if (!offering) return { error: "No such subject." }
+    const { ok, cls } = await classInScope(user!, offering.classId)
+    if (!ok || !cls) return { error: "That class is not in your scope." }
+    // Publication is governance, not teaching: the coordinator, the HOD or an
+    // admin decides, never the teacher acting alone on their own marks.
+    if (!canAllocate(user!, offering.classId, cls.departmentCode)) {
+      return {
+        error:
+          "Only the class coordinator, the HOD, or an admin can publish results.",
+      }
+    }
+
+    if (input.published) {
+      const required: LockComponent[] =
+        offering.course.maxMse > 0 ? ["isa", "mse", "ese"] : ["isa", "ese"]
+      const locked = (await getLockedComponents(input.offeringId)).map(
+        (l) => l.component
+      )
+      const open = required.filter((c) => !locked.includes(c))
+      if (open.length > 0) {
+        return {
+          error: `Lock ${open.join(", ").toUpperCase()} before publishing — publishing says these marks are final.`,
+        }
+      }
+    }
+
+    await setOfferingPublished(
+      input.offeringId,
+      user!.facultyId,
+      input.published
+    )
+    await createAuditLog({
+      action: input.published ? "marks.published" : "marks.withdrawn",
+      actorId: user!.id,
+      targetType: "offering",
+      targetId: input.offeringId,
+      details: { courseCode: offering.course.courseCode },
+    })
+    revalidatePath(`/dashboard/class/${offering.classId}/marks`)
+    revalidatePath("/dashboard/my-marks")
+    return { error: null }
+  } catch (err) {
+    return { error: getErrorMessage(err, "Could not change publication") }
   }
 }

--- a/src/app/dashboard/my-marks/client.tsx
+++ b/src/app/dashboard/my-marks/client.tsx
@@ -23,15 +23,22 @@ type Semester = { semester: number; subjects: Subject[] }
 export function MyMarksClient({
   cgpa,
   semesters,
+  awaiting,
 }: {
   cgpa: CgpaResult
   semesters: Semester[]
+  awaiting: { code: string; name: string; semester: number }[]
 }) {
   if (semesters.length === 0) {
     return (
-      <p className="text-muted-foreground text-sm">
-        No marks recorded yet. They appear here once your teachers enter them.
-      </p>
+      <div className="flex flex-col gap-4">
+        <p className="text-muted-foreground text-sm">
+          {awaiting.length > 0
+            ? "No results have been published yet."
+            : "No marks recorded yet. They appear here once your teachers enter them."}
+        </p>
+        <AwaitingPublication subjects={awaiting} />
+      </div>
     )
   }
 
@@ -60,6 +67,8 @@ export function MyMarksClient({
           hint="earned"
         />
       </div>
+
+      <AwaitingPublication subjects={awaiting} />
 
       {semesters.map((sem) => {
         const result = cgpa.perSemester.find((p) => p.semester === sem.semester)
@@ -253,6 +262,42 @@ function Part({
           `${value}/${max}`
         )}
       </p>
+    </div>
+  )
+}
+
+/**
+ * Subjects a student is taking whose results are not published.
+ *
+ * Naming them matters: silence looks like the subject was forgotten, and a
+ * student who can see four of their six subjects will assume the other two are
+ * lost rather than pending. Marks are deliberately not shown — an unpublished
+ * figure is not a result, and showing it would make publication meaningless.
+ */
+function AwaitingPublication({
+  subjects,
+}: {
+  subjects: { code: string; name: string; semester: number }[]
+}) {
+  if (subjects.length === 0) return null
+  return (
+    <div className="border-border rounded border p-4">
+      <p className="text-sm font-medium">Awaiting publication</p>
+      <p className="text-muted-foreground mt-0.5 text-xs">
+        Your teachers are still entering or finalising these. They appear with a
+        grade once the class coordinator publishes them.
+      </p>
+      <ul className="mt-3 flex flex-col gap-1.5">
+        {subjects.map((s) => (
+          <li key={s.code} className="flex items-center gap-2 text-sm">
+            <span className="identifier">{s.code}</span>
+            <span className="truncate">{s.name}</span>
+            <span className="text-muted-foreground ml-auto text-xs">
+              Semester {s.semester}
+            </span>
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/src/app/dashboard/my-marks/page.tsx
+++ b/src/app/dashboard/my-marks/page.tsx
@@ -14,7 +14,12 @@ export default async function MyMarksPage() {
   if (!user.studentId) redirect("/dashboard")
 
   const rows = await getMarksForStudent(user.studentId)
-  const flat = rows.map((m) => ({
+  // Only published subjects count toward SGPI and CGPA. An unpublished subject
+  // is work in progress; folding it into an average would present a figure that
+  // moves every time a teacher saves, and that nobody has declared final.
+  const published = rows.filter((m) => m.courseOffering.publishedAt != null)
+
+  const flat = published.map((m) => ({
     semester: m.courseOffering.semester,
     marks: { isa: m.isa, mse1: m.mse1, mse2: m.mse2, ese: m.ese },
     course: {
@@ -33,7 +38,7 @@ export default async function MyMarksPage() {
     .sort((a, b) => a - b)
     .map((semester) => ({
       semester,
-      subjects: rows
+      subjects: published
         .filter((m) => m.courseOffering.semester === semester)
         .map((m) => ({
           code: m.courseOffering.course.courseCode,
@@ -55,7 +60,17 @@ export default async function MyMarksPage() {
     <>
       <PageHeader title="My marks" />
       <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
-        <MyMarksClient cgpa={cgpa} semesters={semesters} />
+        <MyMarksClient
+          cgpa={cgpa}
+          semesters={semesters}
+          awaiting={rows
+            .filter((m) => m.courseOffering.publishedAt == null)
+            .map((m) => ({
+              code: m.courseOffering.course.courseCode,
+              name: m.courseOffering.course.courseName,
+              semester: m.courseOffering.semester,
+            }))}
+        />
       </div>
     </>
   )

--- a/src/db/migrations/0004_offering_publication.sql
+++ b/src/db/migrations/0004_offering_publication.sql
@@ -1,0 +1,16 @@
+-- Publication as a governed state, separate from marks entry and locking.
+--
+-- Locking says "I have finished entering this component". Publishing says "the
+-- student may see this result". Until now there was no second statement, so a
+-- half-entered ISA reached a student's record the moment a teacher typed it —
+-- with no ESE and no grade — and read as a result rather than as work in
+-- progress.
+--
+-- Nullable: not-yet-published is the normal state of every offering in a live
+-- term, not an exception.
+ALTER TABLE course_offerings
+  ADD COLUMN IF NOT EXISTS published_at timestamptz,
+  ADD COLUMN IF NOT EXISTS published_by_faculty_id uuid REFERENCES faculty(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS offerings_published_idx
+  ON course_offerings (published_at);

--- a/src/db/queries/offerings.ts
+++ b/src/db/queries/offerings.ts
@@ -50,3 +50,35 @@ export async function setOfferingFaculty(id: string, facultyId: string | null) {
     .returning()
   return row
 }
+
+/**
+ * Publish or withdraw a subject's results.
+ *
+ * Withdrawing is deliberately possible: a result published against a mark that
+ * turns out to be wrong has to be retractable, and the alternative — leaving it
+ * visible while it is corrected — is worse than briefly taking it back.
+ */
+export async function setOfferingPublished(
+  id: string,
+  publishedByFacultyId: string | null,
+  published: boolean
+) {
+  const [row] = await db
+    .update(courseOfferings)
+    .set(
+      published
+        ? {
+            publishedAt: new Date(),
+            publishedByFacultyId,
+            updatedAt: new Date(),
+          }
+        : {
+            publishedAt: null,
+            publishedByFacultyId: null,
+            updatedAt: new Date(),
+          }
+    )
+    .where(eq(courseOfferings.id, id))
+    .returning()
+  return row
+}

--- a/src/db/schema/offerings.ts
+++ b/src/db/schema/offerings.ts
@@ -31,6 +31,16 @@ export const courseOfferings = pgTable(
     }),
     // 1..8 — which semester of the programme this offering runs in.
     semester: integer("semester").notNull(),
+    // Publication is a governed state of its own, separate from entering marks
+    // and from locking them. Locking says "I have finished"; publishing says
+    // "the student may see this". Without it a half-entered ISA appeared on a
+    // student's record the moment a teacher typed it, with no ESE and no grade,
+    // and looked like a result rather than work in progress.
+    publishedAt: timestamp("published_at", { withTimezone: true }),
+    publishedByFacultyId: uuid("published_by_faculty_id").references(
+      () => faculty.id,
+      { onDelete: "set null" }
+    ),
     isActive: boolean("is_active").notNull().default(true),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()


### PR DESCRIPTION
## What

Phase 3's core: results become a **published** state, separate from marks entry and locking (spec §5.3, §6.22, §6.25).

## Why

A student saw a subject's marks **the moment a teacher typed them**. A half-entered ISA with no ESE and no grade reached their record and read as a result rather than as work somebody was still doing.

## The sequence, and why each step exists

```
Not started → In progress → Locked (teacher: these are final)
                          → Published (coordinator: the student may see this)
```

**Every component the course has must be locked before publishing.** That's what makes the sequence real — collapsing lock and publish into one button would leave "final" meaning nothing. A course with no MSE component isn't asked to lock one.

**Publication is governance, not teaching.** The coordinator, HOD or admin decides — never the teacher acting alone on their own marks. Gated on `marks:lock` plus `canAllocate`.

**Withdrawing is deliberately possible.** A result published against a mark that turns out to be wrong has to be retractable; leaving it visible while it's corrected is worse than briefly taking it back.

## Student side

Only published subjects count toward SGPI and CGPA — an unpublished subject folded into an average produces a figure that moves every time a teacher saves and that nobody has declared final.

Unpublished subjects are still **named**, under *Awaiting publication*, without marks. Silence would look like the subject was forgotten — a student seeing four of their six would assume the other two were lost rather than pending — while showing the figures would make publication meaningless.

## Verified against the live database

```
offering EC33T (maxMse=20), student 23108A0023

unpublished (starting state)     student sees 0 published / 1 total
required locks: isa, mse, ese    currently locked: none
publish would be refused: true   want true

after locking all: ese, isa, mse
after publishing                 student sees 1 published / 1 total
after withdrawing                student sees 0 published / 1 total
restored to starting state
```

- [x] Migration `0004` applied
- [x] `npm run check` passes (0 errors; 2 pre-existing warnings), 105 tests
- [x] `npm run build` passes
