### PR TITLE
feat(phase-5): command palette, and a permissions console that says who a change moves

### DIFF
--- a/src/app/dashboard/admin/roles/client.tsx
+++ b/src/app/dashboard/admin/roles/client.tsx
@@ -1,10 +1,22 @@
 "use client"
 
-import { useMemo, useTransition } from "react"
+import { useMemo, useState, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { Switch } from "@/components/ui/switch"
 import { CAPABILITY_CATALOG, ROLE_DEFAULTS, type Capability } from "@/lib/rbac"
+import { Input } from "@/components/ui/input"
+import { SearchIcon } from "lucide-react"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import { setRoleCapabilityAction } from "../actions"
 
 type ToggleTier = "hod" | "faculty" | "student"
@@ -16,9 +28,26 @@ const TIERS: { key: ToggleTier; label: string }[] = [
   { key: "student", label: "Student" },
 ]
 
-export function RolesClient({ overrides }: { overrides: Override[] }) {
+type PendingChange = {
+  tier: ToggleTier
+  tierLabel: string
+  capability: Capability
+  capLabel: string
+  enabled: boolean
+  affected: number
+}
+
+export function RolesClient({
+  overrides,
+  headcount,
+}: {
+  overrides: Override[]
+  headcount: Record<string, number>
+}) {
   const router = useRouter()
   const [pending, start] = useTransition()
+  const [query, setQuery] = useState("")
+  const [confirming, setConfirming] = useState<PendingChange | null>(null)
 
   // (tier, capability) -> effect, for quick lookup.
   const overrideMap = useMemo(() => {
@@ -38,21 +67,53 @@ export function RolesClient({ overrides }: { overrides: Override[] }) {
   const overridden = (tier: ToggleTier, cap: Capability) =>
     overrideMap.has(`${tier}:${cap}`)
 
-  function toggle(tier: ToggleTier, capability: Capability, enabled: boolean) {
+  function apply(tier: ToggleTier, capability: Capability, enabled: boolean) {
     start(async () => {
       const res = await setRoleCapabilityAction({ tier, capability, enabled })
       if (res.error) {
         toast.error(res.error)
         return
       }
+      setConfirming(null)
       router.refresh()
     })
   }
 
-  // Group the catalogue for section headers, preserving order.
+  // Taking a capability away is the direction that breaks someone's day
+  // mid-semester, so it stops to say whose. Granting is additive and goes
+  // straight through: nobody loses work because a switch turned on.
+  function toggle(tier: ToggleTier, capability: Capability, enabled: boolean) {
+    if (enabled) {
+      apply(tier, capability, true)
+      return
+    }
+    setConfirming({
+      tier,
+      tierLabel: TIERS.find((t) => t.key === tier)!.label,
+      capability,
+      capLabel:
+        CAPABILITY_CATALOG.find((c) => c.capability === capability)?.label ??
+        capability,
+      enabled: false,
+      affected: headcount[tier] ?? 0,
+    })
+  }
+
+  // Group the catalogue for section headers, preserving order. The search
+  // matches the capability string as well as its label, because the string is
+  // what appears in the code being reasoned about: somebody arriving from a
+  // Forbidden error knows "marks:lock", not "Lock a marks component".
   const groups = useMemo(() => {
+    const q = query.trim().toLowerCase()
     const out: { group: string; caps: typeof CAPABILITY_CATALOG }[] = []
     for (const entry of CAPABILITY_CATALOG) {
+      if (
+        q &&
+        !entry.capability.toLowerCase().includes(q) &&
+        !entry.label.toLowerCase().includes(q) &&
+        !entry.group.toLowerCase().includes(q)
+      )
+        continue
       let g = out.find((x) => x.group === entry.group)
       if (!g) {
         g = { group: entry.group, caps: [] }
@@ -61,7 +122,9 @@ export function RolesClient({ overrides }: { overrides: Override[] }) {
       g.caps.push(entry)
     }
     return out
-  }, [])
+  }, [query])
+
+  const shown = groups.reduce((n, g) => n + g.caps.length, 0)
 
   return (
     <div className="flex flex-col gap-4">
@@ -71,9 +134,29 @@ export function RolesClient({ overrides }: { overrides: Override[] }) {
         Super-admin always has everything and is never listed.
       </p>
 
-      <div className="border-border overflow-x-auto rounded-lg border">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative w-full max-w-sm">
+          <SearchIcon className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+          <Input
+            placeholder="Search capabilities, e.g. marks:lock"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        {query && (
+          <p className="text-muted-foreground text-xs tabular-nums">
+            {shown} of {CAPABILITY_CATALOG.length} capabilities
+          </p>
+        )}
+      </div>
+
+      <div className="border-border max-h-[70vh] overflow-auto rounded-lg border">
         <table className="w-full min-w-[520px] text-sm">
-          <thead className="bg-muted/60">
+          {/* The table is taller than the screen and the header carries the
+              only thing that says which column is which tier — scrolling it
+              away turns every switch into a guess. */}
+          <thead className="bg-muted/60 sticky top-0 z-10">
             <tr>
               <th className="p-3 text-left text-xs font-medium">Capability</th>
               {TIERS.map((t) => (
@@ -81,26 +164,83 @@ export function RolesClient({ overrides }: { overrides: Override[] }) {
                   key={t.key}
                   className="w-24 p-3 text-center text-xs font-medium"
                 >
-                  {t.label}
+                  <span className="block">{t.label}</span>
+                  <span className="text-muted-foreground font-normal tabular-nums">
+                    {headcount[t.key] ?? 0}
+                  </span>
                 </th>
               ))}
             </tr>
           </thead>
           <tbody className="divide-border divide-y">
-            {groups.map((g) => (
-              <GroupRows
-                key={g.group}
-                group={g.group}
-                caps={g.caps}
-                effective={effective}
-                overridden={overridden}
-                pending={pending}
-                onToggle={toggle}
-              />
-            ))}
+            {groups.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={1 + TIERS.length}
+                  className="text-muted-foreground p-6 text-center text-sm"
+                >
+                  No capability matches “{query}”.
+                </td>
+              </tr>
+            ) : (
+              groups.map((g) => (
+                <GroupRows
+                  key={g.group}
+                  group={g.group}
+                  caps={g.caps}
+                  effective={effective}
+                  overridden={overridden}
+                  pending={pending}
+                  onToggle={toggle}
+                />
+              ))
+            )}
           </tbody>
         </table>
       </div>
+
+      <AlertDialog
+        open={confirming !== null}
+        onOpenChange={(o) => !o && setConfirming(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Revoke {confirming?.capLabel} from {confirming?.tierLabel}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              <span className="text-foreground font-medium tabular-nums">
+                {confirming?.affected}
+              </span>{" "}
+              active {confirming?.tierLabel.toLowerCase()} account
+              {confirming?.affected === 1 ? "" : "s"} lose{" "}
+              <span className="identifier">{confirming?.capability}</span> the
+              moment this is saved. Anyone mid-task is refused on their next
+              action.
+            </AlertDialogDescription>
+            {/* Outside the description, which renders a paragraph of its own —
+                a nested <p> is invalid and hydrates as a mismatch. */}
+            <p className="text-muted-foreground text-xs">
+              Scope still applies on top of this: revoking here removes the
+              action everywhere, not only where you were thinking of. The change
+              is recorded in the audit log against your account.
+            </p>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={pending}>Keep it</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              disabled={pending}
+              onClick={() =>
+                confirming &&
+                apply(confirming.tier, confirming.capability, false)
+              }
+            >
+              {pending ? "Revoking…" : "Revoke"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/app/dashboard/admin/roles/page.tsx
+++ b/src/app/dashboard/admin/roles/page.tsx
@@ -1,11 +1,14 @@
 import { PageHeader } from "@/components/page-header"
-import { listRoleOverrides } from "@/db/queries/permissions"
+import { countUsersByTier, listRoleOverrides } from "@/db/queries/permissions"
 import { RolesClient } from "./client"
 
 export const dynamic = "force-dynamic"
 
 export default async function AdminRolesPage() {
-  const overrides = await listRoleOverrides()
+  const [overrides, headcount] = await Promise.all([
+    listRoleOverrides(),
+    countUsersByTier(),
+  ])
   return (
     <>
       <PageHeader
@@ -20,6 +23,7 @@ export default async function AdminRolesPage() {
             capability: o.capability,
             effect: o.effect,
           }))}
+          headcount={headcount}
         />
       </div>
     </>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation"
 import { AppSidebar } from "@/components/app-sidebar"
+import { CommandPalette } from "@/components/command-palette"
 import { SessionProvider } from "@/components/session-provider"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { getSessionUser, isUnbound } from "@/lib/session"
@@ -39,6 +40,9 @@ export default async function DashboardLayout({
       <SidebarProvider>
         <AppSidebar />
         <SidebarInset>{children}</SidebarInset>
+        {/* Mounted once at the layout so Cmd+K works from every page, rather
+            than each page remembering to include it. */}
+        <CommandPalette />
       </SidebarProvider>
     </SessionProvider>
   )

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -37,6 +37,8 @@ const DOMAIN_ICON: Record<string, React.ReactNode> = {
 }
 import { useSessionUser, useCan } from "@/components/session-provider"
 import { buildNavigation } from "@/lib/navigation"
+import { openCommandPalette } from "@/components/command-palette"
+import { SearchIcon } from "lucide-react"
 import { VossMark } from "@/components/voss-logo"
 
 // MVP surface only: roster and identity. Marks / attendance / courses come back
@@ -90,6 +92,20 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         </SidebarMenu>
       </SidebarHeader>
       <SidebarContent>
+        <SidebarMenu className="px-2">
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              onClick={openCommandPalette}
+              tooltip="Search (⌘K)"
+            >
+              <SearchIcon />
+              <span>Search</span>
+              <kbd className="text-muted-foreground ml-auto text-[10px] group-data-[collapsible=icon]:hidden">
+                ⌘K
+              </kbd>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
         <NavMain items={navItems} />
       </SidebarContent>
       <SidebarFooter>

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandShortcut,
+} from "@/components/ui/command"
+import { useSessionUser, useCan } from "@/components/session-provider"
+import { buildNavigation } from "@/lib/navigation"
+
+/**
+ * Opening the palette from a visible control.
+ *
+ * A shortcut nobody is told about does not exist, so the sidebar shows a
+ * button. It broadcasts rather than sharing state because the palette is
+ * mounted beside the sidebar, not around it — threading a setter through the
+ * layout would make a server component hold client state to pass it along.
+ */
+export const OPEN_PALETTE = "verp:open-command-palette"
+
+export function openCommandPalette() {
+  document.dispatchEvent(new CustomEvent(OPEN_PALETTE))
+}
+
+/**
+ * Cmd+K navigation (spec phase 5).
+ *
+ * Staff move between a class register, a marks grid and a roster dozens of
+ * times an hour, and the sidebar makes each of those two or three clicks
+ * through a tree they have to re-read every time. Typing three letters is the
+ * whole interaction.
+ *
+ * Entries come from buildNavigation, the same function the sidebar renders,
+ * rather than a second list. A palette with its own list is a list that will
+ * disagree: it would keep offering a page after a capability was revoked, and
+ * land the user on a Forbidden screen the sidebar had already stopped showing.
+ */
+export function CommandPalette() {
+  const router = useRouter()
+  const session = useSessionUser()
+  const can = useCan()
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      // Ctrl as well as Cmd: the college's lab machines are Windows.
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        setOpen((o) => !o)
+      }
+    }
+    const onOpen = () => setOpen(true)
+    document.addEventListener("keydown", onKey)
+    document.addEventListener(OPEN_PALETTE, onOpen)
+    return () => {
+      document.removeEventListener("keydown", onKey)
+      document.removeEventListener(OPEN_PALETTE, onOpen)
+    }
+  }, [])
+
+  const domains = buildNavigation({
+    tier: session.tier,
+    can,
+    isCoordinator: session.coordinatorClassIds.length > 0,
+    hasClasses: session.classIds.length > 0,
+  })
+
+  const go = (url: string) => {
+    setOpen(false)
+    router.push(url)
+  }
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={setOpen}
+      title="Go to"
+      description="Search for a page"
+    >
+      <CommandInput placeholder="Go to…" />
+      <CommandList>
+        <CommandEmpty>Nothing matches that.</CommandEmpty>
+        {domains.map((d) => (
+          <CommandGroup key={d.domain} heading={d.domain}>
+            {d.items.map((item) => (
+              <CommandItem
+                // The domain is part of the search text, so "people roster"
+                // finds the roster even though the link is called "Student
+                // roster" — people search for where a thing lives as often as
+                // for what it is called.
+                key={item.url}
+                value={`${d.domain} ${item.title} ${item.url}`}
+                onSelect={() => go(item.url)}
+              >
+                {item.title}
+                <CommandShortcut>{d.domain}</CommandShortcut>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        ))}
+      </CommandList>
+    </CommandDialog>
+  )
+}

--- a/src/db/queries/permissions.ts
+++ b/src/db/queries/permissions.ts
@@ -1,6 +1,6 @@
-import { and, eq } from "drizzle-orm"
+import { and, count, eq } from "drizzle-orm"
 import { db } from "@/db"
-import { permissionOverrides } from "@/db/schema"
+import { faculty, permissionOverrides, students } from "@/db/schema"
 
 export async function listRoleOverrides() {
   const rows = await db
@@ -51,4 +51,34 @@ export async function setRoleOverride(
       createdBy,
     })
   }
+}
+
+/**
+ * How many people a tier's row actually covers.
+ *
+ * A permission switch reads as an abstraction until it says who it moves.
+ * "Revoke marks:write from faculty" is a shrug; "revoke it from 47 teachers,
+ * mid-semester" is a decision. The console cannot ask for confirmation
+ * meaningfully without this number.
+ *
+ * Counted from the tier's own source: a faculty row's role is the tier, and
+ * every active student is the student tier. Super-admin is excluded because it
+ * holds a wildcard no override can touch.
+ */
+export async function countUsersByTier(): Promise<Record<string, number>> {
+  const [staff, studentRows] = await Promise.all([
+    db
+      .select({ role: faculty.role, n: count() })
+      .from(faculty)
+      .where(eq(faculty.isActive, true))
+      .groupBy(faculty.role),
+    db.select({ n: count() }).from(students).where(eq(students.isActive, true)),
+  ])
+
+  const out: Record<string, number> = { hod: 0, faculty: 0, student: 0 }
+  for (const row of staff) {
+    if (row.role in out) out[row.role] = row.n
+  }
+  out.student = studentRows[0]?.n ?? 0
+  return out
 }


### PR DESCRIPTION
## Cmd+K

Staff move between a register, a marks grid and a roster dozens of times an hour, and the sidebar makes each of those two or three clicks through a tree they have to re-read every time. Three letters instead. Ctrl+K too — the college's lab machines are Windows.

Entries come from `buildNavigation`, **the same function the sidebar renders**, rather than a second list. A palette with its own list is a list that will disagree: it would keep offering a page after a capability was revoked, and land the user on a Forbidden screen the sidebar had already stopped showing.

Each entry's search text includes its domain, so "people roster" finds the student roster — people search for where a thing lives as often as for what it is called. And since a shortcut nobody is told about does not exist, the sidebar carries a Search button that opens the same palette.

## The permissions console

It was a wall of switches with no way to find one and no statement of consequence.

- **Search** over the capability string as well as its label. Somebody arriving from a Forbidden error knows `marks:lock`, not "Lock a marks component".
- **Sticky header carrying each tier's headcount.** The table is taller than the screen; scrolling the header away turned every switch into a guess.
- **Revocation stops to say whose day it breaks** — how many active accounts lose the capability the moment it is saved, that anyone mid-task is refused on their next action, and that scope does not narrow it. Granting goes straight through: nobody loses work because a switch turned on.

`countUsersByTier` is the new query behind the impact preview. "Revoke marks:write from faculty" is a shrug; "revoke it from 47 teachers, mid-semester" is a decision.

## Checks

`npm run check` — typecheck, lint (2 pre-existing warnings), format, 116 tests. `npm run build` compiled.

Refs the P2 permissions-console finding in `research/verp-rbac-ux-audit-2026-08-13.md`.