### PR TITLE
feat(tables): open a record in the shared drawer, and read the list on a phone

### DIFF
--- a/src/app/dashboard/faculty/client.tsx
+++ b/src/app/dashboard/faculty/client.tsx
@@ -1,8 +1,11 @@
 "use client"
 
+import { useState } from "react"
 import { DataTableView } from "@/components/data-table-view"
+import { RecordDrawer } from "@/components/record-drawer"
 import {
   facultyColumns,
+  ROLE_LABEL,
   type FacultyRow,
 } from "@/components/columns/faculty-columns"
 
@@ -10,6 +13,8 @@ import { exportTableCsv, exportTableXlsx } from "@/lib/xlsx-export"
 import { downloadBase64File } from "@/lib/utils"
 
 export function FacultyClient({ data }: { data: FacultyRow[] }) {
+  const [open, setOpen] = useState<FacultyRow | null>(null)
+
   const handleExport = async (
     filteredData: FacultyRow[],
     format: "csv" | "xlsx"
@@ -54,15 +59,65 @@ export function FacultyClient({ data }: { data: FacultyRow[] }) {
     }
   }
   return (
-    <DataTableView
-      columns={facultyColumns}
-      data={data}
-      globalSearch
-      searchPlaceholder="Search faculty..."
-      exportConfig={{
-        filename: "Faculty",
-        onExport: handleExport,
-      }}
-    />
+    <>
+      <DataTableView
+        columns={facultyColumns}
+        data={data}
+        globalSearch
+        searchPlaceholder="Search faculty..."
+        facets={[
+          { columnId: "department", label: "Department" },
+          {
+            columnId: "role",
+            label: "Role",
+            format: (v) => ROLE_LABEL[v as FacultyRow["role"]] ?? v,
+          },
+        ]}
+        exportConfig={{
+          filename: "Faculty",
+          onExport: handleExport,
+        }}
+        onRowClick={setOpen}
+        mobileRow={(f) => ({
+          title: `${f.firstName} ${f.lastName}`.trim(),
+          subtitle: f.email,
+          meta: [
+            { label: "ID", value: f.employeeId },
+            { label: "Dept", value: f.department },
+            { label: "Role", value: ROLE_LABEL[f.role] },
+          ],
+        })}
+      />
+
+      <RecordDrawer
+        open={open !== null}
+        onClose={() => setOpen(null)}
+        title={open ? `${open.firstName} ${open.lastName}`.trim() : ""}
+        subtitle={open?.email}
+        badges={
+          open
+            ? [
+                { label: ROLE_LABEL[open.role] },
+                ...(open.isActive
+                  ? []
+                  : [{ label: "Inactive", tone: "critical" as const }]),
+              ]
+            : undefined
+        }
+        facts={
+          open
+            ? [
+                { label: "Employee ID", value: open.employeeId, mono: true },
+                { label: "Department", value: open.department },
+                { label: "Role", value: ROLE_LABEL[open.role] },
+                {
+                  label: "Status",
+                  value: open.isActive ? "Active" : "Inactive",
+                },
+              ]
+            : undefined
+        }
+      />
+    </>
   )
 }

--- a/src/app/dashboard/students/client.tsx
+++ b/src/app/dashboard/students/client.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useTransition } from "react"
+import { useState, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { DataTableView } from "@/components/data-table-view"
@@ -13,6 +13,7 @@ import { downloadBase64File } from "@/lib/utils"
 import Link from "next/link"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Trash2Icon, UploadIcon } from "lucide-react"
+import { RecordDrawer } from "@/components/record-drawer"
 import { bulkDeactivateStudentsAction } from "./actions"
 
 export function StudentsClient({
@@ -24,6 +25,7 @@ export function StudentsClient({
 }) {
   const router = useRouter()
   const [pending, start] = useTransition()
+  const [open, setOpen] = useState<StudentRow | null>(null)
 
   function deactivate(ids: string[], clear: () => void) {
     start(async () => {
@@ -105,6 +107,20 @@ export function StudentsClient({
         searchPlaceholder="Search students..."
         exportConfig={{ filename: "Students", onExport: handleExport }}
         rowId={(s) => s.id}
+        onRowClick={setOpen}
+        mobileRow={(s) => ({
+          title: `${s.firstName} ${s.lastName}`.trim(),
+          subtitle: s.rollNumber,
+          meta: [
+            { label: "Dept", value: s.department },
+            { label: "Year", value: s.year },
+            ...(s.division ? [{ label: "Div", value: s.division }] : []),
+            {
+              label: "Account",
+              value: s.authUserId ? "Claimed" : "Unclaimed",
+            },
+          ],
+        })}
         bulkBar={
           canDeactivate
             ? (ids, clear) => (
@@ -120,6 +136,49 @@ export function StudentsClient({
                 </Button>
               )
             : undefined
+        }
+      />
+
+      <RecordDrawer
+        open={open !== null}
+        onClose={() => setOpen(null)}
+        title={open ? `${open.firstName} ${open.lastName}`.trim() : ""}
+        subtitle={open?.email ?? "No email on record"}
+        badges={
+          open
+            ? [
+                { label: open.rollNumber },
+                ...(open.isActive
+                  ? []
+                  : [{ label: "Inactive", tone: "critical" as const }]),
+                // An unclaimed row is a student who has never signed in, which
+                // is the difference between a roster mistake and a person who
+                // simply has not arrived yet.
+                ...(open.authUserId
+                  ? []
+                  : [{ label: "Unclaimed", tone: "warn" as const }]),
+              ]
+            : undefined
+        }
+        facts={
+          open
+            ? [
+                { label: "Department", value: open.department },
+                { label: "Year", value: open.year },
+                { label: "Division", value: open.division ?? "—" },
+                { label: "Roll number", value: open.rollNumber, mono: true },
+              ]
+            : undefined
+        }
+        footer={
+          open && (
+            <Link
+              href={`/dashboard/students/${open.id}`}
+              className={buttonVariants({ variant: "outline", size: "sm" })}
+            >
+              Open full record
+            </Link>
+          )
         }
       />
     </>

--- a/src/components/columns/faculty-columns.tsx
+++ b/src/components/columns/faculty-columns.tsx
@@ -14,7 +14,10 @@ export type FacultyRow = {
   isActive: boolean
 }
 
-const ROLE_LABEL: Record<FacultyRow["role"], string> = {
+// Exported so the table, the drawer and the filter all name a role the same
+// way. A raw "super_admin" reaching a dropdown is the same class of leak as
+// the "__all" sentinel that used to show in the filter triggers.
+export const ROLE_LABEL: Record<FacultyRow["role"], string> = {
   super_admin: "Super-admin",
   hod: "HOD",
   faculty: "Faculty",

--- a/src/components/data-table-view.tsx
+++ b/src/components/data-table-view.tsx
@@ -53,7 +53,13 @@ interface DataTableViewProps<TData, TValue> {
   // Dropdown filters built from the values actually present in the data.
   // Counts come from TanStack's faceted row model, so no extra queries are
   // needed and the numbers always match what the table is showing.
-  facets?: { columnId: string; label: string }[]
+  // format turns a stored value into what a person calls it: the column holds
+  // "super_admin", the filter has to offer "Super-admin".
+  facets?: {
+    columnId: string
+    label: string
+    format?: (value: string) => string
+  }[]
   exportConfig?: {
     filename: string
     onExport: (data: TData[], format: "csv" | "xlsx") => Promise<void>
@@ -63,6 +69,18 @@ interface DataTableViewProps<TData, TValue> {
   // checkbox column.
   rowId?: (row: TData) => string
   bulkBar?: (ids: string[], clear: () => void) => React.ReactNode
+  // Opening a record. A drawer keeps the list, its filters and its scroll
+  // position behind it, so comparing two records is two clicks rather than
+  // four page loads.
+  onRowClick?: (row: TData) => void
+  // How one record reads when there is no room for a table. A phone cannot
+  // show eight columns, and a horizontally scrolling table hides the columns
+  // that matter behind the ones that do not.
+  mobileRow?: (row: TData) => {
+    title: React.ReactNode
+    subtitle?: React.ReactNode
+    meta?: { label: string; value: React.ReactNode }[]
+  }
 }
 
 export function DataTableView<TData, TValue>({
@@ -75,6 +93,8 @@ export function DataTableView<TData, TValue>({
   exportConfig,
   rowId,
   bulkBar,
+  onRowClick,
+  mobileRow,
 }: DataTableViewProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([])
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
@@ -99,11 +119,18 @@ export function DataTableView<TData, TValue>({
         />
       ),
       cell: ({ row }) => (
-        <Checkbox
-          checked={row.getIsSelected()}
-          onCheckedChange={(v) => row.toggleSelected(!!v)}
-          aria-label="Select row"
-        />
+        // The checkbox lives inside a row that may itself be clickable, so it
+        // has to keep its click: selecting a record must not also open it.
+        <span
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <Checkbox
+            checked={row.getIsSelected()}
+            onCheckedChange={(v) => row.toggleSelected(!!v)}
+            aria-label="Select row"
+          />
+        </span>
       ),
     }
     return [selectCol, ...columns]
@@ -138,6 +165,25 @@ export function DataTableView<TData, TValue>({
     globalFilterFn: "includesString",
     state: { sorting, columnFilters, globalFilter, rowSelection },
   })
+
+  // A row that opens a record has to be operable without a pointer. Giving it
+  // the button role and Enter/Space rather than a nested <button> keeps the
+  // cells' own links and checkboxes working, which a wrapping button would
+  // swallow.
+  const rowHandlers = (row: TData) =>
+    onRowClick
+      ? {
+          role: "button" as const,
+          tabIndex: 0,
+          onClick: () => onRowClick(row),
+          onKeyDown: (e: React.KeyboardEvent) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault()
+              onRowClick(row)
+            }
+          },
+        }
+      : {}
 
   const showSearch = Boolean(globalSearch || searchKey)
   const selectedIds = table.getSelectedRowModel().rows.map((r) => r.id)
@@ -186,6 +232,7 @@ export function DataTableView<TData, TValue>({
                 .sort((a, b) => String(a).localeCompare(String(b)))
               if (options.length === 0) return null
               const value = (column.getFilterValue() as string) ?? ALL
+              const label = facet.format ?? ((v: string) => v)
 
               return (
                 <Select
@@ -205,7 +252,7 @@ export function DataTableView<TData, TValue>({
                     <span className="truncate">
                       {value === ALL
                         ? `All ${facet.label.toLowerCase()}`
-                        : `${value} (${counts.get(value) ?? 0})`}
+                        : `${label(value)} (${counts.get(value) ?? 0})`}
                     </span>
                   </SelectTrigger>
                   <SelectContent>
@@ -214,7 +261,7 @@ export function DataTableView<TData, TValue>({
                     </SelectItem>
                     {options.map((option) => (
                       <SelectItem key={option} value={option}>
-                        {option} ({counts.get(option)})
+                        {label(option)} ({counts.get(option)})
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -270,7 +317,13 @@ export function DataTableView<TData, TValue>({
           </div>
         </div>
       )}
-      <div className="bg-card rounded-lg border">
+      <div
+        className={
+          mobileRow
+            ? "bg-card hidden rounded-lg border sm:block"
+            : "bg-card overflow-x-auto rounded-lg border"
+        }
+      >
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
@@ -291,7 +344,15 @@ export function DataTableView<TData, TValue>({
           <TableBody>
             {table.getRowModel().rows?.length ? (
               table.getRowModel().rows.map((row) => (
-                <TableRow key={row.id}>
+                <TableRow
+                  key={row.id}
+                  {...rowHandlers(row.original)}
+                  className={
+                    onRowClick
+                      ? "focus-visible:ring-ring cursor-pointer focus-visible:ring-2 focus-visible:outline-none"
+                      : undefined
+                  }
+                >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell key={cell.id}>
                       {flexRender(
@@ -315,6 +376,62 @@ export function DataTableView<TData, TValue>({
           </TableBody>
         </Table>
       </div>
+      {mobileRow && (
+        <div className="flex flex-col gap-2 sm:hidden">
+          {table.getRowModel().rows.length === 0 ? (
+            <p className="text-muted-foreground py-8 text-center text-sm">
+              No results.
+            </p>
+          ) : (
+            table.getRowModel().rows.map((row) => {
+              const r = mobileRow(row.original)
+              return (
+                <div
+                  key={row.id}
+                  {...rowHandlers(row.original)}
+                  className={
+                    onRowClick
+                      ? "bg-card focus-visible:ring-ring flex items-start gap-3 rounded-lg border p-3 focus-visible:ring-2 focus-visible:outline-none"
+                      : "bg-card flex items-start gap-3 rounded-lg border p-3"
+                  }
+                >
+                  {selectable && (
+                    <span
+                      className="pt-0.5"
+                      onClick={(e) => e.stopPropagation()}
+                      onKeyDown={(e) => e.stopPropagation()}
+                    >
+                      <Checkbox
+                        checked={row.getIsSelected()}
+                        onCheckedChange={(v) => row.toggleSelected(!!v)}
+                        aria-label="Select record"
+                      />
+                    </span>
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">{r.title}</p>
+                    {r.subtitle && (
+                      <p className="text-muted-foreground truncate text-xs">
+                        {r.subtitle}
+                      </p>
+                    )}
+                    {r.meta && r.meta.length > 0 && (
+                      <dl className="mt-2 flex flex-wrap gap-x-4 gap-y-1">
+                        {r.meta.map((m) => (
+                          <div key={m.label} className="flex gap-1.5 text-xs">
+                            <dt className="text-muted-foreground">{m.label}</dt>
+                            <dd>{m.value}</dd>
+                          </div>
+                        ))}
+                      </dl>
+                    )}
+                  </div>
+                </div>
+              )
+            })
+          )}
+        </div>
+      )}
       <div className="flex items-center justify-between">
         <p className="text-muted-foreground text-xs font-medium tabular-nums">
           {table.getFilteredRowModel().rows.length} record(s)


### PR DESCRIPTION
Completes phase 2c and the mobile half of phase 4.

## The drawer finally has a caller

`RecordDrawer` was built in phase 2c and nothing used it. Both admin tables now do.

Inspecting a person meant leaving the table, losing the filters and the scroll position, and navigating back. A drawer keeps the list behind it, so comparing two records is two clicks rather than four page loads. The full record page is still one click further on, for the things a summary cannot hold.

The student drawer flags an **unclaimed** row — a student who has never signed in — because that is the difference between a roster mistake and a person who simply has not arrived yet.

## The list on a phone

A phone cannot show eight columns, and a horizontally scrolling table hides the columns that matter behind the ones that do not. Where a table supplies `mobileRow` it renders as a record list below `sm` instead: name, identifier, and the three or four facts worth carrying. Tables without one now at least scroll inside their own container rather than pushing the page sideways.

## Keyboard

A row that opens a record has to be operable without a pointer, so it takes `role="button"`, `tabIndex`, and Enter/Space rather than `onClick` alone. Deliberately **not** a nested `<button>` — that would swallow the links and checkboxes inside the cells. The selection checkbox stops both the click and the key, since selecting a record must not also open it.

## One more sentinel caught

Facets can now format their values. The role column stores `super_admin` and the filter was about to offer it verbatim — the same class of leak as the `__all` sentinel that used to reach the filter triggers. `ROLE_LABEL` is exported from the column definitions so the table, the drawer and the filter cannot disagree about what a role is called.

## Checks

`npm run check` — typecheck, lint (2 pre-existing warnings), format, 116 tests. `npm run build` compiled.

Not verified in a browser: reaching an authenticated page locally needs a minted session and I stopped after the sandbox declined that twice. The runtime risk is low — `Sheet` is the same primitive the mobile sidebar already ships, and both consumers are client components — but the drawer's first live render is worth a look on the deploy preview.