### PR TITLE
feat(audit): show a record's own history in its drawer

### DIFF
--- a/src/app/dashboard/audit/actions.ts
+++ b/src/app/dashboard/audit/actions.ts
@@ -1,0 +1,46 @@
+"use server"
+
+import { getSessionUser } from "@/lib/session"
+import { can } from "@/lib/rbac"
+import { getRecordHistory } from "@/db/queries/audit"
+
+export type HistoryEvent = {
+  id: string
+  action: string
+  actorName: string | null
+  createdAt: string
+  details: Record<string, unknown> | null
+}
+
+/**
+ * The recent history of one record, for a drawer that has just been opened.
+ *
+ * Fetched on demand rather than with the table: a roster page would otherwise
+ * carry the audit trail of every student on it to render one drawer. The
+ * capability is checked here and not only where the section renders — hiding a
+ * component is a UI decision, and this is a server action anyone can call.
+ */
+export async function getRecordHistoryAction(input: {
+  targetType: string
+  targetId: string
+}): Promise<{ events: HistoryEvent[]; error: string | null }> {
+  try {
+    const user = await getSessionUser()
+    if (!user || !can(user, "audit:read")) {
+      return { events: [], error: "Not permitted." }
+    }
+    const rows = await getRecordHistory(input.targetType, input.targetId)
+    return {
+      events: rows.map((r) => ({
+        id: r.id,
+        action: r.action,
+        actorName: r.actorName,
+        createdAt: r.createdAt.toISOString(),
+        details: r.details as Record<string, unknown> | null,
+      })),
+      error: null,
+    }
+  } catch {
+    return { events: [], error: "Could not load history." }
+  }
+}

--- a/src/app/dashboard/faculty/client.tsx
+++ b/src/app/dashboard/faculty/client.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import { DataTableView } from "@/components/data-table-view"
 import { RecordDrawer } from "@/components/record-drawer"
+import { RecordHistory } from "@/components/record-history"
 import {
   facultyColumns,
   ROLE_LABEL,
@@ -117,7 +118,9 @@ export function FacultyClient({ data }: { data: FacultyRow[] }) {
               ]
             : undefined
         }
-      />
+      >
+        <RecordHistory targetType="faculty" targetId={open?.id ?? null} />
+      </RecordDrawer>
     </>
   )
 }

--- a/src/app/dashboard/students/client.tsx
+++ b/src/app/dashboard/students/client.tsx
@@ -14,6 +14,7 @@ import Link from "next/link"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Trash2Icon, UploadIcon } from "lucide-react"
 import { RecordDrawer } from "@/components/record-drawer"
+import { RecordHistory } from "@/components/record-history"
 import { bulkDeactivateStudentsAction } from "./actions"
 
 export function StudentsClient({
@@ -185,7 +186,9 @@ export function StudentsClient({
             </Link>
           )
         }
-      />
+      >
+        <RecordHistory targetType="student" targetId={open?.id ?? null} />
+      </RecordDrawer>
     </>
   )
 }

--- a/src/components/record-history.tsx
+++ b/src/components/record-history.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { DrawerSection } from "@/components/record-drawer"
+import { useCan } from "@/components/session-provider"
+import {
+  getRecordHistoryAction,
+  type HistoryEvent,
+} from "@/app/dashboard/audit/actions"
+
+/**
+ * What has happened to this record (spec 5.4).
+ *
+ * The global activity log answers "what happened today". It cannot answer "why
+ * does this student's record look like this", because that means scrolling
+ * thousands of unrelated rows. Same events, asked the other way round.
+ *
+ * Loaded when the drawer opens rather than with the table behind it: a roster
+ * page would otherwise carry the audit trail of every student on it to render
+ * one drawer.
+ */
+export function RecordHistory({
+  targetType,
+  targetId,
+}: {
+  targetType: string
+  targetId: string | null
+}) {
+  const can = useCan()
+  const allowed = can("audit:read")
+  // Which record the loaded events belong to travels with them. Clearing them
+  // separately when the drawer moves on would mean writing state during the
+  // effect, and for one render the previous student's history would sit under
+  // the new one's name.
+  const [loaded, setLoaded] = useState<{
+    forId: string
+    events: HistoryEvent[] | null
+  } | null>(null)
+
+  useEffect(() => {
+    if (!targetId || !allowed) return
+    let live = true
+    getRecordHistoryAction({ targetType, targetId }).then((res) => {
+      if (!live) return
+      setLoaded({ forId: targetId, events: res.error ? null : res.events })
+    })
+    return () => {
+      live = false
+    }
+  }, [targetType, targetId, allowed])
+
+  if (!allowed || !targetId) return null
+
+  const current = loaded?.forId === targetId ? loaded : null
+  const events = current?.events ?? null
+  const failed = current != null && current.events === null
+
+  return (
+    <DrawerSection title="History">
+      {failed ? (
+        <p className="text-muted-foreground text-xs">
+          Could not load the history for this record.
+        </p>
+      ) : current === null ? (
+        <p className="text-muted-foreground text-xs">Loading…</p>
+      ) : events === null || events.length === 0 ? (
+        <p className="text-muted-foreground text-xs">
+          Nothing recorded against this record yet.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {events.map((e) => (
+            <li key={e.id} className="text-xs">
+              <p className="font-medium">{describe(e.action)}</p>
+              <p className="text-muted-foreground">
+                {e.actorName ?? "Unknown"} · {when(e.createdAt)}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </DrawerSection>
+  )
+}
+
+/**
+ * "identity.bound" is what the code calls it; "Signed in and linked" is what
+ * happened. An unmapped action falls back to its raw string rather than being
+ * hidden, because a missing entry in this map must not lose an event.
+ */
+const ACTION_LABEL: Record<string, string> = {
+  "identity.bound": "Signed in and linked to this record",
+  "faculty.created": "Added",
+  "faculty.updated": "Details changed",
+  "faculty.deactivated": "Deactivated",
+  "faculty.role_changed": "Role changed",
+  "student.updated": "Details changed",
+  "student.deactivated": "Deactivated",
+}
+
+function describe(action: string) {
+  return ACTION_LABEL[action] ?? action
+}
+
+/** Absolute date, because "3 days ago" is unusable evidence in a dispute. */
+function when(iso: string) {
+  return new Date(iso).toLocaleString("en-IN", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "Asia/Kolkata",
+  })
+}

--- a/src/db/queries/audit.ts
+++ b/src/db/queries/audit.ts
@@ -68,3 +68,37 @@ export async function getAuditActionTypes() {
     .orderBy(auditLogs.action)
   return rows.map((r) => r.action)
 }
+
+/**
+ * Recent events about one record, for the contextual history in a drawer
+ * (spec 5.4).
+ *
+ * Keyed on (targetType, targetId), which idx_audit_logs_target already covers.
+ * Bulk actions are logged against the plural type with no targetId — a roster
+ * import is an event about the import, not about each of two hundred students —
+ * so they correctly do not surface here.
+ */
+export async function getRecordHistory(
+  targetType: string,
+  targetId: string,
+  limit = 10
+) {
+  return db
+    .select({
+      id: auditLogs.id,
+      action: auditLogs.action,
+      actorName: user.name,
+      details: auditLogs.details,
+      createdAt: auditLogs.createdAt,
+    })
+    .from(auditLogs)
+    .leftJoin(user, eq(auditLogs.actorId, user.id))
+    .where(
+      and(
+        eq(auditLogs.targetType, targetType),
+        eq(auditLogs.targetId, targetId)
+      )
+    )
+    .orderBy(desc(auditLogs.createdAt))
+    .limit(limit)
+}


### PR DESCRIPTION
Spec 5.4. Completes the audit half of phase 5.

## Why

The activity log answers "what happened today". It cannot answer "why does this record look like this" — that means scrolling thousands of unrelated rows to find the three that concern one person. Same events, asked the other way round.

## Scoping

Keyed on `(targetType, targetId)`, which `idx_audit_logs_target` already covers.

Bulk actions are logged against a **plural** type with no `targetId` — a roster import is an event about the import, not about each of two hundred students — so they correctly do not surface in a per-record drawer.

Verified against production:

```
students              11 rows,  0 with a target id   <- correctly excluded
class                 11 rows, 11 with a target id
enrollment_request     4 rows,  4
faculty                3 rows,  3
offering               3 rows,  3
department             3 rows,  3
student                1 rows,  1

student drawer: 1 event -> identity.bound by Student
```

## Two things worth flagging in review

**The capability is checked in the action, not only where the section renders.** Hiding a component is a UI decision; a server action is callable by anyone with a session.

**The record id travels with the events it belongs to.** Clearing them separately when the drawer moves to another record would mean writing state during an effect, and for one render the previous student's history would sit under the new one's name.

Times are absolute rather than "3 days ago" — this is the screen someone opens during a dispute.

Loaded on open rather than with the table, so a roster page does not carry the audit trail of every student on it to render one drawer.

## Checks

`npm run check` — typecheck, lint (2 pre-existing warnings), format, 126 tests. `npm run build` compiled.