### PR TITLE
feat(overview): an attention inbox that ranks work by who is stuck

### DIFF
--- a/src/app/dashboard/attention-inbox.tsx
+++ b/src/app/dashboard/attention-inbox.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link"
+import type { AttentionItem, Urgency } from "@/lib/attention"
+
+/**
+ * What needs doing, in the order it needs doing (spec 4.5).
+ *
+ * The cards below this answer "how are my classes doing". They cannot answer
+ * "what should I do next", because the facts are spread one per class and the
+ * thing blocking a hundred students carries the same visual weight as a
+ * cosmetic gap. This is the one place that ranks them against each other.
+ */
+
+const TONE: Record<Urgency, string> = {
+  blocking: "border-l-destructive",
+  overdue: "border-l-attention",
+  open: "border-l-border",
+}
+
+// The stripe is a repetition of the word, never the only carrier of it.
+const WORD: Record<Urgency, string> = {
+  blocking: "Blocking",
+  overdue: "Overdue",
+  open: "Open",
+}
+
+export function AttentionInbox({ items }: { items: AttentionItem[] }) {
+  if (items.length === 0) return null
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-baseline gap-2">
+        <h3 className="text-sm font-semibold">Needs your attention</h3>
+        <span className="text-muted-foreground text-xs tabular-nums">
+          {items.length}
+        </span>
+      </div>
+      <ul className="flex flex-col gap-2">
+        {items.map((item) => (
+          <li key={item.id}>
+            <Link
+              href={item.href}
+              className={`bg-card hover:bg-muted/40 focus-visible:ring-ring flex items-start gap-3 rounded-lg border border-l-4 p-3 transition-colors focus-visible:ring-2 focus-visible:outline-none ${TONE[item.urgency]}`}
+            >
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium">{item.title}</p>
+                <p className="text-muted-foreground mt-0.5 text-xs">
+                  {item.detail}
+                </p>
+              </div>
+              <span className="text-muted-foreground shrink-0 text-xs">
+                {WORD[item.urgency]}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,8 @@ import { getAttendanceSummaryForStudent } from "@/db/queries/attendance"
 import { getMarksForStudent } from "@/db/queries/marks"
 import { getClassWork, getDeptHealth } from "@/db/queries/overview"
 import { listDepartments } from "@/db/queries/departments"
+import { buildAttention } from "@/lib/attention"
+import { AttentionInbox } from "./attention-inbox"
 import {
   Attention,
   Completion,
@@ -44,6 +46,13 @@ export default async function DashboardPage() {
     deptCodes.length ? getDeptHealth(deptCodes) : Promise.resolve([]),
   ])
 
+  // Derived from what was already fetched, not a fifth query.
+  const attention = buildAttention({
+    classWork: work,
+    deptHealth: health,
+    today,
+  })
+
   const label = (c: {
     admissionYear: number
     departmentCode: string
@@ -67,6 +76,8 @@ export default async function DashboardPage() {
                 : "Nothing is assigned to you yet."}
           </p>
         </div>
+
+        <AttentionInbox items={attention} />
 
         {health.length > 0 && (
           <section className="flex flex-col gap-3">

--- a/src/app/dashboard/students/client.tsx
+++ b/src/app/dashboard/students/client.tsx
@@ -19,9 +19,11 @@ import { bulkDeactivateStudentsAction } from "./actions"
 export function StudentsClient({
   data,
   canDeactivate,
+  department,
 }: {
   data: StudentRow[]
   canDeactivate: boolean
+  department?: string
 }) {
   const router = useRouter()
   const [pending, start] = useTransition()
@@ -105,6 +107,9 @@ export function StudentsClient({
           { columnId: "division", label: "Division" },
         ]}
         searchPlaceholder="Search students..."
+        initialFilters={
+          department ? [{ id: "department", value: department }] : undefined
+        }
         exportConfig={{ filename: "Students", onExport: handleExport }}
         rowId={(s) => s.id}
         onRowClick={setOpen}

--- a/src/app/dashboard/students/page.tsx
+++ b/src/app/dashboard/students/page.tsx
@@ -12,7 +12,12 @@ import {
 
 export const dynamic = "force-dynamic"
 
-export default async function StudentsPage() {
+export default async function StudentsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ department?: string }>
+}) {
+  const { department } = await searchParams
   const user = await getSessionUser()
   if (!user) redirect("/login")
   // A student has no student:read — they can never reach the roster, by URL or nav.
@@ -46,6 +51,7 @@ export default async function StudentsPage() {
         <StudentsClient
           data={rows}
           canDeactivate={can(user, "student:deactivate")}
+          department={department}
         />
       </div>
     </>

--- a/src/components/data-table-view.tsx
+++ b/src/components/data-table-view.tsx
@@ -69,6 +69,10 @@ interface DataTableViewProps<TData, TValue> {
   // checkbox column.
   rowId?: (row: TData) => string
   bulkBar?: (ids: string[], clear: () => void) => React.ReactNode
+  // Filters the table opens with, so a link from elsewhere can land on the
+  // exact list it was talking about rather than the whole roster. Seeded once:
+  // clearing a filter must stay cleared, not snap back on the next render.
+  initialFilters?: ColumnFiltersState
   // Opening a record. A drawer keeps the list, its filters and its scroll
   // position behind it, so comparing two records is two clicks rather than
   // four page loads.
@@ -95,10 +99,11 @@ export function DataTableView<TData, TValue>({
   bulkBar,
   onRowClick,
   mobileRow,
+  initialFilters,
 }: DataTableViewProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([])
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    []
+    initialFilters ?? []
   )
   const [globalFilter, setGlobalFilter] = React.useState("")
   const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({})

--- a/src/lib/attention.test.ts
+++ b/src/lib/attention.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest"
+import { buildAttention } from "./attention"
+import type { ClassWork, DeptHealth } from "@/db/queries/overview"
+
+const cls = (over: Partial<ClassWork> = {}): ClassWork => ({
+  classId: "c1",
+  classKey: "2023-108-A",
+  admissionYear: 2023,
+  division: "A",
+  departmentCode: "EXCS",
+  role: "tr",
+  students: 60,
+  pendingRequests: 0,
+  markedToday: 0,
+  mySubjects: [],
+  unallocatedSubjects: 0,
+  ...over,
+})
+
+const dept = (over: Partial<DeptHealth> = {}): DeptHealth => ({
+  code: "EXCS",
+  name: "Computer Engineering",
+  hod: "A B",
+  classes: 4,
+  classesWithoutCoordinator: 0,
+  faculty: 20,
+  students: 240,
+  unclaimedStudents: 0,
+  unallocatedSubjects: 0,
+  ...over,
+})
+
+const build = (classWork: ClassWork[], deptHealth: DeptHealth[] = []) =>
+  buildAttention({ classWork, deptHealth, today: "2026-08-13" })
+
+describe("buildAttention", () => {
+  it("says nothing when there is nothing to do", () => {
+    expect(build([cls({ markedToday: 60 })])).toEqual([])
+  })
+
+  // The whole point of the ranking: a big number is not an urgent one.
+  it("ranks a blocking item above a larger merely-open one", () => {
+    const items = build([
+      cls({
+        markedToday: 60,
+        unallocatedSubjects: 1,
+        mySubjects: [{ id: "o1", code: "EC33T", name: "DAV", entered: 0 }],
+      }),
+    ])
+    expect(items.map((i) => i.urgency)).toEqual(["blocking", "open"])
+    expect(items[0].count).toBe(1)
+    expect(items[1].count).toBe(60)
+  })
+
+  it("sorts by count within one urgency", () => {
+    const items = build(
+      [],
+      [
+        dept({ code: "EXCS", classesWithoutCoordinator: 1 }),
+        dept({ code: "EXTC", classesWithoutCoordinator: 3 }),
+      ]
+    )
+    expect(items.map((i) => i.count)).toEqual([3, 1])
+  })
+
+  // An empty class has no register to take and no marks to miss. Reporting it
+  // would put a permanent unclearable item in front of whoever owns that class.
+  it("stays quiet about a class with no students", () => {
+    expect(
+      build([
+        cls({
+          students: 0,
+          mySubjects: [{ id: "o1", code: "EC33T", name: "DAV", entered: 0 }],
+        }),
+      ])
+    ).toEqual([])
+  })
+
+  it("does not flag a register that was already taken", () => {
+    const items = build([cls({ markedToday: 60 })])
+    expect(items.find((i) => i.id.startsWith("attendance:"))).toBeUndefined()
+  })
+
+  it("counts what is missing, not what is entered", () => {
+    const items = build([
+      cls({
+        markedToday: 60,
+        mySubjects: [{ id: "o1", code: "EC33T", name: "DAV", entered: 45 }],
+      }),
+    ])
+    expect(items[0].count).toBe(15)
+    expect(items[0].title).toContain("15 students unmarked")
+  })
+
+  it("drops a subject once every student has a mark", () => {
+    expect(
+      build([
+        cls({
+          markedToday: 60,
+          mySubjects: [{ id: "o1", code: "EC33T", name: "DAV", entered: 60 }],
+        }),
+      ])
+    ).toEqual([])
+  })
+
+  it("agrees in number, both noun and verb", () => {
+    expect(build([], [dept({ unclaimedStudents: 4 })])[0].title).toBe(
+      "4 students have never signed in"
+    )
+    const items = build([], [dept({ unclaimedStudents: 1 })])
+    expect(items[0].title).toBe("1 student has never signed in")
+  })
+
+  // Every item promises to land somewhere that can resolve it. A link into a
+  // route that does not exist is worse than no item at all.
+  it("links each item to a real workspace", () => {
+    const items = build(
+      [
+        cls({
+          pendingRequests: 2,
+          unallocatedSubjects: 1,
+          mySubjects: [{ id: "o1", code: "EC33T", name: "DAV", entered: 0 }],
+        }),
+      ],
+      [dept({ classesWithoutCoordinator: 1, unclaimedStudents: 4 })]
+    )
+    expect(items.every((i) => i.href.startsWith("/dashboard/"))).toBe(true)
+    expect(items.map((i) => i.href)).toContain(
+      "/dashboard/class/c1/marks?offering=o1"
+    )
+    expect(items.map((i) => i.href)).toContain(
+      "/dashboard/students?department=EXCS"
+    )
+  })
+
+  it("gives every item a distinct id so the list can key on it", () => {
+    const items = build(
+      [
+        cls({ classId: "c1", pendingRequests: 1, unallocatedSubjects: 1 }),
+        cls({ classId: "c2", pendingRequests: 1 }),
+      ],
+      [dept({ unallocatedSubjects: 2 })]
+    )
+    expect(new Set(items.map((i) => i.id)).size).toBe(items.length)
+  })
+})

--- a/src/lib/attention.ts
+++ b/src/lib/attention.ts
@@ -1,0 +1,140 @@
+// The attention inbox (spec 4.5).
+//
+// The overview already answers "how are my classes doing". It does not answer
+// "what should I do next", and those are different questions: the facts are
+// spread across per-class cards and per-department rows, so the one thing
+// blocking a hundred students sits in the same visual weight as a cosmetic gap.
+//
+// This ranks the same already-fetched facts into one list. It deliberately
+// issues no queries — a second data path would be a second thing to keep in
+// scope, and everything needed is on screen already.
+
+import type { ClassWork, DeptHealth } from "@/db/queries/overview"
+
+/**
+ * How much a thing matters, which is not how big its number is.
+ *
+ * "blocking" means somebody else cannot proceed until this person acts: a
+ * student waiting on an enrolment decision has no way to make progress alone.
+ * "overdue" is work that should already have happened. "open" is real but
+ * nobody is stuck. Sorting by count instead would put forty missing marks above
+ * one unstaffed class, and the unstaffed class is why the marks are missing.
+ */
+export type Urgency = "blocking" | "overdue" | "open"
+
+export type AttentionItem = {
+  id: string
+  urgency: Urgency
+  title: string
+  detail: string
+  href: string
+  count: number
+}
+
+const RANK: Record<Urgency, number> = { blocking: 0, overdue: 1, open: 2 }
+
+const plural = (n: number, one: string, many = `${one}s`) =>
+  n === 1 ? one : many
+
+export function buildAttention(input: {
+  classWork: ClassWork[]
+  deptHealth: DeptHealth[]
+  /** Roster size is the yardstick for whether a subject's marks are complete. */
+  today: string
+}): AttentionItem[] {
+  const items: AttentionItem[] = []
+
+  for (const c of input.classWork) {
+    const label = `${c.classKey} · ${c.departmentCode} ${c.division}`
+
+    if (c.pendingRequests > 0) {
+      items.push({
+        id: `enrol:${c.classId}`,
+        urgency: "blocking",
+        title: `${c.pendingRequests} enrolment ${plural(c.pendingRequests, "request")}`,
+        detail: `${label} — a student cannot see their record until this is decided.`,
+        href: `/dashboard/class/${c.classId}`,
+        count: c.pendingRequests,
+      })
+    }
+
+    // A class with nobody teaching a subject is why its marks and register go
+    // missing later, so it outranks the symptoms.
+    if (c.unallocatedSubjects > 0) {
+      items.push({
+        id: `unallocated:${c.classId}`,
+        urgency: "blocking",
+        title: `${c.unallocatedSubjects} ${plural(c.unallocatedSubjects, "subject")} with no teacher`,
+        detail: `${label} — nobody can enter marks or take the register for these.`,
+        href: `/dashboard/class/${c.classId}/subjects`,
+        count: c.unallocatedSubjects,
+      })
+    }
+
+    // Only meaningful once there is a roster to take a register against.
+    if (c.students > 0 && c.markedToday === 0) {
+      items.push({
+        id: `attendance:${c.classId}`,
+        urgency: "overdue",
+        title: "Register not taken today",
+        detail: `${label} — ${c.students} ${plural(c.students, "student")}, nothing recorded for ${input.today}.`,
+        href: `/dashboard/class/${c.classId}/attendance`,
+        count: c.students,
+      })
+    }
+
+    for (const s of c.mySubjects) {
+      if (c.students === 0 || s.entered >= c.students) continue
+      const missing = c.students - s.entered
+      items.push({
+        id: `marks:${s.id}`,
+        urgency: "open",
+        title: `${s.code} — ${missing} ${plural(missing, "student")} unmarked`,
+        detail: `${label} — ${s.entered} of ${c.students} entered for ${s.name}.`,
+        href: `/dashboard/class/${c.classId}/marks?offering=${s.id}`,
+        count: missing,
+      })
+    }
+  }
+
+  for (const d of input.deptHealth) {
+    if (d.classesWithoutCoordinator > 0) {
+      items.push({
+        id: `coordinator:${d.code}`,
+        urgency: "blocking",
+        title: `${d.classesWithoutCoordinator} ${plural(d.classesWithoutCoordinator, "class", "classes")} without a coordinator`,
+        detail: `${d.code} — nobody can approve enrolments or allocate subjects for these.`,
+        href: `/dashboard/dept/${d.code}`,
+        count: d.classesWithoutCoordinator,
+      })
+    }
+
+    if (d.unallocatedSubjects > 0) {
+      items.push({
+        id: `dept-unallocated:${d.code}`,
+        urgency: "overdue",
+        title: `${d.unallocatedSubjects} unallocated ${plural(d.unallocatedSubjects, "subject")}`,
+        detail: `${d.code} — waiting on a teacher to be appointed.`,
+        href: "/dashboard/dept/appoint",
+        count: d.unallocatedSubjects,
+      })
+    }
+
+    // Not urgent, and never framed as the student's fault: an unclaimed row is
+    // usually a roster typo in the email, which is the department's to fix.
+    if (d.unclaimedStudents > 0) {
+      items.push({
+        id: `unclaimed:${d.code}`,
+        urgency: "open",
+        title: `${d.unclaimedStudents} ${plural(d.unclaimedStudents, "student")} ${plural(d.unclaimedStudents, "has", "have")} never signed in`,
+        detail: `${d.code} — check the email on the roster row if this looks wrong.`,
+        href: `/dashboard/students?department=${d.code}`,
+        count: d.unclaimedStudents,
+      })
+    }
+  }
+
+  return items.sort(
+    (a, b) => RANK[a.urgency] - RANK[b.urgency] || b.count - a.count
+  )
+}


### PR DESCRIPTION
Spec 4.5.

## Why

The overview answers "how are my classes doing". It could not answer "what should I do next": the facts sit one per class card, so the thing blocking a hundred students carries the same visual weight as a cosmetic gap, and nothing puts them in an order.

## Urgency is not size

| Urgency | Means |
|---|---|
| `blocking` | somebody else cannot proceed until this person acts |
| `overdue` | should already have happened |
| `open` | real, but nobody is stuck |

A student waiting on an enrolment decision has no way to make progress alone — that outranks a large number. Sorting by count would put forty missing marks above one unstaffed class, when the unstaffed class is *why* the marks are missing.

## No new query

`buildAttention` derives from the `ClassWork[]` and `DeptHealth[]` the overview already fetches. A second data path would be a second thing to keep in scope, and everything needed is on screen already. Pure function, 10 tests.

## Silence where there is nothing to do

A class with no students has no register to take and no marks to miss. Reporting it would park a permanent, unclearable item in front of whoever owns that class.

## Two dead links caught by writing the test first

Every item promises to land somewhere that can resolve it, and a test holds that promise. Two of the first drafts broke it:

- enrolment requests link to the class root — `/requests` was never built;
- `students?department=` did nothing, because the roster's filters are client-side. `DataTableView` now accepts `initialFilters` and the students page reads the param, so the link lands on the filtered list it was talking about.

## Verified against production data

Ran `getClassWork` + `getDeptHealth` + `buildAttention` over the live database as a super-admin would see it: 2 items, correctly ordered (`overdue` register before `open` unclaimed students), ids unique, every href resolving.

`npm run check` — typecheck, lint (2 pre-existing warnings), format, 126 tests. `npm run build` compiled.