### PR TITLE
chore(a11y): make the interactive surfaces reachable without a pointer

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,63 @@ const eslintConfig = defineConfig([
     "build/**",
     "next-env.d.ts",
   ]),
+  {
+    rules: {
+      // Accessibility rules the college actually needs enforced: a clickable
+      // row a keyboard cannot reach, or a control with no name, is invisible
+      // to a screen reader no matter how it looks.
+      "jsx-a11y/click-events-have-key-events": "warn",
+      "jsx-a11y/no-static-element-interactions": "warn",
+      // The rule only knows native tags unless told otherwise, so every
+      // wrapper that renders one has to be named or a correctly nested control
+      // reads as an orphaned label.
+      "jsx-a11y/label-has-associated-control": [
+        "warn",
+        {
+          controlComponents: [
+            "Input",
+            "Select",
+            "SelectTrigger",
+            "Textarea",
+            "Checkbox",
+            "Switch",
+            "RadioGroup",
+          ],
+        },
+      ],
+      // depth 3, not the default 2: the label text sits inside a span inside
+      // the label, which is one level further than the rule looks by default.
+      "jsx-a11y/control-has-associated-label": ["warn", { depth: 3 }],
+      // A leading underscore is how this codebase says "bound deliberately and
+      // not used" — destructuring a field out of an object to drop it is the
+      // common case, and there is no other way to express it.
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+        },
+      ],
+    },
+  },
+  // Last, so it wins: a later block overrides an earlier one in flat config.
+  //
+  // The vendored primitives are shadcn's own wrappers. Label forwards its props
+  // to whatever consumes it, so it can never name a control itself, and the
+  // interaction primitives compose handlers the rules cannot follow. Holding
+  // upstream's files to our rules would only mean patching them on every
+  // shadcn update.
+  {
+    files: ["src/components/ui/**"],
+    rules: {
+      "jsx-a11y/label-has-associated-control": "off",
+      "jsx-a11y/click-events-have-key-events": "off",
+      "jsx-a11y/no-static-element-interactions": "off",
+      "jsx-a11y/control-has-associated-label": "off",
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/src/app/dashboard/admin/departments/client.tsx
+++ b/src/app/dashboard/admin/departments/client.tsx
@@ -86,24 +86,24 @@ export function DepartmentsClient({ departments }: { departments: Dept[] }) {
       )}
 
       <div className="flex flex-wrap items-end gap-2">
-        <div className="grid gap-1.5">
-          <label className="text-muted-foreground text-xs">Code</label>
+        <label className="grid gap-1.5">
+          <span className="text-muted-foreground text-xs">Code</span>
           <Input
             value={code}
             onChange={(e) => setCode(e.target.value.toUpperCase())}
             placeholder="EXCS"
             className="h-9 w-28 font-mono uppercase"
           />
-        </div>
-        <div className="grid flex-1 gap-1.5">
-          <label className="text-muted-foreground text-xs">Name</label>
+        </label>
+        <label className="grid flex-1 gap-1.5">
+          <span className="text-muted-foreground text-xs">Name</span>
           <Input
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Electronics & Computer Science"
             className="h-9"
           />
-        </div>
+        </label>
         <Button
           disabled={pending || !code || !name}
           onClick={() => create(code, name)}

--- a/src/app/dashboard/class/[classId]/attendance/client.tsx
+++ b/src/app/dashboard/class/[classId]/attendance/client.tsx
@@ -112,17 +112,17 @@ export function AttendanceClient({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-wrap items-end justify-between gap-3">
-        <div className="grid gap-1.5">
-          <label className="text-muted-foreground text-xs">Date</label>
+        <label className="grid gap-1.5">
+          <span className="text-muted-foreground text-xs">Date</span>
           <Input
             type="date"
             value={date}
             onChange={(e) => e.target.value && go({ date: e.target.value })}
             className="h-9 w-44"
           />
-        </div>
-        <div className="grid gap-1.5">
-          <label className="text-muted-foreground text-xs">Session</label>
+        </label>
+        <label className="grid gap-1.5">
+          <span className="text-muted-foreground text-xs">Session</span>
           <select
             value={offeringId ?? ""}
             onChange={(e) => go({ offering: e.target.value || null })}
@@ -137,7 +137,7 @@ export function AttendanceClient({
               </option>
             ))}
           </select>
-        </div>
+        </label>
         <div className="flex w-full items-center gap-2 sm:w-auto">
           <Button
             variant="outline"

--- a/src/app/dashboard/class/[classId]/batches/client.tsx
+++ b/src/app/dashboard/class/[classId]/batches/client.tsx
@@ -104,15 +104,15 @@ export function BatchesClient({
       </div>
 
       <div className="flex flex-wrap items-end gap-2">
-        <div className="grid gap-1.5">
-          <label className="text-muted-foreground text-xs">New batch</label>
+        <label className="grid gap-1.5">
+          <span className="text-muted-foreground text-xs">New batch</span>
           <Input
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="B1"
             className="h-9 w-32"
           />
-        </div>
+        </label>
         <Button size="sm" disabled={pending || !name.trim()} onClick={addBatch}>
           Add batch
         </Button>

--- a/src/app/dashboard/class/[classId]/marks/import/client.tsx
+++ b/src/app/dashboard/class/[classId]/marks/import/client.tsx
@@ -121,13 +121,14 @@ export function ImportClient({
     <div className="flex flex-col gap-5">
       {/* Step 1 — upload */}
       <div className="border-border flex flex-wrap items-end gap-3 rounded border p-4">
-        <div className="grid gap-1.5">
-          <label className="text-muted-foreground text-xs">
+        <label className="grid gap-1.5">
+          <span className="text-muted-foreground text-xs">
             Marksheet file (PDF or Excel)
-          </label>
+          </span>
           <input
             ref={fileRef}
             type="file"
+            aria-label="Marksheet file (PDF or Excel)"
             accept=".pdf,.xlsx,.xls"
             onChange={(e) => {
               setFile(e.target.files?.[0] ?? null)
@@ -135,7 +136,7 @@ export function ImportClient({
             }}
             className="file:border-border file:bg-muted text-sm file:mr-3 file:rounded file:border file:px-3 file:py-1.5 file:text-sm"
           />
-        </div>
+        </label>
         <Button size="sm" disabled={!file || uploading} onClick={runPreview}>
           {uploading ? "Reading…" : "Preview"}
         </Button>
@@ -149,8 +150,8 @@ export function ImportClient({
         <>
           {/* Step 2 — map columns + pick subject */}
           <div className="border-border flex flex-col gap-4 rounded border p-4">
-            <div className="grid gap-1.5 sm:max-w-sm">
-              <label className="text-muted-foreground text-xs">Subject</label>
+            <label className="grid gap-1.5 sm:max-w-sm">
+              <span className="text-muted-foreground text-xs">Subject</span>
               {offerings.length === 0 ? (
                 <p className="text-muted-foreground text-sm">
                   No subjects yet.{" "}
@@ -176,7 +177,7 @@ export function ImportClient({
                   ))}
                 </select>
               )}
-            </div>
+            </label>
 
             <div>
               <p className="mb-2 text-sm font-medium">

--- a/src/app/dashboard/class/[classId]/results/client.tsx
+++ b/src/app/dashboard/class/[classId]/results/client.tsx
@@ -191,7 +191,9 @@ export function ResultsClient({
                   Credits
                 </Th>
                 <th className="px-3 py-2 text-left font-medium">Semesters</th>
-                <th className="px-3 py-2 text-left font-medium"></th>
+                <th className="px-3 py-2 text-left font-medium">
+                  <span className="sr-only">Actions</span>
+                </th>
               </tr>
             </thead>
             <tbody className="divide-border divide-y">

--- a/src/app/dashboard/class/[classId]/subjects/client.tsx
+++ b/src/app/dashboard/class/[classId]/subjects/client.tsx
@@ -215,21 +215,19 @@ export function SubjectsClient({
           ) : (
             <>
               <div className="flex items-end gap-2">
-                <div className="grid flex-1 gap-1.5">
-                  <label className="text-muted-foreground text-xs">
-                    Search
-                  </label>
+                <label className="grid flex-1 gap-1.5">
+                  <span className="text-muted-foreground text-xs">Search</span>
                   <Input
                     value={query}
                     onChange={(e) => setQuery(e.target.value)}
                     placeholder="Code or name…"
                     className="h-9"
                   />
-                </div>
-                <div className="grid w-28 gap-1.5">
-                  <label className="text-muted-foreground text-xs">
+                </label>
+                <label className="grid w-28 gap-1.5">
+                  <span className="text-muted-foreground text-xs">
                     Semester
-                  </label>
+                  </span>
                   <select
                     value={semester}
                     onChange={(e) => setSemester(Number(e.target.value))}
@@ -241,7 +239,7 @@ export function SubjectsClient({
                       </option>
                     ))}
                   </select>
-                </div>
+                </label>
               </div>
 
               <div className="border-border divide-border max-h-[28rem] divide-y overflow-y-auto rounded border">

--- a/src/app/dashboard/dept/client.tsx
+++ b/src/app/dashboard/dept/client.tsx
@@ -250,8 +250,8 @@ function CreateClass({
 
   return (
     <div className="border-border bg-muted/30 flex flex-wrap items-end gap-2 rounded-xl border p-3">
-      <div className="grid gap-1.5">
-        <label className="text-muted-foreground text-xs">Admission year</label>
+      <label className="grid gap-1.5">
+        <span className="text-muted-foreground text-xs">Admission year</span>
         <Input
           value={year}
           onChange={(e) => setYear(e.target.value.replace(/\D/g, ""))}
@@ -260,9 +260,9 @@ function CreateClass({
           maxLength={4}
           className="h-9 w-28"
         />
-      </div>
-      <div className="grid gap-1.5">
-        <label className="text-muted-foreground text-xs">Division</label>
+      </label>
+      <label className="grid gap-1.5">
+        <span className="text-muted-foreground text-xs">Division</span>
         <Select value={division} onValueChange={(v) => v && setDivision(v)}>
           <SelectTrigger className="h-9 w-24">
             <SelectValue />
@@ -275,7 +275,7 @@ function CreateClass({
             ))}
           </SelectContent>
         </Select>
-      </div>
+      </label>
       <Button
         className="h-9"
         disabled={disabled || year.length !== 4}
@@ -314,8 +314,16 @@ function AddDeptFaculty({
   return (
     <div className="border-border bg-muted/30 flex flex-wrap items-end gap-2 rounded-xl border p-3">
       <div className="grid gap-1.5">
-        <label className="text-muted-foreground text-xs">Add faculty</label>
-        <div className="flex flex-wrap gap-2">
+        {/* A heading over four inputs, not a label for one of them. Each input
+            names itself with its placeholder; this names the set. */}
+        <span id="add-faculty-label" className="text-muted-foreground text-xs">
+          Add faculty
+        </span>
+        <div
+          role="group"
+          aria-labelledby="add-faculty-label"
+          className="flex flex-wrap gap-2"
+        >
           <Input
             placeholder="First name"
             value={f.firstName}

--- a/src/app/dashboard/dept/courses/client.tsx
+++ b/src/app/dashboard/dept/courses/client.tsx
@@ -186,7 +186,11 @@ export function CoursesClient({
                 <th className="w-32">Marks split</th>
                 <th className="w-20">In use</th>
                 <th className="w-20">Status</th>
-                {canEdit && <th className="w-28"></th>}
+                {canEdit && (
+                  <th className="w-28">
+                    <span className="sr-only">Actions</span>
+                  </th>
+                )}
               </tr>
             </thead>
             <tbody className="divide-border divide-y">

--- a/src/app/dashboard/dept/courses/import/client.tsx
+++ b/src/app/dashboard/dept/courses/import/client.tsx
@@ -229,7 +229,9 @@ export function ImportClient({
         <table className="w-full text-sm">
           <thead className="bg-muted/50 text-muted-foreground text-xs">
             <tr className="[&>th]:px-2 [&>th]:py-2 [&>th]:text-left [&>th]:font-medium">
-              <th className="w-8"></th>
+              <th className="w-8">
+                <span className="sr-only">Include</span>
+              </th>
               <th className="w-24">Code</th>
               <th>Name</th>
               <th className="w-28">Type</th>

--- a/src/app/dashboard/dept/faculty-import/client.tsx
+++ b/src/app/dashboard/dept/faculty-import/client.tsx
@@ -88,8 +88,8 @@ export function FacultyImportClient({
     <div className="flex flex-col gap-5">
       <div className="border-border flex flex-col gap-4 rounded border p-4">
         {departments.length > 1 && (
-          <div className="grid max-w-xs gap-1.5">
-            <label className="text-muted-foreground text-xs">Department</label>
+          <label className="grid max-w-xs gap-1.5">
+            <span className="text-muted-foreground text-xs">Department</span>
             <select
               value={deptCode}
               onChange={(e) => {
@@ -104,15 +104,16 @@ export function FacultyImportClient({
                 </option>
               ))}
             </select>
-          </div>
+          </label>
         )}
 
-        <div className="grid gap-1.5">
-          <label className="text-muted-foreground text-xs">
+        <label className="grid gap-1.5">
+          <span className="text-muted-foreground text-xs">
             Faculty CSV (name, email, employee ID)
-          </label>
+          </span>
           <input
             type="file"
+            aria-label="Faculty CSV (name, email, employee ID)"
             accept=".csv,text/csv"
             onChange={(e) => {
               const f = e.target.files?.[0]
@@ -120,13 +121,13 @@ export function FacultyImportClient({
             }}
             className="file:border-border file:bg-muted text-sm file:mr-3 file:rounded file:border file:px-3 file:py-1.5 file:text-sm"
           />
-        </div>
+        </label>
 
         <div className="flex flex-wrap items-end gap-3">
-          <div className="grid gap-1.5">
-            <label className="text-muted-foreground text-xs">
+          <label className="grid gap-1.5">
+            <span className="text-muted-foreground text-xs">
               Assign to class (optional)
-            </label>
+            </span>
             <select
               value={assignClassId}
               onChange={(e) => setAssignClassId(e.target.value)}
@@ -139,10 +140,10 @@ export function FacultyImportClient({
                 </option>
               ))}
             </select>
-          </div>
+          </label>
           {assignClassId && (
-            <div className="grid gap-1.5">
-              <label className="text-muted-foreground text-xs">As</label>
+            <label className="grid gap-1.5">
+              <span className="text-muted-foreground text-xs">As</span>
               <select
                 value={assignRole}
                 onChange={(e) => setAssignRole(e.target.value as Role)}
@@ -151,7 +152,7 @@ export function FacultyImportClient({
                 <option value="tr">TR</option>
                 <option value="academic_coordinator">Coordinator</option>
               </select>
-            </div>
+            </label>
           )}
         </div>
         {assignClassId && (

--- a/src/app/dashboard/my-marks/client.tsx
+++ b/src/app/dashboard/my-marks/client.tsx
@@ -115,7 +115,9 @@ export function MyMarksClient({
                       <th className="w-20">Total</th>
                       <th className="w-14">%</th>
                       <th className="w-16">Grade</th>
-                      <th className="w-8"></th>
+                      <th className="w-8">
+                        <span className="sr-only">Expand</span>
+                      </th>
                     </tr>
                   </thead>
                   <tbody className="divide-border divide-y">
@@ -175,9 +177,27 @@ function SubjectRow({ subject }: { subject: Subject }) {
       <tr
         className={cn(
           "[&>td]:px-2 [&>td]:py-1.5",
-          entered && "hover:bg-muted/50 cursor-pointer"
+          entered &&
+            "hover:bg-muted/50 focus-visible:ring-ring cursor-pointer focus-visible:ring-2 focus-visible:outline-none"
         )}
-        onClick={() => entered && setOpen((o) => !o)}
+        // A student reading their own marks may well be doing it by keyboard or
+        // screen reader, so the expander cannot be pointer-only. aria-expanded
+        // is what announces that the row has more behind it — the ▸ glyph says
+        // that to sighted users and nothing to anyone else.
+        {...(entered
+          ? {
+              role: "button" as const,
+              tabIndex: 0,
+              "aria-expanded": open,
+              onClick: () => setOpen((o) => !o),
+              onKeyDown: (e: React.KeyboardEvent) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault()
+                  setOpen((o) => !o)
+                }
+              },
+            }
+          : {})}
       >
         <td className="font-mono text-xs">{subject.code}</td>
         <td>{subject.name}</td>
@@ -193,7 +213,7 @@ function SubjectRow({ subject }: { subject: Subject }) {
         />
         <Cell value={subject.marks.ese} max={subject.course.maxEse} />
         <SubjectResultCells marks={subject.marks} course={subject.course} />
-        <td className="text-muted-foreground text-xs">
+        <td className="text-muted-foreground text-xs" aria-hidden="true">
           {entered ? (open ? "▾" : "▸") : ""}
         </td>
       </tr>

--- a/src/app/dashboard/students/import/client.tsx
+++ b/src/app/dashboard/students/import/client.tsx
@@ -202,6 +202,12 @@ export function ImportClient() {
   if (!preview) {
     return (
       <div
+        // A drop target, named as a region rather than left as a bare div with
+        // handlers. Dropping is a pointer gesture with no keyboard equivalent
+        // to add; the keyboard path is the button inside, which opens the same
+        // picker the drop would feed.
+        role="region"
+        aria-label="Upload a roster"
         onDragOver={(e) => e.preventDefault()}
         onDrop={(e) => {
           e.preventDefault()
@@ -225,6 +231,7 @@ export function ImportClient() {
         <input
           ref={fileInput}
           type="file"
+          aria-label="Roster spreadsheet"
           accept=".xlsx,.xls"
           className="hidden"
           onChange={(e) => {

--- a/src/app/unclaimed/register-form.tsx
+++ b/src/app/unclaimed/register-form.tsx
@@ -84,8 +84,8 @@ export function RegisterForm({
       )}
 
       <div className="mt-6 flex flex-col gap-4">
-        <div className="grid gap-1.5">
-          <label className="text-xs font-medium">Roll number</label>
+        <label className="grid gap-1.5">
+          <span className="text-xs font-medium">Roll number</span>
           <Input
             value={rollNumber}
             onChange={(e) => setRollNumber(e.target.value.toUpperCase())}
@@ -106,23 +106,23 @@ export function RegisterForm({
               That doesn&rsquo;t look like a valid roll number.
             </p>
           )}
-        </div>
+        </label>
 
         <div className="grid grid-cols-2 gap-3">
-          <div className="grid gap-1.5">
-            <label className="text-xs font-medium">First name</label>
+          <label className="grid gap-1.5">
+            <span className="text-xs font-medium">First name</span>
             <Input
               value={firstName}
               onChange={(e) => setFirstName(e.target.value)}
             />
-          </div>
-          <div className="grid gap-1.5">
-            <label className="text-xs font-medium">Last name</label>
+          </label>
+          <label className="grid gap-1.5">
+            <span className="text-xs font-medium">Last name</span>
             <Input
               value={lastName}
               onChange={(e) => setLastName(e.target.value)}
             />
-          </div>
+          </label>
         </div>
 
         <Button

--- a/src/components/data-table-view.tsx
+++ b/src/components/data-table-view.tsx
@@ -125,17 +125,16 @@ export function DataTableView<TData, TValue>({
       ),
       cell: ({ row }) => (
         // The checkbox lives inside a row that may itself be clickable, so it
-        // has to keep its click: selecting a record must not also open it.
-        <span
+        // has to keep its own click and key: selecting a record must not also
+        // open it. Held on the control rather than a wrapper, which would be a
+        // span nothing can reach carrying handlers it does not own.
+        <Checkbox
+          checked={row.getIsSelected()}
+          onCheckedChange={(v) => row.toggleSelected(!!v)}
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
-        >
-          <Checkbox
-            checked={row.getIsSelected()}
-            onCheckedChange={(v) => row.toggleSelected(!!v)}
-            aria-label="Select row"
-          />
-        </span>
+          aria-label="Select row"
+        />
       ),
     }
     return [selectCol, ...columns]
@@ -401,17 +400,14 @@ export function DataTableView<TData, TValue>({
                   }
                 >
                   {selectable && (
-                    <span
-                      className="pt-0.5"
+                    <Checkbox
+                      className="mt-0.5"
+                      checked={row.getIsSelected()}
+                      onCheckedChange={(v) => row.toggleSelected(!!v)}
                       onClick={(e) => e.stopPropagation()}
                       onKeyDown={(e) => e.stopPropagation()}
-                    >
-                      <Checkbox
-                        checked={row.getIsSelected()}
-                        onCheckedChange={(v) => row.toggleSelected(!!v)}
-                        aria-label="Select record"
-                      />
-                    </span>
+                      aria-label="Select record"
+                    />
                   )}
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-sm font-medium">{r.title}</p>

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -111,6 +111,7 @@ export function NavUser({
               */}
               <DropdownMenuItem
                 render={
+                  // eslint-disable-next-line jsx-a11y/control-has-associated-label -- the link's text is this item's children, one level out
                   <a
                     href="https://accounts.vosslabs.org/account"
                     target="_blank"


### PR DESCRIPTION
The final phase-5 item. The spec's definition of done asks for verified keyboard and screen-reader semantics; nothing was verifying it. This turns the rules on and fixes what they found — **36 findings across 19 files, down to zero.**

## The bulk: labels that sat beside their control

A screen reader reads an unassociated label as an orphaned word followed by a stray box. The wrapper div becomes the label and the text becomes a span, so the association is implicit and no ids are invented. The classes move with the elements, so the rendered layout is byte-identical:

```diff
-<div className="grid gap-1.5">
-  <label className="text-muted-foreground text-xs">Date</label>
+<label className="grid gap-1.5">
+  <span className="text-muted-foreground text-xs">Date</span>
   <Input type="date" ... />
-</div>
+</label>
```

**That transform is not safe everywhere, and the first pass proved it.** A label wrapping a whole card also wraps its buttons — clicking "Preview" on the marksheet importer would have opened the file dialog. I caught it by auditing every generated label for the controls it captured, then re-ran with a guard requiring exactly one control and no button. Five wrappers keep their div, and the four-input "Add faculty" row is now a labelled `role="group"` rather than pretending to be a label for one of its inputs.

## The one that mattered most

A student's own marks row expanded on click alone. It now carries `role="button"`, Enter/Space, and `aria-expanded` — the ▸ glyph announced "there is more here" to sighted users and nothing to anyone else.

## Smaller

- The two table checkboxes stop propagation **on the control**, not through a wrapper span — that span was an element nothing could reach, carrying handlers it did not own.
- Empty action columns get screen-reader names.
- File inputs are named outright; an implicit label is not reliably announced for them.
- The roster drop zone is a named `role="region"` rather than a bare div with handlers. Dropping is pointer-only by nature — the keyboard path is the button inside, which opens the same picker.

## Two rules configured rather than obeyed blindly

`label-has-associated-control` only knows native tags, so the components that render them are named. `control-has-associated-label` looks two levels deep when the text sits three in. The vendored shadcn primitives are exempt in a block placed **last** — flat config gives the last block the final word, and holding upstream's files to these rules would only mean patching them on every update.

Also configures the `_`-prefix convention, so a deliberately discarded binding stops warning.

## Checks

`npm run check` — typecheck, lint, format, 126 tests. `npm run build` compiled. Verified no nested or unbalanced `<label>` elements across all 16 touched files.

One warning remains: the React Compiler reporting it skipped TanStack Table. That is it working correctly.