### PR TITLE
fix(security): validate marks at the boundary, and scope every academic write to its allocated teacher

### DIFF
--- a/src/app/api/students/import/preview/route.ts
+++ b/src/app/api/students/import/preview/route.ts
@@ -2,7 +2,8 @@ import { NextRequest } from "next/server"
 import ExcelJS from "exceljs"
 import { apiError, apiSuccess } from "@/lib/api-response"
 import { getErrorMessage } from "@/lib/error-utils"
-import { getSessionUser, isStaff } from "@/lib/session"
+import { getSessionUser } from "@/lib/session"
+import { can } from "@/lib/rbac"
 import {
   buildPreviewRows,
   detectHeaderRow,
@@ -34,7 +35,10 @@ export async function POST(req: NextRequest) {
     const user = await getSessionUser()
     // Faculty (TRs) run this, not just admins — uploading a division's roster is
     // the TR's job. isStaff is the allowlist; a roleless/student user is refused.
-    if (!isStaff(user)) return apiError("Forbidden", 403)
+    // Same capability the commit route requires. A preview reads the whole
+    // submitted sheet back to the caller, so gating it more loosely than the
+    // write would leak a roster to anyone with a staff account.
+    if (!user || !can(user, "student:update")) return apiError("Forbidden", 403)
 
     const form = await req.formData()
     const file = form.get("file")

--- a/src/app/api/students/import/route.ts
+++ b/src/app/api/students/import/route.ts
@@ -2,7 +2,8 @@ import { NextRequest } from "next/server"
 import { z } from "zod"
 import { apiError, apiSuccess } from "@/lib/api-response"
 import { getErrorMessage } from "@/lib/error-utils"
-import { getSessionUser, isStaff } from "@/lib/session"
+import { getSessionUser } from "@/lib/session"
+import { can } from "@/lib/rbac"
 import { rollsInScope } from "@/lib/scope"
 import { tryClassKeyFromRoll } from "@/lib/class-key"
 import { createStudent, createAuditLog } from "@/db/queries"
@@ -31,8 +32,11 @@ const importBodySchema = z.object({
 export async function POST(req: NextRequest) {
   try {
     const user = await getSessionUser()
-    // Faculty (TRs) commit their roster, not just admins.
-    if (!isStaff(user)) return apiError("Forbidden", 403)
+    // Creating student records is a student write, and saying so is the point:
+    // isStaff() let any staff account through regardless of what the permission
+    // model said about them, so revoking student:update in the console changed
+    // nothing here. Scope is still checked per row below.
+    if (!user || !can(user, "student:update")) return apiError("Forbidden", 403)
 
     const body = await req.json()
     const parsed = importBodySchema.safeParse(body)

--- a/src/app/dashboard/class/[classId]/attendance/page.tsx
+++ b/src/app/dashboard/class/[classId]/attendance/page.tsx
@@ -9,6 +9,7 @@ import { getClassById } from "@/db/queries/classes"
 import { getStudentsByClassKeys } from "@/db/queries/students"
 import { listOfferingsForClass } from "@/db/queries/offerings"
 import { getAttendanceForSession } from "@/db/queries/attendance"
+import { canWriteOffering } from "@/lib/allocation"
 import { AttendanceClient } from "./client"
 
 type Status = "present" | "absent" | "late" | "excused"
@@ -50,11 +51,19 @@ export default async function AttendancePage({
   const slot = sp.slot || "1"
   const offeringId = sp.offering || null
 
-  const [students, existing, offerings] = await Promise.all([
+  const [students, existing, allOfferings] = await Promise.all([
     getStudentsByClassKeys([cls.classKey]),
     getAttendanceForSession(classId, date, slot, offeringId),
     listOfferingsForClass(classId),
   ])
+
+  // Offering every subject to every teacher on the class invited them to take a
+  // register they are not allowed to save — the action refuses it, so the only
+  // thing the extra options produced was a dead end. Coordinators, HODs and
+  // admins keep the full list: covering an absent colleague is their job.
+  const offerings = allOfferings.filter((o) =>
+    canWriteOffering(user, o.facultyId, classId, cls.departmentCode)
+  )
   const marked: Record<string, string> = {}
   for (const e of existing) marked[e.studentId] = e.status
 

--- a/src/app/dashboard/class/[classId]/class-context.ts
+++ b/src/app/dashboard/class/[classId]/class-context.ts
@@ -71,7 +71,10 @@ export function classTabs(
       href: `/dashboard/class/${classId}/subjects`,
     })
   }
-  if (can(user, "attendance:write") || can(user, "attendance:read")) {
+  // Write, not read. The destination is the register itself — an entry
+  // surface — and it redirects anyone without attendance:write, so offering it
+  // on read alone produced a tab that bounced you to the Overview.
+  if (can(user, "attendance:write")) {
     tabs.push({
       label: "Attendance",
       href: `/dashboard/class/${classId}/attendance`,

--- a/src/app/dashboard/class/actions.ts
+++ b/src/app/dashboard/class/actions.ts
@@ -4,6 +4,13 @@ import { revalidatePath } from "next/cache"
 import { getSessionUser, type SessionUser } from "@/lib/session"
 import { authorize } from "@/lib/rbac"
 import { studentsInClass } from "@/lib/scope"
+import {
+  type Component,
+  incompleteMessage,
+  incompleteStudents,
+  requiredComponents,
+  validateMarks,
+} from "@/lib/marks-integrity"
 import { canAllocate, canReopenLock, canWriteOffering } from "@/lib/allocation"
 import { getErrorMessage } from "@/lib/error-utils"
 import { parseRollNumber, expectedYear } from "@/lib/roll-number"
@@ -70,6 +77,15 @@ export async function approveEnrollmentAction(input: {
 
     const { ok, cls } = await classInScope(user!, req.classId)
     if (!ok || !cls) return { error: "That class is not in your scope." }
+    // Admitting somebody to a class is governance, not teaching. Every teacher
+    // assigned to the class held this, so any of them could admit a student to
+    // a cohort they do not run.
+    if (!canAllocate(user!, req.classId, cls.departmentCode)) {
+      return {
+        error:
+          "Only the class coordinator, the HOD, or an admin can decide enrolment requests.",
+      }
+    }
 
     if (await getStudentByRollNumber(req.rollNumber)) {
       await updateRequest(req.id, {
@@ -128,7 +144,14 @@ export async function rejectEnrollmentAction(input: {
       return { error: "This request is not pending." }
     if (!req.classId) return { error: "This request is not routed to a class." }
 
-    const { ok } = await classInScope(user!, req.classId)
+    const { ok, cls } = await classInScope(user!, req.classId)
+    if (!cls) return { error: "That class is not in your scope." }
+    if (!canAllocate(user!, req.classId, cls.departmentCode)) {
+      return {
+        error:
+          "Only the class coordinator, the HOD, or an admin can decide enrolment requests.",
+      }
+    }
     if (!ok) return { error: "That class is not in your scope." }
 
     const reason = input.reason.trim() || "Not recognised for this class"
@@ -187,6 +210,19 @@ export async function saveAttendanceAction(input: {
       const offering = await getOfferingById(offeringId)
       if (!offering || offering.classId !== input.classId)
         return { error: "That subject is not taught in this class." }
+      // Belonging to the class is not enough. A subject register is that
+      // teacher's record of their own lecture; a colleague filling it in is the
+      // same mistake as entering their marks, and the same rule settles it.
+      if (
+        !canWriteOffering(
+          user!,
+          offering.facultyId,
+          input.classId,
+          cls.departmentCode
+        )
+      ) {
+        return { error: "That subject is allocated to another teacher." }
+      }
     }
 
     const entries = input.marks.map((m) => ({
@@ -333,6 +369,13 @@ export async function saveMarksAction(input: {
     )
     if (!scope.ok) return { error: scope.reason }
 
+    // The number inputs carry min/max, but that is a courtesy to whoever is
+    // typing. This is the guarantee: a crafted request previously stored a
+    // negative mark, or one above the component maximum, and every average
+    // computed from it downstream was silently wrong.
+    const valid = validateMarks(input.rows, offering.course)
+    if (!valid.ok) return { error: valid.reason }
+
     const lockRows = await getLockedComponents(input.offeringId)
     const locked = lockRows.map((l) => l.component)
     const rows = input.rows.map((r) => ({
@@ -385,6 +428,31 @@ export async function saveMarksAction(input: {
  * acted on. A TR who spots a typo asks the coordinator; that conversation is the
  * point, not an obstacle.
  */
+/**
+ * Roster-wide completeness for an offering.
+ *
+ * Asked of the roster, not of the marks table. Counting rows in `marks` answers
+ * "how many students has somebody touched", and the question that decides
+ * whether a result may be frozen or shown is "is anybody still unmarked".
+ */
+async function rosterIncomplete(
+  offeringId: string,
+  classKey: string,
+  course: { maxIsa: number; maxMse: number; maxEse: number },
+  components: Component[]
+) {
+  const [roster, existing] = await Promise.all([
+    getStudentsByClassKeys([classKey]),
+    getMarksForOffering(offeringId),
+  ])
+  const byStudent = new Map(existing.map((m) => [m.studentId, m]))
+  return incompleteStudents(
+    roster.map((r) => r.id),
+    byStudent,
+    components
+  )
+}
+
 export async function setMarksLockAction(input: {
   offeringId: string
   component: string
@@ -402,6 +470,36 @@ export async function setMarksLockAction(input: {
     if (!offering) return { error: "No such subject." }
     const { ok, cls } = await classInScope(user!, offering.classId)
     if (!ok || !cls) return { error: "That class is not in your scope." }
+
+    // Freezing somebody else's subject is a write to it. This checked class
+    // membership only, so any teacher on the class could submit a colleague's
+    // marks on their behalf — the one thing locking is supposed to make
+    // unambiguous.
+    if (
+      !canWriteOffering(
+        user!,
+        offering.facultyId,
+        offering.classId,
+        cls.departmentCode
+      )
+    ) {
+      return { error: "That subject is allocated to another teacher." }
+    }
+
+    if (input.locked) {
+      // Locking says "these figures are final". It cannot be true of a
+      // component nobody has entered — and once locked, publication accepted
+      // it, so a blank register reached students as a completed result.
+      const missing = await rosterIncomplete(
+        input.offeringId,
+        cls.classKey,
+        offering.course,
+        [component]
+      )
+      if (missing.length > 0) {
+        return { error: incompleteMessage(missing, "Lock") }
+      }
+    }
 
     if (!input.locked) {
       const held = (await getLockedComponents(input.offeringId)).find(
@@ -657,8 +755,7 @@ export async function setPublishedAction(input: {
     }
 
     if (input.published) {
-      const required: LockComponent[] =
-        offering.course.maxMse > 0 ? ["isa", "mse", "ese"] : ["isa", "ese"]
+      const required = requiredComponents(offering.course)
       const locked = (await getLockedComponents(input.offeringId)).map(
         (l) => l.component
       )
@@ -667,6 +764,20 @@ export async function setPublishedAction(input: {
         return {
           error: `Lock ${open.join(", ").toUpperCase()} before publishing — publishing says these marks are final.`,
         }
+      }
+
+      // Checked again here rather than trusted from the locks. Locks predating
+      // this rule exist — the live EC33T offering was locked and published over
+      // an almost entirely blank register, and every student behind it was
+      // shown a finished semester worth zero credits.
+      const missing = await rosterIncomplete(
+        input.offeringId,
+        cls.classKey,
+        offering.course,
+        required
+      )
+      if (missing.length > 0) {
+        return { error: incompleteMessage(missing, "Publish") }
       }
     }
 

--- a/src/app/dashboard/class/page.tsx
+++ b/src/app/dashboard/class/page.tsx
@@ -5,6 +5,8 @@ import { Badge } from "@/components/ui/badge"
 import { getSessionUser } from "@/lib/session"
 import { expectedYear } from "@/lib/roll-number"
 import { getClassesByIds } from "@/db/queries/onboarding"
+import { listClassesForDepts } from "@/db/queries/classes"
+import { listDepartments } from "@/db/queries/departments"
 
 export const dynamic = "force-dynamic"
 
@@ -12,7 +14,17 @@ export default async function ClassIndexPage() {
   const user = await getSessionUser()
   if (!user) redirect("/login")
 
-  const classes = await getClassesByIds(user.classIds)
+  // An HOD holds no class assignments — their scope is the department — so this
+  // listed nothing and told them to ask their HOD, which is themselves. A
+  // super-admin holds neither, and saw the same empty page.
+  const deptScope =
+    user.tier === "super_admin"
+      ? (await listDepartments()).filter((d) => d.isActive).map((d) => d.code)
+      : user.deptCodes
+  const classes =
+    user.tier === "hod" || user.tier === "super_admin"
+      ? await listClassesForDepts(deptScope)
+      : await getClassesByIds(user.classIds)
   const now = new Date()
 
   return (

--- a/src/app/dashboard/students/import/page.tsx
+++ b/src/app/dashboard/students/import/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation"
 import { PageHeader } from "@/components/page-header"
-import { getSessionUser, isStaff } from "@/lib/session"
+import { getSessionUser } from "@/lib/session"
+import { can } from "@/lib/rbac"
 import { ImportClient } from "./client"
 
 export const dynamic = "force-dynamic"
@@ -9,7 +10,7 @@ export default async function ImportStudentsPage() {
   // Server-side guard. The API re-checks too — this just avoids rendering the
   // page for someone who can't use it.
   const user = await getSessionUser()
-  if (!isStaff(user)) redirect("/dashboard")
+  if (!user || !can(user, "student:update")) redirect("/dashboard")
 
   return (
     <>

--- a/src/db/migrations/0006_marks_range_constraints.sql
+++ b/src/db/migrations/0006_marks_range_constraints.sql
@@ -1,0 +1,21 @@
+-- Marks must be non-negative. The application now validates against each
+-- course's own maxima, which the database cannot see from this table -- but
+-- "not negative" is true of every component of every course, and it is the
+-- half that turns a silently wrong average into a rejected write.
+--
+-- Applied as NOT VALID first so an existing bad row cannot block the deploy,
+-- then validated: the constraint binds all new writes immediately either way.
+
+ALTER TABLE marks
+  ADD CONSTRAINT marks_isa_non_negative CHECK (isa IS NULL OR isa >= 0) NOT VALID;
+ALTER TABLE marks
+  ADD CONSTRAINT marks_mse1_non_negative CHECK (mse1 IS NULL OR mse1 >= 0) NOT VALID;
+ALTER TABLE marks
+  ADD CONSTRAINT marks_mse2_non_negative CHECK (mse2 IS NULL OR mse2 >= 0) NOT VALID;
+ALTER TABLE marks
+  ADD CONSTRAINT marks_ese_non_negative CHECK (ese IS NULL OR ese >= 0) NOT VALID;
+
+ALTER TABLE marks VALIDATE CONSTRAINT marks_isa_non_negative;
+ALTER TABLE marks VALIDATE CONSTRAINT marks_mse1_non_negative;
+ALTER TABLE marks VALIDATE CONSTRAINT marks_mse2_non_negative;
+ALTER TABLE marks VALIDATE CONSTRAINT marks_ese_non_negative;

--- a/src/db/queries/overview.ts
+++ b/src/db/queries/overview.ts
@@ -10,6 +10,8 @@
 
 import { and, eq, inArray, isNull, sql } from "drizzle-orm"
 import { db } from "@/db"
+import { completeCount } from "@/lib/marks-integrity"
+import type { MarksInput } from "@/lib/sgpi"
 import {
   classes,
   courseOfferings,
@@ -76,6 +78,9 @@ export async function getClassWork(
         facultyId: courseOfferings.facultyId,
         code: courses.courseCode,
         name: courses.courseName,
+        maxIsa: courses.maxIsa,
+        maxMse: courses.maxMse,
+        maxEse: courses.maxEse,
       })
       .from(courseOfferings)
       .innerJoin(courses, eq(courseOfferings.courseId, courses.id))
@@ -102,8 +107,10 @@ export async function getClassWork(
 
   const offeringIds = offerings.map((o) => o.id)
   const [rosterCounts, markCounts, todayMarked] = await Promise.all([
+    // Ids, not a count: completeness is asked per student, and the count falls
+    // out of the same rows.
     db
-      .select({ classKey: students.classKey, n: sql<number>`count(*)::int` })
+      .select({ id: students.id, classKey: students.classKey })
       .from(students)
       .where(
         and(
@@ -113,17 +120,24 @@ export async function getClassWork(
             rows.map((r) => r.classKey)
           )
         )
-      )
-      .groupBy(students.classKey),
+      ),
+    // Every mark for these offerings, not a count of rows. "89 of 89 entered"
+    // was reported for a register where almost every row was blank: a row is
+    // created the moment anybody touches a student, so counting rows answers
+    // "how many students has somebody opened" rather than "how many are
+    // marked".
     offeringIds.length
       ? db
           .select({
             offeringId: marksTable.courseOfferingId,
-            n: sql<number>`count(*)::int`,
+            studentId: marksTable.studentId,
+            isa: marksTable.isa,
+            mse1: marksTable.mse1,
+            mse2: marksTable.mse2,
+            ese: marksTable.ese,
           })
           .from(marksTable)
           .where(inArray(marksTable.courseOfferingId, offeringIds))
-          .groupBy(marksTable.courseOfferingId)
       : Promise.resolve([]),
     db
       .select({
@@ -144,10 +158,27 @@ export async function getClassWork(
     list: T[],
     pick: (t: T) => string | null
   ) => new Map(list.map((x) => [pick(x) ?? "", x.n]))
-  const roster = num(rosterCounts, (r) => r.classKey)
+  const rosterIds = new Map<string, string[]>()
+  for (const r of rosterCounts) {
+    const key = r.classKey ?? ""
+    const list = rosterIds.get(key) ?? []
+    list.push(r.id)
+    rosterIds.set(key, list)
+  }
   const marked = num(todayMarked, (r) => r.classId)
   const pending = num(requests, (r) => r.classId)
-  const entered = num(markCounts, (r) => r.offeringId)
+
+  // Marks grouped by offering, so completeness can be asked per student.
+  const marksByOffering = new Map<string, Map<string, MarksInput>>()
+  for (const m of markCounts) {
+    const key = m.offeringId ?? ""
+    let inner = marksByOffering.get(key)
+    if (!inner) {
+      inner = new Map()
+      marksByOffering.set(key, inner)
+    }
+    inner.set(m.studentId, m)
+  }
 
   return rows.map((c) => {
     const mine = offerings.filter(
@@ -168,14 +199,25 @@ export async function getClassWork(
       departmentCode: c.departmentCode,
       role:
         facultyId === null ? "admin" : isCoord ? "academic_coordinator" : "tr",
-      students: roster.get(c.classKey) ?? 0,
+      students: (rosterIds.get(c.classKey) ?? []).length,
       pendingRequests: pending.get(c.id) ?? 0,
       markedToday: marked.get(c.id) ?? 0,
       mySubjects: mine.map((o) => ({
         id: o.id,
         code: o.code,
         name: o.name,
-        entered: entered.get(o.id) ?? 0,
+        entered: completeCount(
+          rosterIds.get(c.classKey) ?? [],
+          marksByOffering.get(o.id) ?? new Map(),
+          {
+            courseType: "theory",
+            credits: 0,
+            maxIsa: o.maxIsa,
+            maxMse: o.maxMse,
+            maxEse: o.maxEse,
+            maxTotal: o.maxIsa + o.maxMse + o.maxEse,
+          }
+        ),
       })),
       unallocatedSubjects: offerings.filter(
         (o) => o.classId === c.id && o.facultyId === null

--- a/src/db/schema/marks.ts
+++ b/src/db/schema/marks.ts
@@ -7,7 +7,9 @@ import {
   timestamp,
   index,
   unique,
+  check,
 } from "drizzle-orm/pg-core"
+import { sql } from "drizzle-orm"
 import { courseOfferings } from "./offerings"
 import { students } from "./students"
 import { faculty } from "./faculty"
@@ -43,6 +45,14 @@ export const marks = pgTable(
   (t) => [
     unique("marks_offering_student_uniq").on(t.courseOfferingId, t.studentId),
     index("marks_student_idx").on(t.studentId),
+    // The per-course maxima live on `courses`, so the database cannot check an
+    // upper bound from here — the application does that. Non-negativity holds
+    // for every component of every course, and it is the half that stops a
+    // crafted write from quietly poisoning an average.
+    check("marks_isa_non_negative", sql`${t.isa} IS NULL OR ${t.isa} >= 0`),
+    check("marks_mse1_non_negative", sql`${t.mse1} IS NULL OR ${t.mse1} >= 0`),
+    check("marks_mse2_non_negative", sql`${t.mse2} IS NULL OR ${t.mse2} >= 0`),
+    check("marks_ese_non_negative", sql`${t.ese} IS NULL OR ${t.ese} >= 0`),
   ]
 )
 

--- a/src/lib/marks-integrity.test.ts
+++ b/src/lib/marks-integrity.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest"
+import {
+  completeCount,
+  incompleteStudents,
+  invalidReason,
+  requiredComponents,
+  validateMarks,
+} from "./marks-integrity"
+import type { CourseInfo, MarksInput } from "./sgpi"
+
+const theory: CourseInfo = {
+  courseType: "theory",
+  credits: 4,
+  maxIsa: 20,
+  maxMse: 30,
+  maxEse: 50,
+  maxTotal: 100,
+}
+const practical: CourseInfo = { ...theory, maxMse: 0, maxIsa: 50, maxEse: 50 }
+const blank: MarksInput = { isa: null, mse1: null, mse2: null, ese: null }
+
+describe("invalidReason", () => {
+  it("accepts a blank row — components arrive at different points in the term", () => {
+    expect(invalidReason(blank, theory)).toBeNull()
+  })
+
+  it("accepts a mark at exactly the maximum", () => {
+    expect(invalidReason({ ...blank, isa: 20 }, theory)).toBeNull()
+  })
+
+  // Zero is a score somebody earned, not an absence.
+  it("accepts zero", () => {
+    expect(invalidReason({ ...blank, isa: 0 }, theory)).toBeNull()
+  })
+
+  it("rejects a mark above the component maximum", () => {
+    expect(invalidReason({ ...blank, isa: 21 }, theory)).toBe(
+      "ISA cannot exceed 20."
+    )
+  })
+
+  it("rejects a negative mark", () => {
+    expect(invalidReason({ ...blank, ese: -1 }, theory)).toBe(
+      "ESE cannot be negative."
+    )
+  })
+
+  it("rejects a fractional mark", () => {
+    expect(invalidReason({ ...blank, isa: 12.5 }, theory)).toBe(
+      "ISA must be a whole number."
+    )
+  })
+
+  // Storing it would put a figure in the table that no calculation reads.
+  it("rejects an MSE on a subject that has none", () => {
+    expect(invalidReason({ ...blank, mse1: 10 }, practical)).toBe(
+      "This subject has no MSE component."
+    )
+  })
+
+  it("bounds each MSE by the per-MSE maximum, not their sum", () => {
+    expect(invalidReason({ ...blank, mse1: 30, mse2: 30 }, theory)).toBeNull()
+    expect(invalidReason({ ...blank, mse2: 31 }, theory)).toBe(
+      "MSE 2 cannot exceed 30."
+    )
+  })
+})
+
+describe("validateMarks", () => {
+  it("rejects the whole payload when one row is bad", () => {
+    const res = validateMarks(
+      [
+        { studentId: "a", ...blank, isa: 18 },
+        { studentId: "b", ...blank, isa: 999 },
+        { studentId: "c", ...blank, isa: 15 },
+      ],
+      theory
+    )
+    expect(res.ok).toBe(false)
+    if (!res.ok) {
+      expect(res.studentId).toBe("b")
+      expect(res.reason).toBe("ISA cannot exceed 20.")
+    }
+  })
+
+  it("passes a payload where every row is in range", () => {
+    expect(
+      validateMarks(
+        [
+          { studentId: "a", isa: 18, mse1: 25, mse2: 27, ese: 40 },
+          { studentId: "b", ...blank },
+        ],
+        theory
+      ).ok
+    ).toBe(true)
+  })
+})
+
+describe("incompleteStudents", () => {
+  const roster = ["a", "b", "c"]
+
+  // The bug this exists to stop: an offering with no marks at all was locked
+  // and published, and the students behind it saw a finished semester worth
+  // nothing.
+  it("reports every student when nobody has been marked", () => {
+    const res = incompleteStudents(roster, new Map(), ["isa", "mse", "ese"])
+    expect(res).toHaveLength(3)
+    expect(res[0].missing).toEqual(["isa", "mse", "ese"])
+  })
+
+  it("counts a student with no row at all as missing, not absent from the list", () => {
+    const marks = new Map([["a", { isa: 18, mse1: 25, mse2: 27, ese: 40 }]])
+    expect(
+      incompleteStudents(roster, marks, ["isa"]).map((i) => i.studentId)
+    ).toEqual(["b", "c"])
+  })
+
+  it("treats one MSE of two as unfinished", () => {
+    const marks = new Map([["a", { ...blank, mse1: 25 }]])
+    expect(incompleteStudents(["a"], marks, ["mse"])[0].missing).toEqual([
+      "mse",
+    ])
+  })
+
+  it("is satisfied by both MSEs", () => {
+    const marks = new Map([["a", { ...blank, mse1: 25, mse2: 27 }]])
+    expect(incompleteStudents(["a"], marks, ["mse"])).toEqual([])
+  })
+
+  it("treats a zero as marked", () => {
+    const marks = new Map([["a", { ...blank, isa: 0 }]])
+    expect(incompleteStudents(["a"], marks, ["isa"])).toEqual([])
+  })
+
+  it("only asks about the components named", () => {
+    const marks = new Map([["a", { ...blank, isa: 18 }]])
+    expect(incompleteStudents(["a"], marks, ["isa"])).toEqual([])
+    expect(incompleteStudents(["a"], marks, ["ese"])).toHaveLength(1)
+  })
+
+  // An empty class cannot block its own publication.
+  it("says nothing about an empty roster", () => {
+    expect(incompleteStudents([], new Map(), ["isa"])).toEqual([])
+  })
+})
+
+describe("requiredComponents", () => {
+  it("does not ask a practical for an MSE it does not have", () => {
+    expect(requiredComponents(practical)).toEqual(["isa", "ese"])
+    expect(requiredComponents(theory)).toEqual(["isa", "mse", "ese"])
+  })
+})
+
+describe("completeCount", () => {
+  // What the dashboard should have been counting. Counting rows in `marks`
+  // reported 89 of 89 entered for a register that was almost entirely blank.
+  it("counts fully marked students, not rows touched", () => {
+    const roster = ["a", "b", "c"]
+    const marks = new Map<string, MarksInput>([
+      ["a", { isa: 18, mse1: 25, mse2: 27, ese: 40 }],
+      ["b", { ...blank, isa: 12 }],
+      ["c", blank],
+    ])
+    expect(completeCount(roster, marks, theory)).toBe(1)
+  })
+})

--- a/src/lib/marks-integrity.ts
+++ b/src/lib/marks-integrity.ts
@@ -1,0 +1,145 @@
+// What makes a mark writable, and a result publishable.
+//
+// Both rules were previously enforced only by the UI. A number input with a max
+// is a courtesy to whoever is typing, not a guarantee — a crafted request wrote
+// whatever it liked. And publication checked that components were *locked*,
+// which says the teacher considers them finished, not that anybody was actually
+// marked: a register with 89 blank rows could be locked and published, and the
+// students behind it were shown a completed semester worth zero credits.
+//
+// Pure so the rules can be tested without a database, and so the same functions
+// answer both "may this be written" and "may this be published".
+
+import type { CourseInfo, MarksInput } from "@/lib/sgpi"
+
+export type MarkRow = MarksInput & { studentId: string }
+
+/** The component a value belongs to, and the maximum it may reach. */
+type Bound = { field: keyof MarksInput; label: string; max: number }
+
+function bounds(course: CourseInfo): Bound[] {
+  const b: Bound[] = [{ field: "isa", label: "ISA", max: course.maxIsa }]
+  if (course.maxMse > 0) {
+    b.push({ field: "mse1", label: "MSE 1", max: course.maxMse })
+    b.push({ field: "mse2", label: "MSE 2", max: course.maxMse })
+  }
+  b.push({ field: "ese", label: "ESE", max: course.maxEse })
+  return b
+}
+
+/**
+ * Why a submitted row cannot be stored, or null if it can.
+ *
+ * A blank is always allowed — components are entered at different points in the
+ * term, so "not yet" has to be expressible. Everything else must be a whole
+ * number from zero to that component's maximum. A course with no MSE rejects an
+ * MSE outright rather than storing a figure no calculation will ever read.
+ */
+export function invalidReason(
+  row: MarksInput,
+  course: CourseInfo
+): string | null {
+  const hasMse = course.maxMse > 0
+  if (!hasMse && (row.mse1 != null || row.mse2 != null)) {
+    return "This subject has no MSE component."
+  }
+  for (const b of bounds(course)) {
+    const v = row[b.field]
+    if (v == null) continue
+    if (!Number.isInteger(v)) return `${b.label} must be a whole number.`
+    if (v < 0) return `${b.label} cannot be negative.`
+    if (v > b.max) return `${b.label} cannot exceed ${b.max}.`
+  }
+  return null
+}
+
+export type ValidationResult =
+  | { ok: true }
+  | { ok: false; reason: string; studentId: string }
+
+/**
+ * Validate a whole payload, rejecting all of it if any row is bad.
+ *
+ * Storing the good rows and dropping the rest would look like a successful save
+ * to whoever pressed the button, and the marks that vanished would be found
+ * later by the student they belonged to.
+ */
+export function validateMarks(
+  rows: MarkRow[],
+  course: CourseInfo
+): ValidationResult {
+  for (const row of rows) {
+    const reason = invalidReason(row, course)
+    if (reason) return { ok: false, reason, studentId: row.studentId }
+  }
+  return { ok: true }
+}
+
+export type Component = "isa" | "mse" | "ese"
+
+/** Whether one student's entry for a component is finished. */
+function hasComponent(row: MarksInput | undefined, c: Component): boolean {
+  if (!row) return false
+  if (c === "isa") return row.isa != null
+  if (c === "ese") return row.ese != null
+  // Both halves, because the two average into the single figure that enters the
+  // total. One MSE in is a subject still being marked, not a marked subject.
+  return row.mse1 != null && row.mse2 != null
+}
+
+/** The components a course actually has. */
+export function requiredComponents(course: CourseInfo): Component[] {
+  return course.maxMse > 0 ? ["isa", "mse", "ese"] : ["isa", "ese"]
+}
+
+export type Incomplete = { studentId: string; missing: Component[] }
+
+/**
+ * Students on the roster who are not finished for the given components.
+ *
+ * Keyed on the roster rather than on the marks table, which is the whole point:
+ * counting rows in `marks` answers "how many students has somebody touched",
+ * and the question that matters is "is anybody still unmarked". A student with
+ * no row at all is the case that was being missed.
+ */
+export function incompleteStudents(
+  roster: string[],
+  marks: Map<string, MarksInput>,
+  components: Component[]
+): Incomplete[] {
+  const out: Incomplete[] = []
+  for (const studentId of roster) {
+    const row = marks.get(studentId)
+    const missing = components.filter((c) => !hasComponent(row, c))
+    if (missing.length > 0) out.push({ studentId, missing })
+  }
+  return out
+}
+
+/** How many students on the roster are fully marked for every component. */
+export function completeCount(
+  roster: string[],
+  marks: Map<string, MarksInput>,
+  course: CourseInfo
+): number {
+  const required = requiredComponents(course)
+  return roster.length - incompleteStudents(roster, marks, required).length
+}
+
+const LABEL: Record<Component, string> = {
+  isa: "ISA",
+  mse: "MSE",
+  ese: "ESE",
+}
+
+/** A refusal a teacher can act on: how many, and what is missing. */
+export function incompleteMessage(
+  incomplete: Incomplete[],
+  action: string
+): string {
+  const n = incomplete.length
+  const missing = [...new Set(incomplete.flatMap((i) => i.missing))]
+    .map((c) => LABEL[c])
+    .join(", ")
+  return `${n} student${n === 1 ? " has" : "s have"} no ${missing} mark yet. ${action} once every student on the roster is marked, or deactivate anyone who has left the class.`
+}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -46,7 +46,12 @@ export function buildNavigation(ctx: NavContext): NavDomain[] {
   if (ctx.hasClasses || tier === "super_admin" || tier === "hod") {
     academics.push({ title: "Classes", url: "/dashboard/class" })
   }
-  if (can("course:read")) {
+  // The catalogue sits inside the department workspace, whose layout admits
+  // only an HOD or an admin. Offering it on course:read alone — which every
+  // teacher has — produced a link that bounced them to the Overview. A teacher
+  // still picks from the catalogue, on their class's Subjects page, which is
+  // where that choice belongs.
+  if (can("course:read") && (tier === "hod" || tier === "super_admin")) {
     academics.push({
       title: "Course catalogue",
       url: "/dashboard/dept/courses",


### PR DESCRIPTION
All eight findings from the 15 Aug audit. Every one reproduced against the live database before being fixed, and the fixes verified the same way.

## P0 — results could be published over an empty register

Publication checked that components were **locked**, which says a teacher considers them finished — not that anybody was marked.

Reproduced live:

```
EC33T   published=true   roster=89   rows=89   complete=0   incomplete=89
```

89 rows is why it looked done: a row exists the moment anyone opens a student, so counting rows answers "how many students has somebody touched", not "how many are marked". Every student behind that offering was shown a finished semester worth zero credits.

Locking now requires that component complete for every active student on the roster, and publishing re-checks the whole set rather than trusting locks that predate the rule.

**Live data repaired.** That offering is withdrawn and its locks released. The blank rows are deliberately untouched — the teacher's grid is exactly as they left it — and it cannot be re-published until it is filled in. An audit row records the withdrawal and why.

## P0 — marks were written unvalidated

`saveMarksAction` wrote whatever arrived. The number inputs carry min/max, but that is a courtesy to whoever is typing; a crafted request stored a negative mark or one above the component maximum, and every average computed downstream was silently wrong.

The payload is now validated against the course's own maxima and **rejected whole** — storing the good rows and dropping the rest looks like a successful save to the person who pressed the button, and the marks that vanished get found later by the student they belonged to.

Migration `0006` adds non-negative CHECK constraints (`NOT VALID` then validated, so an existing bad row could not block the deploy). The upper bound lives on `courses`, which this table cannot see, so only the application can enforce that half — the comment says so.

## P1 — four RBAC scope gaps

| Gap | Was | Now |
|---|---|---|
| Lock a colleague's subject | class membership only | `canWriteOffering`, same as entry |
| Take a subject register you don't hold | offering-belongs-to-class only | must be allocated to you |
| Approve/reject enrolment | every teacher | coordinator, with HOD/admin cover |
| Roster import | `isStaff()` | `student:update` — commit, preview **and** page |

The import one mattered beyond the obvious: `isStaff()` meant revoking `student:update` in the permissions console changed nothing. The preview route needed it too — it reads the whole submitted sheet back to the caller.

Verified against the real class and offering:

```
                     may write/lock    may publish &
                     that subject      decide enrolment
  allocated teacher  true              false
  other teacher      false             false
  coordinator        true              true
  HOD                true              true
```

## P1 — navigation offered pages that then refused you

- An HOD saw "Classes" and was told *"You are not assigned to any class yet. Your HOD assigns coordinators."* The page listed class **assignments**, which an HOD has none of. It now lists their department's; a super-admin's, the institution's (they had neither and saw the same empty page).
- A teacher saw "Course catalogue", which lives behind a layout admitting only HOD and above. They still pick from the catalogue on their class's Subjects page, which is where that choice belongs.
- The Attendance tab appeared on `attendance:read` while the register requires `attendance:write`.

## P1 — the dashboard counted the wrong thing

"89 of 89 entered" for an almost entirely blank register, for the same reason publication accepted it. It now counts students with every required component present.

## Shape of the fix

The rules live in `src/lib/marks-integrity.ts` — pure, and shared by the write path, the publish path and the dashboard, so those three cannot drift apart about what "complete" means again. 19 new tests, including the case that caused this: a roster where nobody has been marked at all.

`npm run check` — typecheck, lint, format, **145 tests**. `npm run build` compiled. Migration 0006 applied to production (6/6).

Not fixed here, and worth its own pass: the UI/UX completeness gaps in the audit (attendance lifecycle, HOD dashboard depth, `0 credits` where it should read "not yet computable"), plus the `BETTER_AUTH_URL` and multiple-lockfile build warnings.