### PR TITLE
feat(attendance): record attendance per subject, not per day

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# scratch: syllabus PDFs and other college material used while developing
+study/
+.preset/
+
 # dependencies
 /node_modules
 /.pnp

--- a/docs/UI_UX_SPEC.md
+++ b/docs/UI_UX_SPEC.md
@@ -1,0 +1,1118 @@
+# VERP UI/UX Product Specification
+
+Status: Proposed product and interaction specification  
+Audience: Product, design, frontend, backend, and QA  
+Applies to: Current VERP academic ERP surface  
+Last updated: 13 August 2026
+
+## 1. Product direction
+
+VERP should feel like an academic operations system, not a collection of CRUD pages. The interface must help each person understand four things immediately:
+
+1. What academic scope they are operating in.
+2. What needs their attention now.
+3. What they are allowed to view or change.
+4. What happened before and what happens next.
+
+The central organizing model is:
+
+```text
+Institution
+└── Department
+    ├── Faculty
+    ├── Classes and cohorts
+    │   ├── Coordinator and teachers
+    │   ├── Students
+    │   ├── Subject offerings
+    │   ├── Attendance sessions
+    │   ├── Marks components
+    │   ├── Lab batches
+    │   └── Results
+    └── Course catalogue
+```
+
+The same entity should appear in the same part of the product for every role. Roles change the available scope, information, and actions; they should not create unrelated navigation systems.
+
+## 2. Personas, responsibilities, and scope
+
+VERP has four technical tiers but five operational personas. Academic coordinator and teacher are both `faculty` tier users whose responsibilities come from their class assignments.
+
+| Persona              | Effective scope                           | Primary responsibility                                                                              | Must not see                                                          |
+| -------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Super-admin          | Entire institution                        | Configure departments, staff, roles, and cross-department governance                                | Nothing inside the institution, subject to data-retention rules       |
+| HOD                  | Appointed department(s)                   | Operate department, classes, staffing, catalogue, academic completion and exceptions                | Other departments unless separately appointed                         |
+| Academic coordinator | Coordinated class(es)                     | Own class operations, enrolment, subject allocation, coverage, attendance and assessment completion | Unassigned classes or other department records                        |
+| Teacher/TR           | Assigned class(es) and allocated subjects | Deliver attendance, marks and batches for assigned teaching work                                    | Unassigned subjects, unassigned classes and department administration |
+| Student              | Own student record                        | Understand attendance, marks, results and account state                                             | Any other student's record or staff workflows                         |
+
+### 2.1 Contextual role rules
+
+- A faculty member can be a coordinator in one class and a teacher in another.
+- The UI must display the role for the current context, not only the database tier.
+- HODs have cover authority for attendance and marks within their department.
+- Coordinators can allocate and reallocate subjects within coordinated classes.
+- Teachers can write only the subjects allocated to them, while class-level attendance follows their class assignment.
+- Super-admin is an institution-wide wildcard and cannot be restricted by permission overrides.
+- Capabilities decide whether an action is available; scope decides which records it applies to.
+
+### 2.2 Permission presentation rules
+
+- Hide actions the user never has permission to perform.
+- Disable actions only when the user has permission but the current record state prevents the action. Explain the reason beside or inside the disabled control.
+- A direct unauthorized URL must render a clear access-denied page or redirect to the nearest valid parent. It must never partially render sensitive content.
+- Destructive or institution-wide actions require an impact preview and confirmation.
+- Every mutation must show a success result using the same verb as its initiating action.
+- Permission and scope checks remain server authoritative. UI hiding is usability, not security.
+
+## 3. Design language
+
+### 3.1 Visual character
+
+The interface should resemble a calm academic control room: compact, credible, information-rich and operational. It should avoid decorative dashboard gradients, excessive cards and oversized marketing typography.
+
+### 3.2 Core palette
+
+| Token             | Value     | Use                                             |
+| ----------------- | --------- | ----------------------------------------------- |
+| Institutional ink | `#0B132B` | Sidebar, primary text, selected controls        |
+| Academic blue     | `#1D4ED8` | Primary actions, focus, links and current scope |
+| Canvas            | `#F6F8FC` | Application background                          |
+| Paper             | `#FFFFFF` | Work surfaces and tables                        |
+| Success           | `#15803D` | Completed, published, present and active        |
+| Attention         | `#B45309` | Pending, incomplete and approaching deadline    |
+| Critical          | `#B91C1C` | Failed, rejected, absent and destructive action |
+
+Status colors must always include text or an icon. Color alone cannot carry meaning.
+
+### 3.3 Typography
+
+- Primary UI: Source Sans 3 or the existing system sans stack until font loading is intentionally introduced.
+- Data and academic identifiers: IBM Plex Mono for roll numbers, course codes, class keys and employee IDs.
+- Headings: compact, sentence case, medium or semibold; avoid oversized headings.
+- Table text: 13–14 px with tabular numerals for marks, attendance and counts.
+- Secondary labels: 12 px, never below 11 px.
+
+### 3.4 Signature element: Academic context trail
+
+Every protected page carries an academic context trail:
+
+```text
+VIT / EXCS / BE A / Data Analytics / Semester 1
+```
+
+Each segment is interactive when the user may switch it. This trail is the product's main structural signature and replaces decorative dashboard elements.
+
+### 3.5 Layout density
+
+- Desktop content width uses the available viewport; operational tables should not be trapped inside narrow centered columns.
+- Use cards only for independent summaries or decisions. Use sections and dividers for related information.
+- Page headers remain sticky below the application header when a page contains long tables.
+- Primary actions live in the page header; local row actions live with the record.
+- Use right-side detail drawers for quick inspection and full pages for multi-step or high-risk editing.
+
+## 4. Global application shell
+
+### 4.1 Desktop shell
+
+```text
+┌──────────────┬──────────────────────────────────────────────────────────┐
+│ VOSS / VERP  │ VIT / EXCS / BE A       Search     Alerts     User     │
+├──────────────┼──────────────────────────────────────────────────────────┤
+│ Overview     │ Page title                              Primary action  │
+│ Organization │ Context, status and supporting copy                     │
+│ Academics    ├──────────────────────────────────────────────────────────┤
+│ People       │ Attention strip / page tabs                             │
+│ Attendance   ├──────────────────────────────────────────────────────────┤
+│ Assessment   │ Main workspace                                           │
+│ Reports      │                                                          │
+│ Admin        │                                                          │
+└──────────────┴──────────────────────────────────────────────────────────┘
+```
+
+### 4.2 Header
+
+The persistent header displays:
+
+- Scope switcher: institution, department, class and subject when applicable.
+- Academic period switcher: academic year and semester.
+- Global search across records allowed by current scope.
+- Attention inbox, not a generic notification placeholder.
+- Contextual role such as `HOD · EXCS` or `Coordinator · BE A`.
+- User menu with VOSS account, theme and sign out.
+
+### 4.3 Sidebar
+
+Use stable domain navigation:
+
+| Domain         | Contents                                           |
+| -------------- | -------------------------------------------------- |
+| Overview       | Role-specific command centre                       |
+| Organization   | Departments and institutional structure            |
+| Academics      | Classes, course catalogue and subject offerings    |
+| People         | Faculty and students                               |
+| Attendance     | Sessions, completion and exceptions                |
+| Assessment     | Marks, locks, results and publication              |
+| Reports        | Scoped exports and analytical views                |
+| Administration | Roles, permissions, audit and system configuration |
+
+Only domains containing at least one accessible page are shown. Navigation is generated from effective capabilities and scope, not a hardcoded role array.
+
+### 4.4 Command palette and global search
+
+The command palette opens with `Cmd/Ctrl + K` and supports:
+
+- Find a student by name or roll number.
+- Find faculty by name, email or employee ID.
+- Jump to a class, department or course.
+- Start a permitted action such as Take attendance or Import marks.
+- Switch current department or class context.
+
+Results must be scope-filtered on the server.
+
+### 4.5 Attention inbox
+
+The inbox shows work requiring action:
+
+- Enrolment requests.
+- Unsubmitted attendance sessions.
+- Incomplete marks components.
+- Unallocated subjects.
+- Classes without coordinators.
+- Failed imports.
+- Permission changes requiring review.
+
+Each item links to the exact filtered workspace needed to resolve it.
+
+## 5. Shared interaction patterns
+
+### 5.1 Record tables
+
+Every major table supports:
+
+- Search with visible matching fields.
+- Named filters with human-readable default labels.
+- Sortable columns.
+- Saved views for repeat workflows.
+- Column visibility where the dataset is wide.
+- Sticky header and sticky identity column.
+- Filter state encoded in the URL.
+- Current result count.
+- Bulk selection limited to the filtered scope.
+- Export of the current filtered and sorted view.
+- Empty, loading, error and no-results states.
+
+On mobile, operational tables become record lists or cards. Horizontal scrolling is reserved for comparison-heavy marks and results tables.
+
+### 5.2 Detail drawer
+
+Selecting a person, course or class from a table opens a drawer with:
+
+- Identity and status.
+- Key facts.
+- Current assignments or relationships.
+- Recent activity.
+- Permitted quick actions.
+- Link to the full record.
+
+The user retains table filters and scroll position when the drawer closes.
+
+### 5.3 Status language
+
+Use consistent workflow states:
+
+```text
+Identity: Unclaimed → Awaiting review → Approved → Active
+Attendance: Not opened → In progress → Complete → Submitted → Corrected
+Marks: Not started → In progress → Submitted → Locked → Published
+Staffing: Unallocated → Assigned → Active → Reassigned
+Import: Uploaded → Reviewing → Ready → Importing → Completed / Failed
+```
+
+### 5.4 Audit history
+
+Audit history appears both globally and contextually. A student, faculty member, class, course or subject drawer should show relevant recent events. Each event states actor, action, time, scope, and changed values where safe.
+
+## 6. Page specifications
+
+### 6.1 Login
+
+Route: `/login`
+
+Audience: Signed-out users.
+
+Purpose: Explain the single VOSS authentication path and initiate sign-in.
+
+Display:
+
+- VERP and VIT identity.
+- One-sentence product description.
+- `Continue with VOSS` primary action.
+- Clear explanation: no VERP password exists; VOSS verifies the email.
+- Support link for inaccessible college email or account issues.
+- Service-status message only when authentication is degraded.
+
+UX requirements:
+
+- No feature-pill marketing clutter on small screens.
+- While redirecting, show a progress state and prevent duplicate clicks.
+- On OAuth failure, state whether the user can retry or must contact support.
+- Preserve the intended destination so successful login returns to the requested page when authorized.
+
+### 6.2 Unclaimed account and enrolment
+
+Route: `/unclaimed`
+
+Audience: VOSS-authenticated users without a linked faculty or student record.
+
+Purpose: Explain why access is pending and give the correct next action.
+
+Display variants:
+
+| State                   | Display                                                                 | Primary action                          |
+| ----------------------- | ----------------------------------------------------------------------- | --------------------------------------- |
+| No request              | Verified email, enrolment form and roll-number interpretation preview   | Request enrolment                       |
+| Pending                 | Submitted identity, target class, submission time and review owner      | None; show expected next step           |
+| Unrouted                | Explanation that the class is not configured and responsible department | Contact department or retry after setup |
+| Rejected                | Decision reason and whether resubmission is allowed                     | Correct and resubmit                    |
+| Faculty not provisioned | Verified email and department support direction                         | Contact department administrator        |
+
+The email is displayed as verified and locked. Roll number parsing should preview admission year, branch, division and expected class before submission.
+
+### 6.3 Overview command centre
+
+Route: `/dashboard`
+
+This route renders a different operational home for each persona.
+
+#### Super-admin overview
+
+Display:
+
+- Institution configuration health.
+- Departments without HODs.
+- Classes without coordinators or TRs.
+- Faculty and student identity exceptions.
+- Recent privileged activity.
+- Permission override count and recent changes.
+- Failed imports and system errors.
+- Cross-department academic completion summary.
+
+Primary actions: Add department, add faculty, appoint HOD, review permissions.
+
+Do not display generic totals without exceptions or drill-downs.
+
+#### HOD overview
+
+Display:
+
+- Department identity and leadership.
+- Classes by year/division with staffing and completion status.
+- Faculty workload and unallocated subjects.
+- Students pending claim or enrolment.
+- Today's attendance completion.
+- Marks completion by component and semester.
+- Decisions requiring HOD attention.
+
+Primary actions: Create class, add faculty, allocate subjects, resolve exception.
+
+#### Coordinator overview
+
+Display:
+
+- Current class and ability to switch coordinated classes.
+- Enrolment requests.
+- Today’s attendance sessions and completion.
+- Subject allocation status.
+- Marks components awaiting entry, lock or publication.
+- Lab batch completeness.
+- Students with missing academic records.
+
+Primary actions: Take attendance, review enrolment, allocate subject, enter marks.
+
+#### Teacher/TR overview
+
+Display:
+
+- Today’s assigned classes and subjects.
+- Attendance work due.
+- Marks work due per subject and component.
+- Locked and submitted work.
+- Students with incomplete records in assigned classes.
+- Recently saved activity for confidence and recovery.
+
+Primary actions: Take attendance, enter marks, import marks, manage lab batch.
+
+#### Student overview
+
+Display:
+
+- Attendance by subject with overall and threshold state.
+- Published and provisional marks clearly separated.
+- SGPI/CGPA only when computable.
+- Current subjects and credit progress.
+- Academic notices affecting the student.
+- Identity, class and department context.
+
+Primary actions: View detailed marks, inspect attendance by subject.
+
+### 6.4 Administration landing
+
+Route: `/dashboard/admin`
+
+Audience: Super-admin.
+
+Purpose: Institution configuration and governance entry point.
+
+Display:
+
+- Setup completion checklist across departments, faculty, leadership and classes.
+- Configuration exceptions ordered by operational impact.
+- Recent admin changes.
+- Links to Departments, Faculty, Roles and permissions, and Activity log.
+
+The page should not be three generic navigation cards. It should show whether the institution is ready to operate.
+
+### 6.5 Department administration
+
+Route: `/dashboard/admin/departments`
+
+Audience: Super-admin.
+
+Scope: All departments.
+
+Display:
+
+- Department table: code, name, HOD, coordinator, active classes, faculty, students, configuration status and activity state.
+- Setup-progress indicator for each department.
+- Quick creation of standard VIT branches without hiding the normal add flow.
+- Department detail drawer on row selection.
+
+Actions:
+
+- Add department.
+- Appoint or change HOD.
+- Activate/deactivate department with impact preview.
+- Open department workspace.
+
+Empty state: Explain that departments are the root of classes, faculty, courses and students; offer Add department.
+
+### 6.6 Faculty administration
+
+Route: `/dashboard/admin/faculty`
+
+Audience: Super-admin.
+
+Scope: All faculty.
+
+Display:
+
+- Searchable faculty directory with employee ID, department, tier, contextual assignments, subjects, identity claim state and active status.
+- Filters for department, tier, assignment, claim and status.
+- Workload summary inside the faculty drawer.
+- Separate visual treatment for institutional tier and contextual class role.
+
+Actions:
+
+- Add faculty.
+- Change tier with an impact preview.
+- Appoint department leadership.
+- Activate/deactivate faculty.
+- Review or revoke sessions where supported.
+
+Do not label deactivation as Remove. Preserve the distinction between inactive records and deletion.
+
+### 6.7 Roles and permissions
+
+Route: `/dashboard/admin/roles`
+
+Audience: Super-admin.
+
+Display:
+
+- Searchable capability matrix grouped by domain.
+- Sticky capability column and sticky role headers.
+- Baseline, granted override and denied override shown distinctly.
+- Effective user count affected by each tier change.
+- Side panel explaining selected capability, enforcement points and scope behavior.
+- Recent permission changes.
+
+Actions:
+
+- Grant or revoke a tier capability.
+- Return an override to baseline.
+- Add an audit reason for high-impact changes.
+
+Confirmation is required when revoking a default capability or granting an administrative capability. User-specific exceptions should be introduced only with a defined operational need.
+
+### 6.8 Department hub
+
+Route: `/dashboard/dept`
+
+Audience: Super-admin and HOD.
+
+Scope:
+
+- Super-admin sees every department and can switch among them.
+- HOD sees only appointed department(s).
+
+Display:
+
+- Department switcher or single-department identity.
+- Class grid grouped by programme year and division.
+- Staffing completeness, roster size, attendance state and assessment state per class.
+- Department-level attention list.
+- Compact faculty and course health summaries.
+
+Actions:
+
+- Open department workspace.
+- Create class.
+- Add faculty.
+- Resolve an unstaffed class.
+- Graduate a cohort with impact confirmation.
+
+### 6.9 Department workspace
+
+Route: `/dashboard/dept/[code]`
+
+Audience: Super-admin and in-scope HOD.
+
+Tabs:
+
+```text
+Overview | Classes | Faculty | Students | Courses | Attendance | Assessment | Activity
+```
+
+Overview displays:
+
+- Leadership.
+- Active academic period.
+- Class and staffing health.
+- Claimed/unclaimed student state.
+- Attendance completion.
+- Marks completion.
+- Operational exceptions.
+
+Classes tab displays class, coordinator, teachers, student count, attendance status, marks status and cohort state.
+
+Faculty tab displays assignments and workload rather than only directory fields.
+
+Activity tab displays department-scoped audit events.
+
+### 6.10 Faculty appointments and workload
+
+Route: `/dashboard/dept/appoint`
+
+Audience: Super-admin and HOD.
+
+Scope: Current department.
+
+Purpose: Assign people to classes and subjects while seeing workload impact.
+
+Display:
+
+- Faculty list with search, workload and current responsibilities.
+- Selected faculty detail with classes, contextual role and subjects.
+- Unstaffed classes and unallocated subjects as actionable queues.
+- Before/after workload preview for a proposed assignment.
+
+Actions:
+
+- Assign/remove coordinator or teacher role.
+- Allocate/reallocate a subject.
+- Open the faculty or class record.
+
+Avoid a long single-page form. Use a two-pane assignment workspace on desktop and sequential drawers on mobile.
+
+### 6.11 Course catalogue
+
+Route: `/dashboard/dept/courses`
+
+Audience: Super-admin and in-scope HOD; read-only visibility may be available to scoped faculty.
+
+Display:
+
+- Course code, name, programme year, type, credits, marks structure, active offerings and state.
+- Filters for department, year, type, active state and in-use state.
+- Course detail drawer showing all active offerings and change history.
+- Clear distinction between catalogue definition and a class-specific subject offering.
+
+Actions:
+
+- Add course.
+- Edit course.
+- Activate/deactivate with usage impact.
+- Import syllabus.
+- Open affected class offerings.
+
+### 6.12 Syllabus import
+
+Route: `/dashboard/dept/courses/import`
+
+Audience: Super-admin and in-scope HOD.
+
+Use a step-based workflow:
+
+```text
+Upload PDF → Parse → Review courses → Resolve warnings → Confirm import → Result
+```
+
+Display:
+
+- File requirements before upload.
+- Parsing progress with page count.
+- Editable review table.
+- Existing-course conflicts.
+- Marks-total validation.
+- Selected versus skipped course count.
+- Final created, skipped and failed results.
+
+The final confirmation names the target department and academic year.
+
+### 6.13 Faculty import
+
+Route: `/dashboard/dept/faculty-import`
+
+Audience: Super-admin and in-scope HOD.
+
+Use the same import grammar as syllabus and roster imports.
+
+Display:
+
+- Downloadable template.
+- Parsed faculty preview.
+- Duplicate email and employee-ID warnings.
+- Optional class/role assignment, with scope shown explicitly.
+- Final created, reused, assigned and failed counts.
+
+No row may silently land in a department different from the selected scope.
+
+### 6.14 Faculty directory
+
+Route: `/dashboard/faculty`
+
+Audience: Super-admin and in-scope HOD.
+
+Display:
+
+- Scoped faculty directory.
+- Employee identity, department tier, contextual class roles, subject allocation, workload, claim state and status.
+- Faculty detail drawer with assignments and recent activity.
+
+HOD actions are restricted to faculty within their department. Super-admin can cross departments.
+
+### 6.15 Class list
+
+Route: `/dashboard/class`
+
+Audience: Coordinator and teacher; optionally HOD through department navigation.
+
+Display:
+
+- Classes assigned to the user.
+- Contextual role per class.
+- Today’s attendance state.
+- Enrolment request count.
+- Subject and marks completion.
+- Next required action.
+
+Sort by urgency first, then academic year/division. Do not show empty global statistics.
+
+### 6.16 Class workspace
+
+Route: `/dashboard/class/[classId]`
+
+Audience: Super-admin, in-scope HOD, assigned coordinator and assigned teacher.
+
+Tabs:
+
+```text
+Overview | Students | Subjects | Attendance | Marks | Batches | Results | Activity
+```
+
+Header displays:
+
+- `BE · EXCS · A` and class key.
+- Coordinator and teachers.
+- Student count and claim state.
+- Contextual role of the current user.
+- Academic period.
+
+Overview displays:
+
+- Enrolment requests.
+- Staffing gaps.
+- Today’s attendance completion.
+- Subject allocation.
+- Marks completion and lock status.
+- Result readiness.
+- Recent class activity.
+
+Role differences:
+
+- Coordinator sees all class workflows and exceptions.
+- Teacher sees assigned teaching work first and class-wide read-only summaries where allowed.
+- HOD sees completion, intervention and cover actions.
+- Super-admin sees the full operational view.
+
+### 6.17 Student roster
+
+Route: `/dashboard/students`
+
+Audience: Super-admin, in-scope HOD, assigned coordinator and teacher.
+
+Scope:
+
+- Super-admin: all students.
+- HOD: department students.
+- Coordinator/teacher: assigned class students.
+
+Display:
+
+- Roll number, name, class, department, claim state, attendance health, assessment completeness and active state.
+- Human-readable filter defaults such as All departments and All years.
+- Saved views: Unclaimed, Attendance risk, Missing marks, Graduated and Inactive.
+- Student detail drawer on row selection.
+
+Actions vary by role:
+
+- Super-admin/HOD: deactivate within scope, export, inspect history.
+- Coordinator: review enrolment and class record state.
+- Teacher: read academic context; no identity or lifecycle mutation without capability.
+
+Import roster is shown only when the user can import into the current explicit scope.
+
+### 6.18 Student detail
+
+Route: `/dashboard/students/[id]`
+
+Audience: Authorized staff within student scope. Students use their self-service pages instead.
+
+Header displays:
+
+- Name, roll number, class, department and active/claim state.
+- No decorative avatar is required when no real image exists; initials are sufficient.
+
+Tabs:
+
+```text
+Summary | Attendance | Marks | Results | Identity | Activity
+```
+
+Summary displays:
+
+- Current class and academic period.
+- Attendance by subject.
+- Assessment completion.
+- Current SGPI/CGPA state.
+- Exceptions needing staff attention.
+
+Identity displays verified email, binding date and claim state without exposing authentication secrets.
+
+Actions require explicit permissions and must show impact. A teacher should not receive student lifecycle actions merely because they can read the roster.
+
+### 6.19 Roster import
+
+Route: `/dashboard/students/import`
+
+Audience: Super-admin, in-scope HOD and faculty importing into an assigned class.
+
+The target scope must be selected before file upload and remain visible throughout:
+
+```text
+Target: EXCS / BE A / Admission year 2023
+```
+
+Workflow:
+
+```text
+Choose target → Upload workbook → Select sheet → Review rows → Resolve errors → Confirm → Result
+```
+
+Display:
+
+- Downloadable template and accepted formats.
+- Sheet and header detection.
+- Derived class preview from every roll number.
+- Duplicate, malformed and out-of-scope rows.
+- Exact valid/invalid counts.
+- Atomic-import choice: reject entire file when any row violates scope.
+- Final audit reference.
+
+Department and class fields derived from roll numbers cannot be freely changed to contradict the target scope.
+
+### 6.20 Attendance workspace
+
+Route: `/dashboard/class/[classId]/attendance`
+
+Audience: Super-admin, in-scope HOD, coordinator and assigned teacher with write capability.
+
+Header controls:
+
+- Class context.
+- Local college date.
+- Subject or homeroom session.
+- Lecture/lab slot and start time.
+- Draft/submitted/corrected state.
+
+Display:
+
+- Students begin Unmarked, never Present by default.
+- Completion progress: `63 of 89 marked`.
+- Search by roll or name.
+- Quick filters: Unmarked, Present, Absent, Late, Excused.
+- Bulk Mark remaining present action with confirmation.
+- Sticky Save draft and Submit attendance actions.
+- Existing-session history and correction reason.
+
+Desktop row:
+
+```text
+23108A0023  Mandar Patil        Unmarked  Present  Absent  Late  Excused
+```
+
+Mobile row:
+
+```text
+23108A0023  Mandar Patil
+[Present] [Absent] [More]
+```
+
+After submission, the page becomes read-only until a permitted correction is started. Correcting requires a reason and produces an audit event.
+
+### 6.21 Subject allocation
+
+Route: `/dashboard/class/[classId]/subjects`
+
+Audience: Super-admin, in-scope HOD, coordinator; assigned teacher has read-only access.
+
+Display:
+
+- Subject offerings grouped by semester.
+- Course code/name, type, credits, marks structure, assigned teacher, batch requirement and status.
+- Unallocated subjects at the top as an attention queue.
+- Catalogue browser filtered to the class year and department.
+- Teacher workload during allocation.
+
+Actions:
+
+- Add offering from catalogue.
+- Allocate or reallocate teacher.
+- Leave intentionally unallocated with a visible warning.
+- Open marks or batches.
+
+Teacher experience: show only the offering details and responsibility; hide allocation controls.
+
+### 6.22 Marks workspace
+
+Route: `/dashboard/class/[classId]/marks`
+
+Audience: Super-admin, in-scope HOD, coordinator and assigned teacher.
+
+Subject selection view displays:
+
+- Assigned offerings first.
+- Teacher, semester and marks structure.
+- Completion for ISA, MSE and ESE.
+- Lock and publication state.
+- Missing-student count.
+
+Marks grid displays:
+
+- Sticky roll and name columns.
+- Component inputs with maximum marks in the header.
+- Inline range validation.
+- Autosaved draft indicator or explicit unsaved-change indicator.
+- Provisional total clearly separated from final grade.
+- Lock state per component.
+- Filter for incomplete or invalid rows.
+- Import and export actions.
+- Submit/lock action distinct from Save draft.
+
+Role behavior:
+
+- Assigned teacher edits allocated offering.
+- Coordinator can cover, review, lock and reopen within coordinated class.
+- HOD can cover and reopen within department.
+- Super-admin can intervene institution-wide.
+
+An incomplete subject displays In progress, never a misleading final zero.
+
+### 6.23 Marks import
+
+Route: `/dashboard/class/[classId]/marks/import`
+
+Audience: Users allowed to write the selected offering.
+
+Workflow:
+
+```text
+Select subject → Upload → Map columns → Match roster → Review → Confirm → Result
+```
+
+Display:
+
+- Explicit target class and subject.
+- Detected column headers and editable mapping.
+- Matched and unmatched rolls.
+- Maximum-mark violations.
+- Existing marks that would be replaced.
+- Locked components excluded from mutation.
+- Before/after value preview for changed cells.
+
+Reject out-of-class students and preserve all locked components server-side.
+
+### 6.24 Lab batches
+
+Route: `/dashboard/class/[classId]/batches`
+
+Audience: Super-admin, in-scope HOD, coordinator and assigned practical/project teacher.
+
+Display:
+
+- Practical/project offering selector.
+- Batch cards with name, size, teacher, schedule if available and unassigned count.
+- Unassigned-student queue.
+- Duplicate or conflicting assignment warnings.
+- Balanced distribution suggestion as an assistive action, not automatic mutation.
+
+Actions:
+
+- Create/rename/deactivate batch.
+- Assign or move scoped students.
+- Remove student with confirmation when it affects attendance records.
+- Export batch list.
+
+Theory-only empty state explains why batches are unavailable and links to Subjects.
+
+### 6.25 Class results
+
+Route: `/dashboard/class/[classId]/results`
+
+Audience: Super-admin, in-scope HOD, coordinator and assigned teacher with results-read permission.
+
+Display:
+
+- Publication/readiness banner.
+- Result completeness: students complete, incomplete and failed.
+- Filters for result state, semester and subject.
+- Roll, name, SGPI/CGPA, credits, result state and breakdown.
+- Student breakdown drawer with component provenance.
+- Export metadata: class, academic period, generated time and actor.
+
+Do not show `0 credits / 0 semesters` as if it were a valid result. Use Not yet computable and explain missing components.
+
+Publication must be a separate governed state from marks entry and locking.
+
+### 6.26 Student marks and results
+
+Route: `/dashboard/my-marks`
+
+Audience: Student only.
+
+Display:
+
+- Current CGPA and semester SGPI only when computable.
+- Credits earned and attempted.
+- Published versus provisional subjects.
+- Subject rows with total, percentage, grade and publication state.
+- Expandable component breakdown: ISA, both MSEs, counted MSE and ESE.
+- Clear explanation when a result is held or incomplete.
+- Academic-period switcher for history.
+
+Future attendance detail should sit beside this as My attendance, using subject-level percentages and session history.
+
+Mobile uses stacked semester sections and expandable subject cards rather than a wide table.
+
+### 6.27 Activity log
+
+Route: `/dashboard/audit`
+
+Audience: Super-admin by default; department-scoped audit may be granted to HOD deliberately.
+
+Display:
+
+- Time, actor, action, scope, target and concise change summary.
+- Filters for time, actor, domain, action, department, class and target.
+- Detail drawer with structured before/after values where captured.
+- Links to the affected record when still available.
+- Export with active filters and generation metadata.
+
+Unauthorized users receive a full access-denied state, not a mostly empty audit page.
+
+### 6.28 Missing, unavailable and access-denied pages
+
+Routes: `/dashboard/[...missing]`, `not-found`, and guarded fallbacks.
+
+Differentiate:
+
+- Record does not exist.
+- Record exists but is outside scope.
+- User lacks capability.
+- Record is inactive or archived.
+- Feature is not configured.
+
+Do not reveal sensitive record existence to out-of-scope users. Provide a safe route back to the nearest valid workspace.
+
+## 7. Responsive behavior
+
+### 7.1 Desktop priorities
+
+Desktop serves super-admin and HOD comparison-heavy work:
+
+- Persistent sidebar.
+- Multi-column operational layouts.
+- Dense tables with sticky columns.
+- Two-pane assignment workspaces.
+- Side drawers for inspection.
+
+### 7.2 Tablet priorities
+
+- Collapsible sidebar.
+- Two-column summaries become one or two columns based on available width.
+- Page actions collapse into an overflow menu only after preserving the primary action.
+- Drawers may become full-height sheets.
+
+### 7.3 Mobile priorities
+
+Mobile is a first-class surface for teachers and students:
+
+- Bottom or compact drawer navigation for key domains.
+- Sticky primary action at the bottom for long attendance/marks workflows.
+- Tables become lists except where column comparison is essential.
+- Touch targets are at least 44 px.
+- Filters open in a sheet with an active-filter count.
+- Context trail collapses to current class/subject with a back hierarchy.
+- No important action depends on hover.
+
+## 8. Loading, empty, error and success states
+
+Every page specification includes four non-happy states.
+
+### Loading
+
+- Preserve the actual page structure with skeletons.
+- Do not flash an empty navigation or `User` identity while client auth loads.
+- Long imports show deterministic steps and progress when available.
+
+### Empty
+
+An empty state explains why the page is empty and the correct next action.
+
+Examples:
+
+- `No classes are assigned to you. Ask your HOD to add you to a class.`
+- `No subjects are on this class. Add one from the EXCS catalogue.`
+- `No marks are published yet. Entered components will appear after publication.`
+
+### Error
+
+- State what failed.
+- Preserve user-entered data.
+- Explain whether retry is safe.
+- Include a reference ID for support when the failure is logged.
+
+### Success
+
+- Use the same action verb: `Attendance submitted`, `Marks saved`, `Subject allocated`.
+- For high-impact changes, summarize the affected records.
+- Keep an Undo action only when reversal is safe and audited.
+
+## 9. Accessibility requirements
+
+- Meet WCAG 2.2 AA contrast and interaction requirements.
+- All functionality works by keyboard.
+- Visible focus is never removed.
+- Tables have correct header relationships and useful accessible names.
+- Status changes are announced through a polite live region.
+- Validation errors are connected to their fields.
+- Dialogs and drawers trap and restore focus correctly.
+- Charts, where introduced, include textual equivalents.
+- Reduced-motion preference disables nonessential transitions.
+- Dates and numbers are readable without relying on color.
+
+## 10. Content and terminology
+
+Use one vocabulary across the product:
+
+| Use                  | Avoid                                                          |
+| -------------------- | -------------------------------------------------------------- |
+| Student roster       | All Students when the view is scoped                           |
+| Faculty              | Staff member where the record is specifically academic faculty |
+| Academic coordinator | AC without first defining it                                   |
+| Teacher              | TR when the user-facing responsibility is teaching             |
+| Deactivate           | Remove or Delete for retained records                          |
+| Save draft           | Save when submission is a separate state                       |
+| Submit attendance    | Save attendance when it becomes governed/final                 |
+| Publish results      | Make live                                                      |
+| Course catalogue     | Subjects when referring to reusable course definitions         |
+| Subject offering     | Course when referring to a class-specific instance             |
+
+Sentence case is used for page titles, buttons and labels. Avoid internal capability names such as `marks:write` outside the permissions console.
+
+## 11. Analytics and UX quality signals
+
+Collect privacy-respecting product signals:
+
+- Time to complete attendance.
+- Percentage of attendance sessions submitted without correction.
+- Time from enrolment request to decision.
+- Time from marks entry start to locked completion.
+- Import error rate by type.
+- Number of unallocated subjects and unstaffed classes over time.
+- Search-to-record success rate.
+- Permission-denied events by route and action.
+- Mobile completion rate for faculty workflows.
+
+Do not use engagement time as a success metric. ERP success means correct work completed with fewer errors and less administrative friction.
+
+## 12. Implementation sequence
+
+### Phase 1: secure interaction foundation
+
+- Close cross-scope roster, marks and batch write gaps.
+- Reconcile HOD and coordinator capabilities with the workflow model.
+- Pass server-resolved identity and scope into the application shell.
+- Build capability-driven navigation and the academic context trail.
+
+### Phase 2: operational workspaces
+
+- Build role-specific overview command centres.
+- Convert department and class pages into tabbed workspaces.
+- Introduce shared table, detail-drawer, attention and audit components.
+
+### Phase 3: academic workflows
+
+- Redesign attendance around explicit sessions and an Unmarked state.
+- Separate marks draft, submit, lock and publish states.
+- Standardize roster, marks, faculty and syllabus imports.
+- Add subject and batch workflow completion states.
+
+### Phase 4: student and mobile quality
+
+- Build subject-level student attendance.
+- Unify provisional and final marks semantics.
+- Replace mobile admin tables with record lists where appropriate.
+- Optimize attendance and marks entry for touch.
+
+### Phase 5: governance and polish
+
+- Improve the permission console and impact previews.
+- Add contextual audit history.
+- Add saved views, global search and the attention inbox.
+- Apply final visual, accessibility and performance QA.
+
+## 13. Definition of done for each redesigned page
+
+A page is complete only when:
+
+- Its permitted personas and exact scope are documented and tested.
+- Its primary user job is clear above the fold.
+- Its data is scope-filtered server-side.
+- Its actions map to capabilities and contextual responsibility.
+- Loading, empty, error, success and access-denied states exist.
+- It works at desktop, tablet and mobile sizes appropriate to its persona.
+- Keyboard navigation and screen-reader semantics are verified.
+- High-impact mutations provide an impact preview and audit event.
+- Filters and selection survive drawers and reasonable navigation.
+- No placeholder count, fake chart, dead control or internal sentinel reaches production.

--- a/research/verp-rbac-ux-audit-2026-08-13.md
+++ b/research/verp-rbac-ux-audit-2026-08-13.md
@@ -1,0 +1,165 @@
+# VERP RBAC and ERP UX Audit
+
+Date: 2026-08-13  
+Target: `https://verp.vosslabs.org/`  
+Scope: repository architecture, production demo identities, role and scope boundaries, first-login identity binding, academic workflows, responsive behavior, and UI/UX consistency.
+
+## Executive verdict
+
+VERP has a sound RBAC foundation: VOSS is the only authentication door, identity binding uses verified email, session resolution carries role and scope separately, capability precedence is unit-tested, page guards generally fail closed, and the tested roles could not navigate into higher-privilege surfaces.
+
+It is not ready to hold production academic records without hardening three write paths. An authenticated faculty member can submit roster rows outside their scope, and forged marks or batch payloads can name students outside the target class. The capability model also disagrees with the coordinator and HOD workflows rendered by the UI, leaving legitimate controls unusable.
+
+Recommended direction: repair the scoped write boundary first, then reconcile role defaults with the workflow rules already encoded in `allocation.ts`. Do not begin with visual polish while cross-scope academic writes remain possible.
+
+## Test environment and data state
+
+- Production demo identities verified: `admin@vosslabs.org`, `hod@vosslabs.org`, `ac@vosslabs.org`, `tr@vosslabs.org`, and `student@vosslabs.org`.
+- HOD scope: department `EXCS`.
+- Coordinator and TR scope: class `2023-108-A` / `BE · EXCS · A`.
+- No permission overrides existed during the audit.
+- The seeded student row for `student@vosslabs.org` was unclaimed before testing. The normal VOSS first-login flow created its auth identity and VERP bound it to roll `23108A0099`. The `identity.bound` audit event was verified.
+- No attendance, marks, permissions, roster, course, class, faculty, or department data was modified.
+- `npm run check` passed: typecheck, formatting, 80 Vitest tests, and lint with two non-blocking warnings.
+- Production emitted one React hydration error (`#418`, text mismatch) while switching and loading role surfaces.
+
+## RBAC model observed
+
+| Tier | Intended scope | Verified accessible surfaces | Verified denied surfaces |
+|---|---|---|---|
+| Super-admin | Institution-wide wildcard | Admin console, departments, faculty, role matrix, audit, all students, all class academic pages | None in the tested ERP surface |
+| HOD | Appointed department(s) | Department/classes, faculty, course catalogue, students, class overview, subject allocation | Admin console, audit, student self view; attendance and marks entry are also denied |
+| Coordinator | Assigned coordinator class(es) | Class roster, enrolment queue, attendance, marks, locks, results, batches, subject UI | Admin, department console, faculty, audit, out-of-class students |
+| TR/faculty | Assigned class(es), allocated offerings | Class roster, enrolment queue, attendance, own offering marks, results, batches | Admin, department console, faculty, audit, out-of-class students, student self view |
+| Student | Own linked student ID | Own dashboard and marks/SGPI | Every staff/admin surface, roster/import, class pages, audit, own and other student-detail URLs |
+
+Direct URL checks confirmed that navigation hiding is not the only control: server-rendered guards redirected or denied unauthorized pages. A coordinator request for a known student in another class redirected to the coordinator's scoped roster.
+
+## Findings
+
+### P0: roster import permits cross-scope student creation
+
+`src/app/api/students/import/route.ts:32-34` checks only `isStaff(user)`. It then trusts each submitted `department`, `division`, and roll-derived `classKey` and inserts the row at lines 97-109. There is no comparison with `user.deptCodes`, `user.classKeys`, or a capability dedicated to roster creation.
+
+Impact: any authenticated faculty member, including a TR assigned to one class, can forge a POST payload that creates students for another class or department. The UI exposes Import roster to every faculty user, so this is not an unreachable code path.
+
+Required fix: derive department and class from the roll on the server, reject mismatches in the supplied descriptive fields, and enforce one scope rule before any insert:
+
+- super-admin: any valid known class/department;
+- HOD: derived department in `deptCodes`;
+- faculty: derived class key in `classKeys`.
+
+Apply the same scope validation in preview and commit, but treat commit as authoritative.
+
+### P0: marks and batch writes accept students outside the class
+
+`saveMarksAction` verifies the offering and caller's class/subject authority, but maps every submitted `studentId` directly into the upsert (`src/app/dashboard/class/actions.ts:303-310`). Unlike attendance (`lines 165-179`), it never intersects the submitted IDs with the target class roster. The marks table has no database constraint linking a student to the offering's class.
+
+`assignBatchAction` has the same gap (`src/app/dashboard/class/actions.ts:479-483`): arbitrary student IDs are passed into `assignStudentsToBatch`, and the batch-assignment schema only checks that both referenced rows exist.
+
+Impact: a teacher can attach marks or lab-batch membership from their offering to a student in another class. `getMarksForStudent` reads by student ID alone, so the foreign mark can appear in that student's academic record.
+
+Required fix: create one reusable `requireStudentsInClass(classKey, ids)` boundary and call it from marks, batch assignment, attendance, imports, and future enrolment writes. Reject the entire request when any ID is outside scope; silently dropping forged IDs makes corruption attempts harder to detect. Add database-level enrolment/class invariants or RLS as the second layer.
+
+### P1: coordinator controls are rendered but capability checks reject them
+
+The Subjects page recognizes `coordinatorClassIds` and renders allocation controls (`src/app/dashboard/class/[classId]/subjects/page.tsx:29-34`). `allocation.ts` also states that coordinators may allocate subjects. However:
+
+- `createSubjectAction` first requires `offering:create`;
+- `assignOfferingFacultyAction` first requires `offering:update`;
+- the faculty defaults in `src/lib/rbac.ts:183-197` grant neither capability.
+
+Impact: the coordinator sees teacher selectors and Add from catalogue, but the corresponding server actions return Forbidden.
+
+Required fix: grant `offering:create` and `offering:update` to the faculty tier, retaining `canAllocate(...)` as the class-assignment scope check that excludes plain TRs. Add integration tests for coordinator success and TR denial.
+
+### P1: HOD workflow copy and allocation rules disagree with HOD capabilities
+
+The Subjects UI says, “Coordinators and the HOD can write any of them” (`subjects/client.tsx:191-192`), and `allocation.ts` treats the HOD as able to cover an allocated teacher. But HOD defaults include only `attendance:read` and `marks:read` (`src/lib/rbac.ts:158-182`). Production therefore redirects the HOD away from attendance and marks entry.
+
+Required fix: decide the workflow once. The existing product copy and allocation code consistently imply cover authority, so add `attendance:write`, `marks:write`, and `marks:lock` to HOD defaults and test the full path. If HOD must be read-only, remove every contrary rule and sentence instead.
+
+### P1: staff overview leaks global counts outside role scope
+
+Every staff tier executes the same four unscoped counts over departments, classes, students, and faculty (`src/app/dashboard/page.tsx:21-50`). In production, both TR and coordinator saw the institution-wide totals even though their roster access was limited to one class.
+
+Required fix: make the overview role-specific and scope-specific. A TR needs assigned classes, roster size, pending approvals, attendance sessions, and outstanding marks. An HOD needs department totals. Only super-admin should receive institution totals.
+
+### P1: attendance defaults unsaved sessions to 100% present
+
+For a new date/slot, every missing attendance row becomes `present` (`attendance/page.tsx:59-64`). Production displayed `89 / 89 present` before any record existed, and Save would persist the entire class as present.
+
+The UI also hardcodes slot `1` unless a URL parameter is manually supplied and offers no subject/session selector (`attendance/page.tsx:34-39`). This cannot model multiple lectures in one day reliably. The UTC-based `toISOString()` default can also select the previous local date during early-morning IST use.
+
+Required fix: use an explicit unmarked state, require session/subject selection, show progress as “0 of 89 marked,” confirm bulk-present actions, and derive the default date in the college timezone. Persist only explicitly marked students or require 100% completion before final submission.
+
+### P1: production hydration error and identity/navigation flicker
+
+Production logged React error `#418` for a text hydration mismatch. The UI repeatedly rendered `User` before replacing it with the signed-in identity. `DashboardLayout` already resolves the full server-side `SessionUser`, but `AppSidebar` independently calls `useSession`, while `PageHeader` and the sidebar independently fetch `/api/me` through a module-global client cache.
+
+Required fix: pass a serialized server-resolved identity and tier from `DashboardLayout` into a small client provider. Use it as the initial source for sidebar, header, and navigation; refresh it only after an actual session change. This removes duplicate auth reads, the empty navigation frame, and the hydration mismatch.
+
+### P2: filter controls expose the internal `__all` sentinel
+
+The student roster displays `__all` in the Department, Year, and Division controls. `DataTableView` uses `__all` as an internal Select sentinel but the trigger renders the raw value (`src/components/data-table-view.tsx:44-46, 189-207`).
+
+Required fix: provide a label/value item map to the Select primitive or render “All departments,” “All years,” and “All divisions” explicitly in the trigger.
+
+### P2: incomplete marks use inconsistent semantics
+
+For the same ungraded subject, the dashboard displayed `0 / 75` while My marks displayed `—`. A partial MSE entry can also leave Total at zero because the two MSE values are averaged only after both exist. The calculation is defensible, but the UI reads as lost data.
+
+Required fix: use one presentation component everywhere. Show “In progress” for incomplete subjects, show a provisional sum only when clearly labelled provisional, and expose entered components without implying a final total or zero grade.
+
+### P2: permissions console needs operational safeguards
+
+The role matrix is understandable on desktop, but high-impact changes are immediate switches with no summary of affected users/scopes, no search, no sticky headers/first column, and no confirmation for revoking a default. The underlying session resolver supports user-level overrides, but the console exposes only role-level overrides.
+
+Required fix: add capability search, sticky role headers, an impact preview, confirmation for destructive revocations, a visible audit reason, and a user-exception screen only when a concrete use case requires it.
+
+### P2: repository documentation describes an obsolete product
+
+`README.md:13,33-40` says email/password auth and seeded password accounts. `docs/api.md:9-17,39-88` documents old roles, password endpoints, broad write endpoints, and CORS behavior that do not match the current application routes.
+
+Impact: operators and contributors can configure or integrate against an authentication path that no longer exists.
+
+Required fix: rewrite setup and API docs around VOSS OIDC, verified-email binding, the four tiers, capabilities plus scope, current routes, demo seeding, and the actual first-login lifecycle.
+
+### Hardening: the planned database isolation layer is still absent
+
+The research architecture intentionally sequenced PostgreSQL RLS after the app-layer scoped-query boundary. No RLS policies or non-owner application role are present. Because the app boundary currently has the marks, batch, and roster holes above, database defense-in-depth is now more valuable than the original plan assumed.
+
+Do not bolt session GUCs onto stateless `neon-http`. After the application fixes, implement the already-researched transaction/JWT approach for tenant tables or enforce equivalent database invariants that make cross-class academic rows impossible.
+
+## UI/UX direction for a real college ERP
+
+The visual system is clean and restrained, but most overview screens still behave like generic CRUD. The product should orient each user around today's academic work:
+
+- TR/coordinator home: today's classes, pending attendance, pending marks components, unreviewed enrolments, and exceptions.
+- HOD home: department health, unstaffed classes, unallocated subjects, unclaimed students, incomplete attendance/marks, and decisions requiring approval.
+- Student home: attendance by subject with threshold warnings, marks publication state, upcoming assessments, and a clear distinction between provisional and final results.
+- Super-admin home: configuration completeness, identity/claim anomalies, audit exceptions, and cross-department operational health.
+
+Keep the existing restrained visual language. The key improvement is information architecture and workflow state, not decoration.
+
+## Verification matrix to add to CI
+
+1. Table-driven capability tests for defaults and role/user override precedence.
+2. Integration tests for every server action: unauthenticated, missing capability, in-scope success, out-of-scope denial, inactive subject/user, and forged related IDs.
+3. Route tests for all role/page combinations.
+4. Coordinator versus TR tests for allocation, marks locking, and reopening.
+5. HOD cover-authority tests after the role decision is applied.
+6. Import tests proving mixed-scope batches fail atomically.
+7. Marks and batch tests proving an out-of-class student ID is rejected.
+8. Identity lifecycle tests: roster-first binding, request-first approval, already-bound conflict, inactive row, and unbound user.
+9. Browser tests for hydration, mobile roster scrolling, attendance completion, empty states, and filter labels.
+
+## Recommended implementation order
+
+1. Close roster, marks, and batch scope escapes and add integration tests.
+2. Reconcile coordinator/HOD capabilities with `allocation.ts` and UI copy.
+3. Redesign attendance around explicit sessions and unmarked state.
+4. Scope staff dashboards and remove hydration/client-auth duplication.
+5. Fix filter labels and student marks semantics.
+6. Rewrite operational documentation.
+7. Add the planned database isolation layer before wider real-student rollout.

--- a/src/app/dashboard/class/[classId]/attendance/client.tsx
+++ b/src/app/dashboard/class/[classId]/attendance/client.tsx
@@ -29,15 +29,21 @@ type Student = {
   status: Mark
 }
 
+type Offering = { id: string; code: string; name: string }
+
 export function AttendanceClient({
   classId,
   date,
   slot,
+  offeringId,
+  offerings,
   students,
 }: {
   classId: string
   date: string
   slot: string
+  offeringId: string | null
+  offerings: Offering[]
   students: Student[]
 }) {
   const router = useRouter()
@@ -55,8 +61,21 @@ export function AttendanceClient({
       Object.fromEntries(students.map((s) => [s.id, m[s.id] ?? status]))
     )
 
-  const goDate = (d: string) =>
-    router.push(`/dashboard/class/${classId}/attendance?date=${d}&slot=${slot}`)
+  // Date, slot and subject together identify the session, so changing any of
+  // them navigates rather than mutating what is on screen: a half-marked
+  // register must not silently become another session's.
+  const go = (next: {
+    date?: string
+    slot?: string
+    offering?: string | null
+  }) => {
+    const d = next.date ?? date
+    const s = next.slot ?? slot
+    const o = next.offering === undefined ? offeringId : next.offering
+    const q = new URLSearchParams({ date: d, slot: s })
+    if (o) q.set("offering", o)
+    router.push(`/dashboard/class/${classId}/attendance?${q}`)
+  }
 
   const markedCount = students.filter((s) => marks[s.id] != null).length
   const remaining = students.length - markedCount
@@ -74,6 +93,7 @@ export function AttendanceClient({
         classId,
         sessionDate: date,
         sessionSlot: slot,
+        offeringId,
         // Only what somebody actually marked. Sending the unmarked as present
         // is what produced a full register from an untouched page.
         marks: students
@@ -97,9 +117,26 @@ export function AttendanceClient({
           <Input
             type="date"
             value={date}
-            onChange={(e) => e.target.value && goDate(e.target.value)}
+            onChange={(e) => e.target.value && go({ date: e.target.value })}
             className="h-9 w-44"
           />
+        </div>
+        <div className="grid gap-1.5">
+          <label className="text-muted-foreground text-xs">Session</label>
+          <select
+            value={offeringId ?? ""}
+            onChange={(e) => go({ offering: e.target.value || null })}
+            className="border-input bg-background h-9 rounded border px-2 text-sm"
+          >
+            {/* A register with no subject is the homeroom one. Naming it keeps
+                it distinct from a subject whose register has not been taken. */}
+            <option value="">Class session (no subject)</option>
+            {offerings.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.code} — {o.name}
+              </option>
+            ))}
+          </select>
         </div>
         <div className="flex items-center gap-2">
           <Button

--- a/src/app/dashboard/class/[classId]/attendance/page.tsx
+++ b/src/app/dashboard/class/[classId]/attendance/page.tsx
@@ -7,6 +7,7 @@ import { can } from "@/lib/rbac"
 import { expectedYear } from "@/lib/roll-number"
 import { getClassById } from "@/db/queries/classes"
 import { getStudentsByClassKeys } from "@/db/queries/students"
+import { listOfferingsForClass } from "@/db/queries/offerings"
 import { getAttendanceForSession } from "@/db/queries/attendance"
 import { AttendanceClient } from "./client"
 
@@ -19,7 +20,7 @@ export default async function AttendancePage({
   searchParams,
 }: {
   params: Promise<{ classId: string }>
-  searchParams: Promise<{ date?: string; slot?: string }>
+  searchParams: Promise<{ date?: string; slot?: string; offering?: string }>
 }) {
   const { classId } = await params
   const sp = await searchParams
@@ -39,12 +40,20 @@ export default async function AttendancePage({
     (user.tier === "hod" && user.deptCodes.includes(cls.departmentCode))
   if (!inScope) redirect("/dashboard/class")
 
-  const date = sp.date || new Date().toISOString().slice(0, 10)
+  // The college's date, not UTC. toISOString() rolls over at 05:30 IST and
+  // would open tomorrow's register during an early-morning lecture.
+  const date =
+    sp.date ||
+    new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Kolkata" }).format(
+      new Date()
+    )
   const slot = sp.slot || "1"
+  const offeringId = sp.offering || null
 
-  const [students, existing] = await Promise.all([
+  const [students, existing, offerings] = await Promise.all([
     getStudentsByClassKeys([cls.classKey]),
-    getAttendanceForSession(classId, date, slot),
+    getAttendanceForSession(classId, date, slot, offeringId),
+    listOfferingsForClass(classId),
   ])
   const marked: Record<string, string> = {}
   for (const e of existing) marked[e.studentId] = e.status
@@ -66,6 +75,12 @@ export default async function AttendancePage({
           classId={classId}
           date={date}
           slot={slot}
+          offeringId={offeringId}
+          offerings={offerings.map((o) => ({
+            id: o.id,
+            code: o.course.courseCode,
+            name: o.course.courseName,
+          }))}
           students={students.map((s) => ({
             id: s.id,
             name: `${s.firstName} ${s.lastName}`.trim(),

--- a/src/app/dashboard/class/actions.ts
+++ b/src/app/dashboard/class/actions.ts
@@ -156,6 +156,8 @@ export async function saveAttendanceAction(input: {
   classId: string
   sessionDate: string
   sessionSlot: string
+  /** The subject this register is for. Null is a class-level session. */
+  offeringId?: string | null
   marks: { studentId: string; status: AttStatus }[]
 }): Promise<Result> {
   try {
@@ -177,9 +179,20 @@ export async function saveAttendanceAction(input: {
     )
     if (!attScope.ok) return { error: attScope.reason }
 
+    // A register named for a subject has to be a subject of this class,
+    // otherwise the class scope check above is worked around by pointing at
+    // another class's offering.
+    const offeringId = input.offeringId ?? null
+    if (offeringId) {
+      const offering = await getOfferingById(offeringId)
+      if (!offering || offering.classId !== input.classId)
+        return { error: "That subject is not taught in this class." }
+    }
+
     const entries = input.marks.map((m) => ({
       studentId: m.studentId,
       classId: input.classId,
+      courseOfferingId: offeringId,
       sessionDate: input.sessionDate,
       sessionSlot: input.sessionSlot,
       status: m.status,
@@ -195,6 +208,7 @@ export async function saveAttendanceAction(input: {
       details: {
         date: input.sessionDate,
         slot: input.sessionSlot,
+        offeringId,
         count: entries.length,
       },
     })

--- a/src/app/dashboard/my-marks/client.tsx
+++ b/src/app/dashboard/my-marks/client.tsx
@@ -24,9 +24,18 @@ export function MyMarksClient({
   cgpa,
   semesters,
   awaiting,
+  attendance,
 }: {
   cgpa: CgpaResult
   semesters: Semester[]
+  attendance: {
+    offeringId: string | null
+    code: string
+    name: string
+    present: number
+    total: number
+    percent: number | null
+  }[]
   awaiting: { code: string; name: string; semester: number }[]
 }) {
   if (semesters.length === 0) {
@@ -37,6 +46,7 @@ export function MyMarksClient({
             ? "No results have been published yet."
             : "No marks recorded yet. They appear here once your teachers enter them."}
         </p>
+        <SubjectAttendance rows={attendance} />
         <AwaitingPublication subjects={awaiting} />
       </div>
     )
@@ -68,6 +78,7 @@ export function MyMarksClient({
         />
       </div>
 
+      <SubjectAttendance rows={attendance} />
       <AwaitingPublication subjects={awaiting} />
 
       {semesters.map((sem) => {
@@ -346,5 +357,66 @@ function Cell({
         </>
       )}
     </td>
+  )
+}
+
+/**
+ * Attendance per subject, with the 75% rule stated where it applies.
+ *
+ * A single overall percentage cannot answer the question a student actually
+ * has, because the rule is enforced per subject: 80% overall hides a subject
+ * sitting at 60%, and the student finds out when they are barred from the exam.
+ */
+function SubjectAttendance({
+  rows,
+}: {
+  rows: {
+    offeringId: string | null
+    code: string
+    name: string
+    present: number
+    total: number
+    percent: number | null
+  }[]
+}) {
+  if (rows.length === 0) return null
+  return (
+    <div className="border-border rounded border p-4">
+      <p className="text-sm font-medium">Attendance</p>
+      <p className="text-muted-foreground mt-0.5 text-xs">
+        VIT requires 75% in each subject. Late counts as present.
+      </p>
+      <ul className="mt-3 flex flex-col gap-2">
+        {rows.map((r) => {
+          const short = r.percent != null && r.percent < 75
+          return (
+            <li
+              key={r.offeringId ?? "class"}
+              className="flex items-center gap-2 text-sm"
+            >
+              <span className="identifier">{r.code}</span>
+              <span className="truncate">{r.name}</span>
+              <span className="text-muted-foreground ml-auto shrink-0 text-xs tabular-nums">
+                {r.present}/{r.total}
+              </span>
+              <span
+                className={
+                  short
+                    ? "text-destructive w-16 shrink-0 text-right text-sm font-medium tabular-nums"
+                    : "w-16 shrink-0 text-right text-sm font-medium tabular-nums"
+                }
+              >
+                {r.percent == null ? "—" : `${r.percent}%`}
+                {/* The number alone is not the warning — colour never carries
+                    meaning by itself. */}
+              </span>
+              {short && (
+                <span className="text-destructive shrink-0 text-xs">Short</span>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    </div>
   )
 }

--- a/src/app/dashboard/my-marks/page.tsx
+++ b/src/app/dashboard/my-marks/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation"
 import { PageHeader } from "@/components/page-header"
 import { getSessionUser } from "@/lib/session"
 import { getMarksForStudent } from "@/db/queries/marks"
+import { getAttendanceBySubject } from "@/db/queries/attendance"
 import { computeCgpa, groupBySemester } from "@/lib/sgpi"
 import { MyMarksClient } from "./client"
 
@@ -13,7 +14,10 @@ export default async function MyMarksPage() {
   // Staff have no marks of their own; the dashboard is where they belong.
   if (!user.studentId) redirect("/dashboard")
 
-  const rows = await getMarksForStudent(user.studentId)
+  const [rows, attendance] = await Promise.all([
+    getMarksForStudent(user.studentId),
+    getAttendanceBySubject(user.studentId),
+  ])
   // Only published subjects count toward SGPI and CGPA. An unpublished subject
   // is work in progress; folding it into an average would present a figure that
   // moves every time a teacher saves, and that nobody has declared final.
@@ -63,6 +67,7 @@ export default async function MyMarksPage() {
         <MyMarksClient
           cgpa={cgpa}
           semesters={semesters}
+          attendance={attendance}
           awaiting={rows
             .filter((m) => m.courseOffering.publishedAt == null)
             .map((m) => ({

--- a/src/db/migrations/0005_attendance_per_subject.sql
+++ b/src/db/migrations/0005_attendance_per_subject.sql
@@ -1,0 +1,24 @@
+-- Attendance is identified by subject as well as slot.
+--
+-- courseOfferingId has been on the row since attendance was introduced, but the
+-- unique key was (student, date, slot) only. Two subjects taught in the same
+-- slot on the same day therefore collided, and the second register silently
+-- overwrote the first — a class could lose a lecture's attendance without any
+-- error.
+--
+-- Postgres treats NULLs as distinct inside a unique index, so a single key
+-- including course_offering_id would stop constraining the class-level form at
+-- all. Two partial indexes instead: one for subject sessions, one for
+-- class-level ones.
+-- The constraint owns the index, so dropping the index first is refused.
+ALTER TABLE attendance
+  DROP CONSTRAINT IF EXISTS attendance_student_session_uniq;
+DROP INDEX IF EXISTS attendance_student_session_uniq;
+
+CREATE UNIQUE INDEX IF NOT EXISTS attendance_student_subject_session_uniq
+  ON attendance (student_id, session_date, session_slot, course_offering_id)
+  WHERE course_offering_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS attendance_student_class_session_uniq
+  ON attendance (student_id, session_date, session_slot)
+  WHERE course_offering_id IS NULL;

--- a/src/db/queries/attendance.ts
+++ b/src/db/queries/attendance.ts
@@ -1,40 +1,73 @@
-import { and, eq, sql } from "drizzle-orm"
+import { and, eq, isNull, sql } from "drizzle-orm"
 import { db } from "@/db"
 import { attendance, courseOfferings, courses } from "@/db/schema"
 
 type Entry = {
   studentId: string
   classId: string
+  courseOfferingId: string | null
   sessionDate: string
   sessionSlot: string
   status: "present" | "absent" | "late" | "excused"
   recordedByFacultyId: string | null
 }
 
-// One row per (student, date, slot); re-recording a session overwrites it.
+const overwrite = {
+  status: sql`excluded.status`,
+  recordedByFacultyId: sql`excluded.recorded_by_faculty_id`,
+  updatedAt: new Date(),
+}
+
+/**
+ * One row per (student, date, slot, subject); re-recording a session overwrites
+ * it, because a teacher correcting a mistake is the common case.
+ *
+ * Two partial unique indexes back that identity — one for subject registers,
+ * one for class-level ones — so the insert has to name the matching index for
+ * Postgres to resolve a conflict against it. Naming the wrong one does not fall
+ * back to an update: it raises a duplicate-key error on the second save.
+ */
 export async function upsertAttendance(entries: Entry[]) {
-  if (entries.length === 0) return
-  await db
-    .insert(attendance)
-    .values(entries)
-    .onConflictDoUpdate({
-      target: [
-        attendance.studentId,
-        attendance.sessionDate,
-        attendance.sessionSlot,
-      ],
-      set: {
-        status: sql`excluded.status`,
-        recordedByFacultyId: sql`excluded.recorded_by_faculty_id`,
-        updatedAt: new Date(),
-      },
-    })
+  const subject = entries.filter((e) => e.courseOfferingId !== null)
+  const classLevel = entries.filter((e) => e.courseOfferingId === null)
+
+  if (subject.length > 0) {
+    await db
+      .insert(attendance)
+      .values(subject)
+      .onConflictDoUpdate({
+        target: [
+          attendance.studentId,
+          attendance.sessionDate,
+          attendance.sessionSlot,
+          attendance.courseOfferingId,
+        ],
+        targetWhere: sql`course_offering_id IS NOT NULL`,
+        set: overwrite,
+      })
+  }
+
+  if (classLevel.length > 0) {
+    await db
+      .insert(attendance)
+      .values(classLevel)
+      .onConflictDoUpdate({
+        target: [
+          attendance.studentId,
+          attendance.sessionDate,
+          attendance.sessionSlot,
+        ],
+        targetWhere: sql`course_offering_id IS NULL`,
+        set: overwrite,
+      })
+  }
 }
 
 export async function getAttendanceForSession(
   classId: string,
   sessionDate: string,
-  sessionSlot: string
+  sessionSlot: string,
+  courseOfferingId: string | null
 ) {
   return db
     .select({
@@ -46,7 +79,12 @@ export async function getAttendanceForSession(
       and(
         eq(attendance.classId, classId),
         eq(attendance.sessionDate, sessionDate),
-        eq(attendance.sessionSlot, sessionSlot)
+        eq(attendance.sessionSlot, sessionSlot),
+        // A subject's register and the class-level one are different sessions
+        // on the same day; reading them together would show one as the other.
+        courseOfferingId
+          ? eq(attendance.courseOfferingId, courseOfferingId)
+          : isNull(attendance.courseOfferingId)
       )
     )
 }

--- a/src/db/schema/attendance.ts
+++ b/src/db/schema/attendance.ts
@@ -5,8 +5,9 @@ import {
   date,
   timestamp,
   index,
-  unique,
+  uniqueIndex,
 } from "drizzle-orm/pg-core"
+import { sql } from "drizzle-orm"
 import { students } from "./students"
 import { classes } from "./classes"
 import { courseOfferings } from "./offerings"
@@ -46,11 +47,17 @@ export const attendance = pgTable(
       .defaultNow(),
   },
   (t) => [
-    unique("attendance_student_session_uniq").on(
-      t.studentId,
-      t.sessionDate,
-      t.sessionSlot
-    ),
+    // The subject is part of what identifies a session. Without it, two
+    // subjects taught in the same slot on the same day collided on this key and
+    // the second register silently overwrote the first. Postgres treats NULLs
+    // as distinct in a unique index, so the class-level form (no offering) is
+    // kept unique by the partial index below instead.
+    uniqueIndex("attendance_student_subject_session_uniq")
+      .on(t.studentId, t.sessionDate, t.sessionSlot, t.courseOfferingId)
+      .where(sql`course_offering_id IS NOT NULL`),
+    uniqueIndex("attendance_student_class_session_uniq")
+      .on(t.studentId, t.sessionDate, t.sessionSlot)
+      .where(sql`course_offering_id IS NULL`),
     index("attendance_class_date_idx").on(t.classId, t.sessionDate),
     index("attendance_student_idx").on(t.studentId),
   ]


### PR DESCRIPTION
## What

Attendance was keyed on `(student, date, slot)`. Two subjects taught in the same slot on the same day collided on that key, and the second register silently overwrote the first.

The subject is part of what identifies a session, so it now belongs in the key.

## The key is two partial indexes, not one

Postgres treats NULLs as distinct, so a single unique index over a nullable `course_offering_id` would let a class-level register be recorded any number of times for the same student and slot. Instead:

- `attendance_student_subject_session_uniq` WHERE `course_offering_id IS NOT NULL`
- `attendance_student_class_session_uniq` WHERE `course_offering_id IS NULL`

An insert has to name the matching index for `ON CONFLICT` to resolve against it. Naming the wrong one does not fall back to an update — it raises a duplicate-key error on the second save — so `upsertAttendance` splits its batch by whether a subject is named and runs the right arbiter for each. Verified against the live database: both register kinds re-save cleanly (a teacher correcting a mistake), a mixed batch lands both rows, and the two registers for one student in one slot coexist.

`saveAttendanceAction` validates that a named offering actually belongs to the class, so the class-scope check cannot be sidestepped by pointing at another class's offering.

## Teacher

A session selector at the top of the register, defaulting to the class-level session so existing use is unchanged. The default date is now derived in `Asia/Kolkata` — `toISOString()` selected the previous day during early-morning use.

## Student

Attendance per subject on My marks, with the 75% threshold stated where it applies and short subjects marked in text as well as colour. A single overall percentage cannot answer the question a student has: 80% overall hides a subject sitting at 60%, and they find out when they are barred from the exam.

## Migration

`0005_attendance_per_subject.sql`, already applied to production (5/5).

## Checks

`npm run check` — typecheck, lint (2 pre-existing warnings), format, 110 tests. `npm run build` compiled.

Refs the P1 attendance finding in `research/verp-rbac-ux-audit-2026-08-13.md`.