### PR TITLE
feat(marks): components in the student row, semesters derived from the cohort

### DIFF
--- a/src/app/dashboard/class/[classId]/subjects/client.tsx
+++ b/src/app/dashboard/class/[classId]/subjects/client.tsx
@@ -37,6 +37,7 @@ export function SubjectsClient({
   classId,
   canAllocate,
   classYear,
+  semesters,
   offerings,
   staff,
   catalogue,
@@ -44,6 +45,8 @@ export function SubjectsClient({
   classId: string
   canAllocate: boolean
   classYear: string | null
+  /** The two semesters this cohort can actually be sitting. */
+  semesters: [number, number]
   offerings: Offering[]
   staff: Staff[]
   catalogue: CatalogueCourse[]
@@ -51,7 +54,10 @@ export function SubjectsClient({
   const router = useRouter()
   const [pending, start] = useTransition()
   const [query, setQuery] = useState("")
-  const [semester, setSemester] = useState(1)
+  // Defaulting to 1 filed a BE class's subject three years before that cohort
+  // sat it. The class knows which semesters it can be in; the form should not
+  // have to be told.
+  const [semester, setSemester] = useState(semesters[0])
 
   function allocate(offeringId: string, facultyId: string) {
     start(async () => {
@@ -220,16 +226,21 @@ export function SubjectsClient({
                     className="h-9"
                   />
                 </div>
-                <div className="grid w-20 gap-1.5">
-                  <label className="text-muted-foreground text-xs">Sem</label>
-                  <Input
-                    type="number"
-                    min={1}
-                    max={8}
+                <div className="grid w-28 gap-1.5">
+                  <label className="text-muted-foreground text-xs">
+                    Semester
+                  </label>
+                  <select
                     value={semester}
                     onChange={(e) => setSemester(Number(e.target.value))}
-                    className="h-9"
-                  />
+                    className="border-input bg-background h-9 rounded border px-2 text-sm"
+                  >
+                    {semesters.map((n) => (
+                      <option key={n} value={n}>
+                        Semester {n}
+                      </option>
+                    ))}
+                  </select>
                 </div>
               </div>
 

--- a/src/app/dashboard/class/[classId]/subjects/page.tsx
+++ b/src/app/dashboard/class/[classId]/subjects/page.tsx
@@ -4,7 +4,7 @@ import { ClassTabs } from "../class-tabs"
 import { classTabs, classTrail } from "../class-context"
 import { getSessionUser } from "@/lib/session"
 import { can } from "@/lib/rbac"
-import { expectedYear } from "@/lib/roll-number"
+import { expectedYear, semestersForClass } from "@/lib/roll-number"
 import { getClassById } from "@/db/queries/classes"
 import { listClassStaff } from "@/db/queries/class-staff"
 import { listOfferingsForClass } from "@/db/queries/offerings"
@@ -58,6 +58,7 @@ export default async function SubjectsPage({
           classId={classId}
           canAllocate={canAllocate}
           classYear={yr ?? null}
+          semesters={semestersForClass(cls.admissionYear, new Date()) ?? [1, 2]}
           offerings={offerings.map((o) => ({
             id: o.id,
             code: o.course.courseCode,

--- a/src/app/dashboard/my-marks/client.tsx
+++ b/src/app/dashboard/my-marks/client.tsx
@@ -97,7 +97,10 @@ export function MyMarksClient({
                       <th>Code</th>
                       <th>Subject</th>
                       <th className="w-16">Credits</th>
-                      <th className="w-16">Total</th>
+                      <th className="w-16">ISA</th>
+                      <th className="w-16">MSE</th>
+                      <th className="w-16">ESE</th>
+                      <th className="w-20">Total</th>
                       <th className="w-14">%</th>
                       <th className="w-16">Grade</th>
                       <th className="w-8"></th>
@@ -167,6 +170,16 @@ function SubjectRow({ subject }: { subject: Subject }) {
         <td className="font-mono text-xs">{subject.code}</td>
         <td>{subject.name}</td>
         <td className="tabular-nums">{subject.credits}</td>
+        {/* The components sit in the row rather than behind the expander: a
+            student checking a marksheet wants ISA and MSE at a glance, and
+            opening every subject to find them was the slow way round. */}
+        <Cell value={subject.marks.isa} max={subject.course.maxIsa} />
+        <Cell
+          value={hasMse ? c.finalMse : null}
+          max={subject.course.maxMse}
+          absent={!hasMse}
+        />
+        <Cell value={subject.marks.ese} max={subject.course.maxEse} />
         <td className="tabular-nums">
           {c.percentage == null ? "—" : `${c.total}/${subject.course.maxTotal}`}
         </td>
@@ -189,7 +202,7 @@ function SubjectRow({ subject }: { subject: Subject }) {
 
       {open && (
         <tr className="bg-muted/30">
-          <td colSpan={7} className="px-2 py-3">
+          <td colSpan={10} className="px-2 py-3">
             <div className="flex flex-wrap items-start gap-6 text-xs">
               <Part
                 label="ISA"
@@ -299,5 +312,39 @@ function AwaitingPublication({
         ))}
       </ul>
     </div>
+  )
+}
+
+/**
+ * One component's mark against its maximum.
+ *
+ * A blank is not a zero: "not entered" and "scored nothing" look identical as a
+ * bare 0, and a student reading their own marksheet must be able to tell them
+ * apart. A component the course does not have shows as a dash rather than an
+ * empty gap that reads like missing data.
+ */
+function Cell({
+  value,
+  max,
+  absent,
+}: {
+  value: number | null
+  max: number
+  absent?: boolean
+}) {
+  if (absent) {
+    return <td className="text-muted-foreground text-xs">—</td>
+  }
+  return (
+    <td className="tabular-nums">
+      {value == null ? (
+        <span className="text-muted-foreground text-xs">not entered</span>
+      ) : (
+        <>
+          {value}
+          <span className="text-muted-foreground text-xs">/{max}</span>
+        </>
+      )}
+    </td>
   )
 }

--- a/src/db/queries/attendance.ts
+++ b/src/db/queries/attendance.ts
@@ -1,6 +1,6 @@
 import { and, eq, sql } from "drizzle-orm"
 import { db } from "@/db"
-import { attendance } from "@/db/schema"
+import { attendance, courseOfferings, courses } from "@/db/schema"
 
 type Entry = {
   studentId: string
@@ -61,4 +61,60 @@ export async function getAttendanceSummaryForStudent(studentId: string) {
     .from(attendance)
     .where(eq(attendance.studentId, studentId))
   return { present: row?.present ?? 0, total: row?.total ?? 0 }
+}
+
+/**
+ * A student's attendance broken down by subject, plus the sessions that were
+ * taken for the class as a whole.
+ *
+ * The schema always allowed a subject-wise mark — courseOfferingId has been
+ * nullable on the row since attendance was introduced — but the register only
+ * ever wrote the class-level form, so a student could see one overall figure and
+ * never which subject they were short in. VIT's 75% rule is enforced per
+ * subject, so an overall number cannot answer the question anybody actually
+ * asks.
+ */
+export async function getAttendanceBySubject(studentId: string) {
+  const rows = await db
+    .select({
+      offeringId: attendance.courseOfferingId,
+      code: courses.courseCode,
+      name: courses.courseName,
+      status: attendance.status,
+    })
+    .from(attendance)
+    .leftJoin(
+      courseOfferings,
+      eq(attendance.courseOfferingId, courseOfferings.id)
+    )
+    .leftJoin(courses, eq(courseOfferings.courseId, courses.id))
+    .where(eq(attendance.studentId, studentId))
+
+  const bucket = new Map<
+    string,
+    { code: string; name: string; present: number; total: number }
+  >()
+  for (const r of rows) {
+    // A session with no offering was taken for the class rather than a subject;
+    // it is reported separately instead of being spread across subjects it was
+    // never attached to.
+    const key = r.offeringId ?? "__class"
+    const cur = bucket.get(key) ?? {
+      code: r.code ?? "—",
+      name: r.name ?? "Class sessions",
+      present: 0,
+      total: 0,
+    }
+    cur.total += 1
+    if (r.status === "present" || r.status === "late") cur.present += 1
+    bucket.set(key, cur)
+  }
+
+  return [...bucket.entries()]
+    .map(([key, v]) => ({
+      ...v,
+      offeringId: key === "__class" ? null : key,
+      percent: v.total > 0 ? Math.round((v.present / v.total) * 100) : null,
+    }))
+    .sort((a, b) => a.code.localeCompare(b.code))
 }

--- a/src/lib/roll-number.test.ts
+++ b/src/lib/roll-number.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest"
 import {
   currentYear,
   expectedYear,
+  semestersForClass,
+  semestersForYear,
   isValidRollNumber,
   looksLikeRoll,
   parseRollNumber,
@@ -114,5 +116,39 @@ describe("currentYear", () => {
 
   it("falls back past BE, where there is no year left to compute", () => {
     expect(currentYear("21108A0001", "BE", on)).toBe("BE")
+  })
+})
+
+describe("semestersForYear", () => {
+  it("maps each programme year to its two semesters", () => {
+    expect(semestersForYear("FE")).toEqual([1, 2])
+    expect(semestersForYear("SE")).toEqual([3, 4])
+    expect(semestersForYear("TE")).toEqual([5, 6])
+    expect(semestersForYear("BE")).toEqual([7, 8])
+  })
+
+  it("returns null for anything that is not a programme year", () => {
+    expect(semestersForYear("Graduated")).toBeNull()
+    expect(semestersForYear("")).toBeNull()
+  })
+})
+
+describe("semestersForClass", () => {
+  const on = new Date("2026-08-01")
+
+  // The bug this exists to prevent: a BE class's subject filed under semester 1,
+  // three years before that cohort sat it.
+  it("gives a 2023 cohort its final-year semesters", () => {
+    expect(semestersForClass(2023, on)).toEqual([7, 8])
+  })
+
+  it("advances with the cohort", () => {
+    expect(semestersForClass(2026, on)).toEqual([1, 2])
+    expect(semestersForClass(2025, on)).toEqual([3, 4])
+    expect(semestersForClass(2024, on)).toEqual([5, 6])
+  })
+
+  it("returns null past the final year, where there is no semester left", () => {
+    expect(semestersForClass(2022, on)).toBeNull()
   })
 })

--- a/src/lib/roll-number.ts
+++ b/src/lib/roll-number.ts
@@ -170,3 +170,35 @@ export function currentYear(
     return storedYear
   }
 }
+
+/**
+ * The two semesters a programme year covers.
+ *
+ * A BE student sits semesters 7 and 8; putting their subject in "Semester 1"
+ * is not a small display slip, it files the result under a year they finished
+ * three years ago. The subject form defaulted to 1 because that was the lowest
+ * number, not because anything derived it.
+ */
+export function semestersForYear(year: string): [number, number] | null {
+  switch (year) {
+    case "FE":
+      return [1, 2]
+    case "SE":
+      return [3, 4]
+    case "TE":
+      return [5, 6]
+    case "BE":
+      return [7, 8]
+    default:
+      return null
+  }
+}
+
+/** The semesters a class can plausibly be taught, given when it was admitted. */
+export function semestersForClass(
+  admissionYear: number,
+  on: Date = new Date()
+): [number, number] | null {
+  const year = expectedYear(admissionYear, on)
+  return year ? semestersForYear(year) : null
+}


### PR DESCRIPTION
## Two things you spotted

### 1. ISA and MSE now sit in the row

The row showed total, percentage and grade; ISA/MSE/ESE were one click away behind the expander. A student checking against their own answer sheet wants **those three first** — the total is the thing they can already work out.

The expander keeps the detail: both MSEs separately, the averaged figure that actually enters the total, and the maxima.

**A blank is not a zero.** "Not entered" and "scored nothing" look identical as a bare `0`, and a student reading their own marks must be able to tell them apart. A component the course doesn't have shows a dash rather than an empty cell that reads like missing data.

### 2. Semester came from a form default, not from the cohort

You're right, and it's a bug I introduced. The subject form defaulted to **semester 1 because 1 was the lowest number** — so a BE class's subject was filed three years before that cohort sat it.

```
EC33T  2023-108-A  BE  semester=1  valid=7/8  WRONG
corrected 1 offering(s)
EC33T -> semester 7
```

`semestersForClass` derives the pair a cohort can actually be in from its admission year (FE 1/2, SE 3/4, TE 5/6, BE 7/8), and the picker now offers **only those two** rather than a free 1–8 number input. Existing data was audited against the same rule and the one wrong offering corrected on your live database.

## Testing

- [x] `npm run check` passes (0 errors; 2 pre-existing warnings) — **110 tests**, 5 new for semester derivation
- [x] `npm run build` passes
- [x] Live data audited and corrected

## Note

Publication (#87) is now live, so an unpublished subject appears under *Awaiting publication* without marks rather than in the table. EC33T will show its components in the row once the coordinator locks all three and publishes.
