### PR TITLE
feat(marks): one presentation for a subject's result, and a register that works on a phone

### DIFF
--- a/src/app/dashboard/class/[classId]/attendance/client.tsx
+++ b/src/app/dashboard/class/[classId]/attendance/client.tsx
@@ -138,10 +138,11 @@ export function AttendanceClient({
             ))}
           </select>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex w-full items-center gap-2 sm:w-auto">
           <Button
             variant="outline"
             size="sm"
+            className="flex-1 sm:flex-none"
             disabled={remaining === 0}
             onClick={() => {
               if (
@@ -157,6 +158,7 @@ export function AttendanceClient({
           </Button>
           <Button
             size="sm"
+            className="flex-1 sm:flex-none"
             disabled={pending || markedCount === 0}
             onClick={save}
           >
@@ -188,7 +190,7 @@ export function AttendanceClient({
               type="button"
               onClick={() => setFilter(key as typeof filter)}
               className={cn(
-                "rounded border px-2 py-0.5 text-xs capitalize transition-colors",
+                "rounded border px-2.5 py-1.5 text-xs capitalize transition-colors sm:py-0.5",
                 filter === key
                   ? "border-foreground text-foreground"
                   : "border-border text-muted-foreground hover:text-foreground"
@@ -214,21 +216,32 @@ export function AttendanceClient({
             {visible.map((s) => {
               const status = marks[s.id]
               return (
+                // A register is taken standing up, on a phone, while looking
+                // at the room. On a narrow screen the four buttons get a row of
+                // their own under the name rather than being squeezed beside
+                // it, and each is tall enough to hit without aiming.
                 <li
                   key={s.id}
-                  className="flex items-center justify-between gap-3 px-4 py-2.5"
+                  className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-3 sm:py-2.5"
                 >
                   <div className="flex items-center gap-3">
                     <Badge variant="outline" className="font-mono">
                       {s.rollNumber}
                     </Badge>
                     <span className="text-sm">{s.name}</span>
+                    {status == null && (
+                      <span className="ml-auto text-xs text-amber-600 sm:hidden">
+                        Unmarked
+                      </span>
+                    )}
                   </div>
                   <div className="flex items-center gap-2">
                     {status == null && (
-                      <span className="text-xs text-amber-600">Unmarked</span>
+                      <span className="hidden text-xs text-amber-600 sm:inline">
+                        Unmarked
+                      </span>
                     )}
-                    <div className="flex overflow-hidden rounded border">
+                    <div className="grid w-full grid-cols-4 overflow-hidden rounded border sm:flex sm:w-auto">
                       {STATUSES.map((v) => (
                         <button
                           key={v}
@@ -244,7 +257,7 @@ export function AttendanceClient({
                             }))
                           }
                           className={cn(
-                            "px-3 py-1 text-xs font-medium capitalize transition-colors",
+                            "min-h-11 px-3 text-xs font-medium capitalize transition-colors sm:min-h-0 sm:py-1",
                             status === v
                               ? STATUS_STYLE[v]
                               : "text-muted-foreground hover:bg-muted"

--- a/src/app/dashboard/class/[classId]/marks/client.tsx
+++ b/src/app/dashboard/class/[classId]/marks/client.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
 import { computeMarks, type CourseInfo } from "@/lib/sgpi"
+import { SubjectResultCells } from "@/components/subject-result"
 import { downloadBase64File } from "@/lib/utils"
 import { exportTableCsv, exportTableXlsx } from "@/lib/xlsx-export"
 import {
@@ -406,64 +407,51 @@ function MarksGrid({
               </tr>
             </thead>
             <tbody className="divide-border divide-y">
-              {rows.map((r) => {
-                const c = computeMarks(r, course)
-                return (
-                  <tr key={r.studentId} className="[&>td]:px-3 [&>td]:py-1.5">
-                    <td className="font-mono text-xs">{r.rollNumber}</td>
-                    <td className="whitespace-nowrap">{r.name}</td>
+              {rows.map((r) => (
+                <tr key={r.studentId} className="[&>td]:px-3 [&>td]:py-1.5">
+                  <td className="font-mono text-xs">{r.rollNumber}</td>
+                  <td className="whitespace-nowrap">{r.name}</td>
+                  <td>
+                    <MarkInput
+                      value={r.isa}
+                      max={course.maxIsa}
+                      locked={isLocked("isa")}
+                      onChange={(v) => edit(r.studentId, "isa", v)}
+                    />
+                  </td>
+                  {hasMse && (
                     <td>
                       <MarkInput
-                        value={r.isa}
-                        max={course.maxIsa}
-                        locked={isLocked("isa")}
-                        onChange={(v) => edit(r.studentId, "isa", v)}
+                        value={r.mse1}
+                        max={course.maxMse}
+                        locked={isLocked("mse")}
+                        onChange={(v) => edit(r.studentId, "mse1", v)}
                       />
                     </td>
-                    {hasMse && (
-                      <td>
-                        <MarkInput
-                          value={r.mse1}
-                          max={course.maxMse}
-                          locked={isLocked("mse")}
-                          onChange={(v) => edit(r.studentId, "mse1", v)}
-                        />
-                      </td>
-                    )}
-                    {hasMse && (
-                      <td>
-                        <MarkInput
-                          value={r.mse2}
-                          max={course.maxMse}
-                          locked={isLocked("mse")}
-                          onChange={(v) => edit(r.studentId, "mse2", v)}
-                        />
-                      </td>
-                    )}
+                  )}
+                  {hasMse && (
                     <td>
                       <MarkInput
-                        value={r.ese}
-                        max={course.maxEse}
-                        locked={isLocked("ese")}
-                        onChange={(v) => edit(r.studentId, "ese", v)}
+                        value={r.mse2}
+                        max={course.maxMse}
+                        locked={isLocked("mse")}
+                        onChange={(v) => edit(r.studentId, "mse2", v)}
                       />
                     </td>
-                    <td className="tabular-nums">{c.total}</td>
-                    <td className="text-muted-foreground tabular-nums">
-                      {c.percentage ?? "—"}
-                    </td>
-                    <td>
-                      {c.gradePoint == null ? (
-                        <span className="text-muted-foreground">—</span>
-                      ) : c.gradePoint === "Fail" ? (
-                        <Badge variant="destructive">Fail</Badge>
-                      ) : (
-                        <Badge variant="outline">{c.gradePoint}</Badge>
-                      )}
-                    </td>
-                  </tr>
-                )
-              })}
+                  )}
+                  <td>
+                    <MarkInput
+                      value={r.ese}
+                      max={course.maxEse}
+                      locked={isLocked("ese")}
+                      onChange={(v) => edit(r.studentId, "ese", v)}
+                    />
+                  </td>
+                  {/* The same cells the student will see, so a teacher can
+                        tell what a row currently reads as before publishing. */}
+                  <SubjectResultCells marks={r} course={course} />
+                </tr>
+              ))}
             </tbody>
           </table>
         </div>
@@ -486,6 +474,7 @@ function MarkInput({
   return (
     <Input
       type="number"
+      inputMode="numeric"
       min={0}
       max={max}
       value={value ?? ""}
@@ -493,8 +482,12 @@ function MarkInput({
       disabled={locked}
       aria-label={locked ? "Locked — submitted" : undefined}
       onChange={(e) => onChange(e.target.value)}
+      // A wheel over a focused number input changes its value. Scrolling down
+      // a class of ninety would silently rewrite whichever mark the pointer
+      // crossed, and nothing on screen would say so.
+      onWheel={(e) => e.currentTarget.blur()}
       className={cn(
-        "h-8 w-16 tabular-nums",
+        "h-9 w-16 tabular-nums sm:h-8",
         locked && "bg-muted text-muted-foreground cursor-not-allowed"
       )}
     />

--- a/src/app/dashboard/class/[classId]/results/client.tsx
+++ b/src/app/dashboard/class/[classId]/results/client.tsx
@@ -12,7 +12,8 @@ import {
 } from "@/components/ui/dialog"
 import { downloadBase64File } from "@/lib/utils"
 import { exportTableCsv, exportTableXlsx } from "@/lib/xlsx-export"
-import { computeMarks, type CourseInfo } from "@/lib/sgpi"
+import { type CourseInfo } from "@/lib/sgpi"
+import { SubjectResultCells } from "@/components/subject-result"
 
 type Subject = {
   semester: number
@@ -268,32 +269,13 @@ function Breakdown({ row }: { row: Row }) {
               </tr>
             </thead>
             <tbody className="divide-border divide-y">
-              {subjects.map((s) => {
-                const c = computeMarks(s.marks, s.course)
-                return (
-                  <tr key={s.code} className="[&>td]:px-2 [&>td]:py-1">
-                    <td className="font-mono text-xs">{s.code}</td>
-                    <td>{s.name}</td>
-                    <td className="tabular-nums">
-                      {c.percentage == null
-                        ? "—"
-                        : `${c.total}/${s.course.maxTotal}`}
-                    </td>
-                    <td className="text-muted-foreground tabular-nums">
-                      {c.percentage ?? "—"}
-                    </td>
-                    <td>
-                      {c.gradePoint == null ? (
-                        <span className="text-muted-foreground">—</span>
-                      ) : c.gradePoint === "Fail" ? (
-                        <Badge variant="destructive">Fail</Badge>
-                      ) : (
-                        <Badge variant="outline">{c.gradePoint}</Badge>
-                      )}
-                    </td>
-                  </tr>
-                )
-              })}
+              {subjects.map((s) => (
+                <tr key={s.code} className="[&>td]:px-2 [&>td]:py-1">
+                  <td className="font-mono text-xs">{s.code}</td>
+                  <td>{s.name}</td>
+                  <SubjectResultCells marks={s.marks} course={s.course} />
+                </tr>
+              ))}
             </tbody>
           </table>
         </div>

--- a/src/app/dashboard/my-marks/client.tsx
+++ b/src/app/dashboard/my-marks/client.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { computeMarks, type CgpaResult, type CourseInfo } from "@/lib/sgpi"
+import { SubjectResultCells } from "@/components/subject-result"
 
 type Subject = {
   code: string
@@ -191,21 +192,7 @@ function SubjectRow({ subject }: { subject: Subject }) {
           absent={!hasMse}
         />
         <Cell value={subject.marks.ese} max={subject.course.maxEse} />
-        <td className="tabular-nums">
-          {c.percentage == null ? "—" : `${c.total}/${subject.course.maxTotal}`}
-        </td>
-        <td className="text-muted-foreground tabular-nums">
-          {c.percentage ?? "—"}
-        </td>
-        <td>
-          {c.gradePoint == null ? (
-            <span className="text-muted-foreground">—</span>
-          ) : c.gradePoint === "Fail" ? (
-            <Badge variant="destructive">Fail</Badge>
-          ) : (
-            <Badge variant="outline">{c.gradePoint}</Badge>
-          )}
-        </td>
+        <SubjectResultCells marks={subject.marks} course={subject.course} />
         <td className="text-muted-foreground text-xs">
           {entered ? (open ? "▾" : "▸") : ""}
         </td>

--- a/src/components/subject-result.tsx
+++ b/src/components/subject-result.tsx
@@ -1,0 +1,72 @@
+import { Badge } from "@/components/ui/badge"
+import {
+  computeMarks,
+  marksState,
+  type CourseInfo,
+  type MarksInput,
+} from "@/lib/sgpi"
+
+/**
+ * The Total, %, and Grade cells of a subject row.
+ *
+ * One component because three screens show the same three numbers and had
+ * drifted apart: the overview read 0/75 where My marks read a dash, for the
+ * same subject on the same day. Whichever is right, a student cannot be shown
+ * both.
+ *
+ * The three states read differently on purpose. Nothing entered is a dash --
+ * there is no fact to report. Partly entered shows the running total with
+ * "provisional" attached, because the sum is real but not final: until both
+ * MSEs exist their component counts nothing, so the figure is genuinely lower
+ * than the student has scored and stating it unqualified would be a lie. Only a
+ * fully marked subject gets a percentage and a grade.
+ */
+export function SubjectResultCells({
+  marks,
+  course,
+}: {
+  marks: MarksInput
+  course: CourseInfo
+}) {
+  const c = computeMarks(marks, course)
+  const state = marksState(marks, course)
+
+  return (
+    <>
+      <td className="tabular-nums">
+        {state === "empty" ? (
+          <span className="text-muted-foreground">—</span>
+        ) : (
+          <>
+            {c.total}
+            <span className="text-muted-foreground text-xs">
+              /{course.maxTotal}
+            </span>
+          </>
+        )}
+      </td>
+      <td className="text-muted-foreground tabular-nums">
+        {state === "graded" ? (
+          c.percentage
+        ) : state === "partial" ? (
+          <span className="text-xs">provisional</span>
+        ) : (
+          "—"
+        )}
+      </td>
+      <td>
+        {state === "graded" ? (
+          c.gradePoint === "Fail" ? (
+            <Badge variant="destructive">Fail</Badge>
+          ) : (
+            <Badge variant="outline">{c.gradePoint}</Badge>
+          )
+        ) : state === "partial" ? (
+          <span className="text-muted-foreground text-xs">In progress</span>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </td>
+    </>
+  )
+}

--- a/src/lib/sgpi.test.ts
+++ b/src/lib/sgpi.test.ts
@@ -5,6 +5,7 @@ import {
   computeSgpi,
   getGradePoint,
   groupBySemester,
+  marksState,
   type CourseInfo,
 } from "./sgpi"
 
@@ -190,5 +191,53 @@ describe("computeCgpa", () => {
 
   it("returns null for a student with no marks", () => {
     expect(computeCgpa([]).cgpa).toBeNull()
+  })
+})
+
+describe("marksState", () => {
+  const theory: CourseInfo = {
+    courseType: "theory",
+    credits: 4,
+    maxIsa: 20,
+    maxMse: 30,
+    maxEse: 50,
+    maxTotal: 100,
+  }
+  const blank = { isa: null, mse1: null, mse2: null, ese: null }
+
+  it("is empty before a teacher enters anything", () => {
+    expect(marksState(blank, theory)).toBe("empty")
+  })
+
+  it("is partial once any component is in", () => {
+    expect(marksState({ ...blank, isa: 18 }, theory)).toBe("partial")
+  })
+
+  // A zero is a mark, not an absence. Treating it as "nothing entered" would
+  // hide a real result from the student who scored it.
+  it("treats a scored zero as entered, not missing", () => {
+    expect(marksState({ ...blank, isa: 0 }, theory)).toBe("partial")
+  })
+
+  it("stays partial with only one MSE, whose total is provisional", () => {
+    const one = { isa: 18, mse1: 25, mse2: null, ese: 40 }
+    expect(marksState(one, theory)).toBe("partial")
+    // 58, not 83: the MSE component counts nothing until both halves exist.
+    expect(computeMarks(one, theory).total).toBe(58)
+  })
+
+  it("is graded once every component is in", () => {
+    expect(marksState({ isa: 18, mse1: 25, mse2: 27, ese: 40 }, theory)).toBe(
+      "graded"
+    )
+  })
+
+  // A practical has no MSE at all, so waiting for one would leave it forever
+  // ungraded.
+  it("grades a practical without waiting for an MSE", () => {
+    const prac: CourseInfo = { ...theory, maxMse: 0, maxIsa: 50, maxEse: 50 }
+    expect(marksState({ isa: 40, mse1: null, mse2: null, ese: 45 }, prac)).toBe(
+      "graded"
+    )
   })
 })

--- a/src/lib/sgpi.ts
+++ b/src/lib/sgpi.ts
@@ -190,3 +190,30 @@ export function groupBySemester(
     entries,
   }))
 }
+
+/**
+ * How far along a subject's marking is.
+ *
+ * "Nothing entered yet" and "graded 0" are different facts, and a bare dash
+ * says neither. The distinction has to exist in one place because three screens
+ * render it: a student reading their own marksheet, a coordinator scanning a
+ * results table, and the overview counting what is outstanding. Deriving it
+ * separately in each is how they came to disagree — the dashboard showed 0/75
+ * for the subject My marks showed as a dash.
+ *
+ * "partial" carries a real total, but a provisional one: the two MSEs average
+ * into a single component only once both exist, so a subject with one MSE in
+ * genuinely sums lower than the student has scored. That total is worth showing
+ * and must never be shown unlabelled.
+ */
+export type MarksState = "empty" | "partial" | "graded"
+
+export function marksState(marks: MarksInput, course: CourseInfo): MarksState {
+  if (computeMarks(marks, course).gradePoint != null) return "graded"
+  const entered =
+    marks.isa != null ||
+    marks.mse1 != null ||
+    marks.mse2 != null ||
+    marks.ese != null
+  return entered ? "partial" : "empty"
+}


### PR DESCRIPTION
## One presentation, not three

Three screens rendered the same three numbers — total, percentage, grade — from their own copy of the logic, and they had drifted apart: the overview read `0 / 75` where My marks read `—`, for the same subject on the same day. Whichever is right, a student cannot be shown both.

`SubjectResultCells` is now the only place those cells are built, and `marksState` the only place the distinction is derived. It names **three** states rather than two:

| State | Total | % | Grade |
|---|---|---|---|
| nothing entered | `—` | `—` | `—` |
| partly entered | `58/100` | `provisional` | `In progress` |
| fully marked | `85/100` | `85` | `10` |

"Nothing entered yet" and "graded zero" are different facts and a bare dash states neither. The provisional label is not decoration: until both MSEs exist their component counts nothing, so a subject with one MSE in genuinely sums lower than the student has scored. Showing that total unqualified would be a lie; hiding it throws away something the student wants to see.

Used by My marks, the results table, and the teacher's own entry grid — so a teacher can see what a row currently reads as before publishing it.

## The register on a phone

A register is taken standing up, on a phone, while looking at the room. The four status buttons were 24px tall and shared a row with the student's name. On a narrow screen they now get a row of their own as a 4-up grid with a 44px target; the desktop layout is unchanged. Filter chips and the two header actions are likewise tappable.

## A silent data-corruption bug in marks entry

`type="number"` inputs change value on wheel. Scrolling down a class of ninety would silently rewrite whichever mark the pointer crossed, and nothing on screen would say so. The input now drops focus on wheel. Also `inputMode="numeric"` so mobile gets the keypad rather than the full keyboard.

## Tests

Six new cases on `marksState`, including a scored zero counting as entered (not missing), a practical grading without waiting for an MSE it does not have, and the one-MSE total being 58 rather than 83.

`npm run check` — typecheck, lint (2 pre-existing warnings), format, 116 tests. `npm run build` compiled.

Refs the P2 marks-semantics finding in `research/verp-rbac-ux-audit-2026-08-13.md`.