### PR TITLE
feat(dev): a local environment a contributor can actually run

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,0 +1,29 @@
+# Local development. Copy to .env.local and run `npm run dev:setup`.
+#
+# No VOSS credentials, no Neon account, no Better Auth secret worth guarding.
+# The identity switcher in the sidebar replaces signing in; see docs/local-dev.md.
+
+# The container from docker-compose.yml. The host port is 5433 to stay clear of
+# a Postgres you may already be running.
+DATABASE_URL="postgresql://verp:verp@localhost:5433/verp"
+DIRECT_URL="postgresql://verp:verp@localhost:5433/verp"
+
+# Turns on the sidebar identity switcher. Refused by `next build` when
+# NODE_ENV=production, and ignored at runtime outside development.
+VERP_DEV_AUTH=1
+
+# Better Auth still loads, so it wants a secret. It signs nothing that matters
+# locally — do not reuse this value anywhere real.
+BETTER_AUTH_SECRET="dev-only-not-a-secret-0000000000000000000000"
+BETTER_AUTH_URL="http://localhost:3000"
+
+# Unused while the switcher is on. Left blank so the OIDC client can construct
+# itself without reaching for credentials you do not have.
+VOSS_DISCOVERY_URL=""
+VOSS_CLIENT_ID=""
+VOSS_CLIENT_SECRET=""
+
+# The switcher's super-admin persona is a faculty row with role=super_admin, so
+# this allowlist is not needed locally. Add your own address to test the
+# bootstrap seam itself.
+SUPER_ADMIN_EMAILS=""

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ yarn-error.log*
 .env*
 # ...but the example template must ship so contributors know what to set.
 !.env.example
+!.env.development.example
 
 # vercel
 .vercel
@@ -52,4 +53,6 @@ next-env.d.ts
 # trailing slash git never descends, so the negations below would not apply.
 /scripts/*
 !/scripts/setup.ts
+!/scripts/dev-setup.ts
+!/scripts/seed-dev.ts
 !/scripts/lib/

--- a/README.md
+++ b/README.md
@@ -10,18 +10,39 @@ VERP handles the core academic operations of the college: student records, facul
 - **Language**: TypeScript (strict mode)
 - **Database**: PostgreSQL on [Neon](https://neon.tech)
 - **ORM**: Drizzle ORM
-- **Auth**: Better Auth (email/password)
+- **Auth**: VOSS OIDC via Better Auth (VERP holds no credentials)
 - **Styling**: Tailwind CSS 4, shadcn/ui
 - **Validation**: Zod
 
 ## Getting Started
 
+### Contributing? Start here
+
+```bash
+git clone https://github.com/voss-labs/verp.git
+cd verp
+npm install
+npm run dev:setup
+npm run dev
+```
+
+One command, a Postgres container, and a college's worth of mock data. No Neon
+account and no VOSS credentials: you pick who you are — super-admin, HOD,
+coordinator, teacher, student — from a switcher in the sidebar, and every
+permission is still resolved from the database exactly as in production.
+
+Needs Docker running ([OrbStack](https://orbstack.dev) works and is lighter on
+a Mac). Full detail, including why this cannot reach production, is in
+[docs/local-dev.md](docs/local-dev.md).
+
 ### Prerequisites
 
 - Node.js 20+ (required by Next 16 / React 19)
-- A PostgreSQL database (we use [Neon](https://neon.tech) -- free tier works)
+- Docker, for the local database
+- Or, to run against a hosted database instead: a [Neon](https://neon.tech)
+  project and a VOSS client
 
-### Setup
+### Setup against a hosted database
 
 ```bash
 git clone https://github.com/voss-labs/verp.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+# The local database. Nothing else runs in a container: the app itself is
+# happier as `npm run dev` on the host, where hot reload and the debugger work
+# without a bind mount in the way.
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: verp-postgres
+    environment:
+      POSTGRES_USER: verp
+      POSTGRES_PASSWORD: verp
+      POSTGRES_DB: verp
+    ports:
+      # 5433 on the host: 5432 is usually taken by a Postgres somebody already
+      # runs, and a port clash is a confusing first five minutes.
+      - "5433:5432"
+    volumes:
+      - verp-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      # `npm run dev:setup` waits on this before migrating — the container
+      # accepts connections a moment before the database is ready for them.
+      test: ["CMD-SHELL", "pg_isready -U verp -d verp"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+volumes:
+  verp-pgdata:

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,0 +1,155 @@
+# Running VERP locally
+
+```bash
+git clone https://github.com/voss-labs/verp.git
+cd verp
+npm install
+npm run dev:setup
+npm run dev
+```
+
+That is the whole thing. No Neon account, no VOSS client credentials, no
+sign-in. Open <http://localhost:3000> and pick who you are from the switcher
+beside the VOSS mark in the sidebar.
+
+You need Docker running — [OrbStack](https://orbstack.dev) is lighter than
+Docker Desktop on a Mac and works unchanged, since it provides the same
+`docker` and `docker compose` commands.
+
+## Why this exists
+
+VERP authenticates through VOSS, the college's identity provider. A contributor
+cannot register a VOSS client, so before this the app ran and then redirected
+you to a login you had no way to complete. The setup instructions were
+unfollowable through no fault of anyone following them.
+
+## What `npm run dev:setup` does
+
+1. Copies `.env.development.example` to `.env.local` if you have no `.env.local`
+2. Starts a Postgres container and waits for it to accept connections
+3. Pushes the schema, then records the migration files as already applied
+4. Seeds a college's worth of mock data
+
+| Command | |
+|---|---|
+| `npm run dev:setup` | the whole thing, from nothing |
+| `npm run dev:seed` | rewrite the mock data |
+| `npm run dev:down` | stop the container, keep the data |
+| `npm run dev:reset` | destroy the data and start over |
+
+## The identity switcher
+
+Ten people are seeded, and the switcher makes you one of them. There is no
+password because there is no sign-in — the cookie names a persona, and that is
+the only thing being faked.
+
+| | Role | Scope |
+|---|---|---|
+| Asha Deshpande | Super-admin | the whole institution |
+| Ravi Kulkarni | HOD | EXCS — two classes, cover authority |
+| Sunita Rane | HOD | EXTC — nothing in EXCS is visible |
+| Priya Nair | Coordinator | BE EXCS A — publishes, decides enrolment |
+| Mandar Patil | Teacher | BE EXCS A — Data Analytics only |
+| Kavita Joshi | Teacher | BE EXCS A — Computer Networks only |
+| Imran Shaikh | Teacher | BE EXCS B — a different division |
+| Neha Bhosale | Student | 23108A0001, has published results |
+| Omkar Sawant | Student | 23108A0002, nothing published yet |
+| Rohit Gaikwad | Unplaced | authenticated, on no roster |
+
+### The permissions are real
+
+This is the part worth understanding before you rely on it.
+
+`getSessionUser()` takes four fields from the identity provider — id, name,
+email, image — and resolves everything that matters from the database: which
+tier you are, which departments and classes you can reach, and your whole
+capability set including any override an admin has set. The switcher substitutes
+those four fields and nothing else.
+
+So becoming the HOD of EXTC does not *grant* you EXTC. It makes you a person
+whose faculty row says so, and the same queries decide the rest. If you break a
+scope rule, this environment shows you — which a mock that returned a
+fabricated permission set could not.
+
+Measured on the seeded data, the roster each persona can read:
+
+```
+admin          1736     every student
+hod-excs        509     EXCS only
+hod-extc        503     EXTC only
+coordinator      62     one class
+teacher-dav      62     one class
+student          62     their own class
+unplaced          0
+```
+
+## What the mock data contains
+
+Roughly 1,700 students across three departments and all four year-cohorts, so
+filters, search, pagination and the scoped queries behave the way they will in
+front of a real roster. An N+1 that is invisible against a dozen rows is obvious
+against a thousand.
+
+**BE EXCS A** is wired end to end, and is where the rules become visible:
+
+- `EC33T` published — the student persona has a result and an SGPI to read
+- `EC34T` ISA only — provisional, "In progress", 0 of 62 complete
+- `EC35T` no teacher — top of the attention inbox
+- `EC36P` an untouched lab
+- today's register deliberately not taken, so there is work waiting
+- one pending enrolment request for the coordinator to decide
+- one student below the 75% attendance rule, so the warning has something to say
+
+Two teachers hold different subjects on that one class on purpose: it is what
+makes "that subject is allocated to another teacher" reachable rather than
+theoretical.
+
+## This cannot reach production
+
+An authentication bypass is worth being paranoid about, so there are three
+independent locks and any one of them is enough.
+
+1. **`NODE_ENV`** must not be `production`. Both `next build` and `next start`
+   set it, so a deployed bundle fails the check regardless of configuration.
+2. **`VERP_DEV_AUTH`** must be exactly `"1"`. Nothing sets it by accident;
+   `"true"`, `"yes"` and `"0"` are all rejected, and there are tests for that.
+3. **`next.config.ts` refuses to build or start** when a production build and
+   the flag are both present. The artifact cannot be produced.
+
+Verified rather than asserted — a production build with the flag set:
+
+```
+Error: VERP_DEV_AUTH is set for a production build. It bypasses sign-in and
+must never be present in a deployed environment — unset it and rebuild.
+```
+
+and a production build with the flag absent, handed a valid persona cookie:
+
+```
+admin        -> 307 /login
+student      -> 307 /login
+coordinator  -> 307 /login
+```
+
+The seeder has its own lock: it refuses to run against any host that is not
+local, because everything it does begins by deleting rows.
+
+## Working against the real thing
+
+Nothing stops you. Put your Neon and VOSS credentials in `.env.local` and drop
+`VERP_DEV_AUTH`, and the switcher disappears — the dev identity falls through to
+the real login whenever it cannot resolve a persona, so the two paths coexist
+without a build flag.
+
+## Notes
+
+- The local driver is `node-postgres`; production is Neon over HTTP. The one
+  behavioural difference is that node-postgres supports transactions and
+  neon-http does not, so **do not write code that assumes them** — it will work
+  on your machine and fail in production. The codebase is transaction-free for
+  this reason.
+- The container listens on **5433**, not 5432, to stay clear of a Postgres you
+  may already be running.
+- The switcher is deliberately ugly — dashed border, flask icon — so a
+  screenshot from a contributor's laptop is never mistaken for the real
+  application.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,21 @@
 import type { NextConfig } from "next"
 
+// The third lock on dev impersonation (lib/dev-auth.ts explains the other two).
+// The runtime gate already refuses when NODE_ENV is "production", but a refusal
+// at runtime is a bug report from a user; this is a build that never ships.
+if (process.env.NODE_ENV === "production" && process.env.VERP_DEV_AUTH) {
+  throw new Error(
+    "VERP_DEV_AUTH is set for a production build. It bypasses sign-in and must " +
+      "never be present in a deployed environment — unset it and rebuild."
+  )
+}
+
 const nextConfig: NextConfig = {
+  // Required at runtime by the local-Postgres branch in src/db/index.ts and
+  // never by the hosted one. Listing it here keeps it out of the compiled
+  // server bundle, so a production deploy carries no trace of the local path.
+  serverExternalPackages: ["pg"],
+
   async headers() {
     return [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "next": "16.1.6",
         "next-themes": "^0.4.6",
         "open": "^11.0.0",
+        "pg": "^8.23.0",
         "react": "19.2.3",
         "react-day-picker": "^9.14.0",
         "react-dom": "19.2.3",
@@ -46,6 +47,7 @@
         "@clack/prompts": "^1.2.0",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
+        "@types/pg": "^8.21.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/ws": "^8.18.1",
@@ -4523,9 +4525,9 @@
       }
     },
     "node_modules/@types/pg": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.18.0.tgz",
-      "integrity": "sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AYdtudzabjLZgVgRZmAnU8bAnVUXzuJX2IYHeSIiIHm68olD+LgQYCGWdtcNYnP0uq9c4S4NibVG3Ni7VbKW7Q==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -11940,6 +11942,46 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
+      "integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.16.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -11949,10 +11991,19 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
     "node_modules/pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
       "license": "MIT"
     },
     "node_modules/pg-types": {
@@ -11969,6 +12020,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/picocolors": {
@@ -13432,6 +13492,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stable-hash": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,12 @@
     "db:migrate:status": "tsx src/db/migrate-status.ts",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "dev:setup": "tsx scripts/dev-setup.ts",
+    "dev:seed": "tsx scripts/seed-dev.ts",
+    "dev:up": "docker compose up -d",
+    "dev:down": "docker compose down",
+    "dev:reset": "docker compose down -v && npm run dev:setup"
   },
   "dependencies": {
     "@base-ui/react": "^1.2.0",
@@ -47,6 +52,7 @@
     "next": "16.1.6",
     "next-themes": "^0.4.6",
     "open": "^11.0.0",
+    "pg": "^8.23.0",
     "react": "19.2.3",
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.3",
@@ -65,6 +71,7 @@
     "@clack/prompts": "^1.2.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/pg": "^8.21.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/ws": "^8.18.1",

--- a/scripts/dev-setup.ts
+++ b/scripts/dev-setup.ts
@@ -1,0 +1,106 @@
+// One command from a fresh clone to a running college.
+//
+// Ordered the way it is because each step needs the one before it to have
+// actually finished: the container reports "started" a moment before Postgres
+// will accept a connection, and migrating a database that is not listening
+// yet fails in a way that reads like a broken migration.
+
+import { execSync, spawnSync } from "node:child_process"
+import { existsSync, copyFileSync } from "node:fs"
+
+const step = (n: number, msg: string) => console.log(`\n[${n}/4] ${msg}`)
+
+function run(cmd: string, args: string[]) {
+  const r = spawnSync(cmd, args, {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  })
+  if (r.status !== 0) process.exit(r.status ?? 1)
+}
+
+function compose(): string[] {
+  // `docker compose` on anything current, `docker-compose` on older installs.
+  try {
+    execSync("docker compose version", { stdio: "ignore" })
+    return ["docker", "compose"]
+  } catch {
+    try {
+      execSync("docker-compose version", { stdio: "ignore" })
+      return ["docker-compose"]
+    } catch {
+      console.error(
+        "\nDocker is not available.\n" +
+          "Install Docker Desktop (or any Docker engine) and start it, then re-run.\n"
+      )
+      process.exit(1)
+    }
+  }
+}
+
+async function main() {
+  step(1, "environment")
+  if (!existsSync(".env.local")) {
+    copyFileSync(".env.development.example", ".env.local")
+    console.log("  created .env.local from .env.development.example")
+  } else {
+    console.log("  .env.local already exists, leaving it alone")
+  }
+
+  step(2, "database container")
+  const [bin, ...sub] = compose()
+  run(bin, [...sub, "up", "-d"])
+
+  process.stdout.write("  waiting for postgres")
+  const deadline = Date.now() + 60_000
+  for (;;) {
+    const r = spawnSync(
+      bin,
+      [
+        ...sub,
+        "exec",
+        "-T",
+        "postgres",
+        "pg_isready",
+        "-U",
+        "verp",
+        "-d",
+        "verp",
+      ],
+      { stdio: "ignore" }
+    )
+    if (r.status === 0) break
+    if (Date.now() > deadline) {
+      console.error("\n  postgres did not become ready within 60s.")
+      console.error(`  check: ${bin} ${sub.join(" ")} logs postgres`)
+      process.exit(1)
+    }
+    process.stdout.write(".")
+    await new Promise((r) => setTimeout(r, 1000))
+  }
+  console.log(" ready")
+
+  step(3, "schema")
+  // push builds the whole current schema; --baseline then records the
+  // migration files as applied rather than replaying changes the push already
+  // contains. Any migration written after this point runs normally.
+  run("npx", ["drizzle-kit", "push", "--force"])
+  run("npx", ["tsx", "src/db/migrate.ts", "--baseline"])
+
+  step(4, "mock data")
+  run("npx", ["tsx", "scripts/seed-dev.ts"])
+
+  console.log(`
+Ready. Start the app:
+
+  npm run dev
+
+Then open http://localhost:3000 and choose who you are from the switcher
+beside the VOSS mark in the sidebar. No sign-in, no VOSS credentials.
+
+  npm run dev:seed    rewrite the mock data
+  npm run dev:down    stop the container (data is kept)
+  npm run dev:reset   destroy the container and its data, then start over
+`)
+}
+
+main()

--- a/scripts/seed-dev.ts
+++ b/scripts/seed-dev.ts
@@ -1,0 +1,670 @@
+// The local development dataset.
+//
+// Two layers, because a fixture that is only one of them is misleading in a
+// different way each time.
+//
+// BREADTH gives the app a college's worth of rows: three departments, all four
+// year-cohorts, ~1,100 students. Filters, search, pagination and the scoped
+// queries behave the way they will in front of a real roster, and an N+1 that
+// is invisible against twelve rows is obvious against a thousand.
+//
+// DEPTH wires one class — BE EXCS A — end to end, and that class is where the
+// authorization rules become visible. Two teachers on it so "allocated to
+// another teacher" is reachable; a coordinator who teaches nothing so the
+// decisions that are theirs can be told apart from the ones that are not; a
+// subject nobody teaches so the attention inbox has something real to rank; and
+// marks in three different states so published, provisional and untouched can
+// be seen side by side.
+//
+// Idempotent: it clears the tables it owns and rewrites them, so running it
+// twice is the same as running it once and a broken experiment is one command
+// from a known state.
+
+import { config } from "dotenv"
+config({ path: ".env.local", quiet: true })
+
+import { Pool } from "pg"
+import { drizzle } from "drizzle-orm/node-postgres"
+import { eq } from "drizzle-orm"
+import { randomUUID } from "node:crypto"
+import * as schema from "../src/db/schema"
+import { isLocalPostgres } from "../src/db/driver"
+import {
+  DEV_PERSONAS,
+  DEV_CLASS_A,
+  DEV_CLASS_B,
+  DEV_CLASS_EXTC,
+} from "../src/lib/dev-personas"
+
+const url = process.env.DATABASE_URL ?? ""
+
+// The one check that matters in this file. Everything below deletes rows, and
+// the difference between the container and the college's database is one line
+// in .env.local that is easy to have forgotten about.
+if (!url) {
+  console.error("DATABASE_URL is not set. Copy .env.development.example first.")
+  process.exit(1)
+}
+if (!isLocalPostgres(url)) {
+  console.error(
+    `Refusing to seed ${new URL(url).hostname}.\n` +
+      "This script deletes and rewrites academic tables, and only ever runs\n" +
+      "against a local database. Point DATABASE_URL at the container from\n" +
+      "docker-compose.yml (localhost:5433) and try again."
+  )
+  process.exit(1)
+}
+
+const pool = new Pool({ connectionString: url })
+const db = drizzle(pool, { schema })
+
+const uid = () => randomUUID()
+const now = new Date()
+const daysAgo = (n: number) => {
+  const d = new Date(now)
+  d.setDate(d.getDate() - n)
+  return d.toISOString().slice(0, 10)
+}
+
+// Deterministic, so two contributors comparing screens see the same college.
+let seed = 20260815
+const rand = () => {
+  seed = (seed * 1103515245 + 12345) % 2147483648
+  return seed / 2147483648
+}
+const pick = <T>(xs: readonly T[]) => xs[Math.floor(rand() * xs.length)]
+
+/** Postgres has a parameter ceiling per statement; large tables go in chunks. */
+async function insertAll<T>(
+  table: Parameters<typeof db.insert>[0],
+  rows: T[],
+  size = 400
+) {
+  for (let i = 0; i < rows.length; i += size) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await db.insert(table).values(rows.slice(i, i + size) as any)
+  }
+}
+
+const FIRST = [
+  "Neha",
+  "Omkar",
+  "Sanika",
+  "Aditya",
+  "Isha",
+  "Rohan",
+  "Tanvi",
+  "Yash",
+  "Gauri",
+  "Siddharth",
+  "Manasi",
+  "Kunal",
+  "Shreya",
+  "Atharva",
+  "Mrunal",
+  "Vedant",
+  "Ketaki",
+  "Soham",
+  "Rutuja",
+  "Pranav",
+  "Aarti",
+  "Nikhil",
+  "Sayali",
+  "Harsh",
+  "Devika",
+  "Chinmay",
+  "Anushka",
+  "Parth",
+]
+const LAST = [
+  "Bhosale",
+  "Sawant",
+  "Kadam",
+  "Jadhav",
+  "Pawar",
+  "Shinde",
+  "More",
+  "Chavan",
+  "Salunkhe",
+  "Thorat",
+  "Dalvi",
+  "Ghadge",
+  "Deshmukh",
+  "Kulkarni",
+  "Patil",
+  "Joshi",
+  "Naik",
+  "Rane",
+  "Gaikwad",
+  "Mane",
+  "Bhagat",
+  "Waghmare",
+]
+
+// Today is in academic year 2026-27, so a 2023 intake is in its BE year.
+const COHORTS = [
+  { year: "BE", admissionYear: 2023, semester: 7 },
+  { year: "TE", admissionYear: 2024, semester: 5 },
+  { year: "SE", admissionYear: 2025, semester: 3 },
+  { year: "FE", admissionYear: 2026, semester: 1 },
+] as const
+
+const DEPTS = [
+  // `prefix` is the course-code stem and has to differ per department: course
+  // codes are unique college-wide, and EXCS and EXTC both start "EX".
+  {
+    code: "EXCS",
+    name: "Electronics & Computer Science",
+    branch: "108",
+    prefix: "EC",
+    divisions: ["A", "B"],
+  },
+  {
+    code: "CMPN",
+    name: "Computer Engineering",
+    branch: "102",
+    prefix: "CM",
+    divisions: ["A", "B", "C"],
+  },
+  {
+    code: "EXTC",
+    name: "Electronics & Telecommunication",
+    branch: "104",
+    prefix: "ET",
+    divisions: ["A", "B"],
+  },
+] as const
+
+/** Four subjects per cohort per department, named plausibly for the year. */
+const SUBJECTS: Record<string, [string, string, "theory" | "practical"][]> = {
+  BE: [
+    ["33T", "Data Analytics & Visualization", "theory"],
+    ["34T", "Computer Networks", "theory"],
+    ["35T", "Machine Learning", "theory"],
+    ["36P", "Data Analytics Laboratory", "practical"],
+  ],
+  TE: [
+    ["23T", "Operating Systems", "theory"],
+    ["24T", "Database Management Systems", "theory"],
+    ["25T", "Software Engineering", "theory"],
+    ["26P", "Database Laboratory", "practical"],
+  ],
+  SE: [
+    ["13T", "Data Structures", "theory"],
+    ["14T", "Discrete Mathematics", "theory"],
+    ["15T", "Digital Electronics", "theory"],
+    ["16P", "Data Structures Laboratory", "practical"],
+  ],
+  FE: [
+    ["03T", "Engineering Mathematics I", "theory"],
+    ["04T", "Engineering Physics", "theory"],
+    ["05T", "Problem Solving with C", "theory"],
+    ["06P", "Physics Laboratory", "practical"],
+  ],
+}
+
+async function main() {
+  // Deleted child-first: each of these has a foreign key into the one above, so
+  // the order is the schema's, not a preference.
+  console.log("clearing…")
+  for (const table of [
+    "attendance",
+    "marks_locks",
+    "marks",
+    "batch_assignments",
+    "batches",
+    "course_offerings",
+    "enrollment_requests",
+    "faculty_class_assignments",
+    "dept_appointments",
+    "audit_logs",
+    "permission_overrides",
+    "students",
+    "courses",
+    "classes",
+    "faculty",
+    "departments",
+    "session",
+    "account",
+    '"user"',
+  ]) {
+    await pool.query(`DELETE FROM ${table}`)
+  }
+
+  await db
+    .insert(schema.departments)
+    .values(DEPTS.map((d) => ({ code: d.code, name: d.name })))
+
+  // ── classes: every department, every cohort, every division ────────────
+  type ClassRow = typeof schema.classes.$inferInsert & { id: string }
+  const classes: ClassRow[] = []
+  for (const d of DEPTS) {
+    for (const c of COHORTS) {
+      for (const div of d.divisions) {
+        classes.push({
+          id: uid(),
+          classKey: `${c.admissionYear}-${d.branch}-${div}`,
+          admissionYear: c.admissionYear,
+          branchCode: d.branch,
+          departmentCode: d.code,
+          division: div,
+        })
+      }
+    }
+  }
+  await insertAll(schema.classes, classes)
+  const classBy = (key: string) => classes.find((c) => c.classKey === key)!
+  const classA = classBy(DEV_CLASS_A).id
+  const classB = classBy(DEV_CLASS_B).id
+
+  // ── auth users, one per persona ────────────────────────────────────────
+  // No account rows: nobody signs in locally, the switcher names them instead.
+  const userIdByEmail = new Map<string, string>()
+  await db.insert(schema.user).values(
+    DEV_PERSONAS.map((p) => {
+      const id = `dev-${p.key}`
+      userIdByEmail.set(p.email, id)
+      return {
+        id,
+        name: p.name,
+        email: p.email,
+        emailVerified: true,
+        image: null,
+        createdAt: now,
+        updatedAt: now,
+      }
+    })
+  )
+  const authId = (email: string) => userIdByEmail.get(email) ?? null
+
+  // ── faculty ────────────────────────────────────────────────────────────
+  const fAdmin = uid(),
+    fHodExcs = uid(),
+    fHodExtc = uid(),
+    fHodCmpn = uid()
+  const fCoord = uid(),
+    fDav = uid(),
+    fCn = uid(),
+    fTeacherB = uid()
+
+  type FacRow = typeof schema.faculty.$inferInsert
+  const named: FacRow[] = [
+    {
+      id: fAdmin,
+      authUserId: authId("dev.admin@vit.edu.in"),
+      firstName: "Asha",
+      lastName: "Deshpande",
+      employeeId: "VIT0001",
+      email: "dev.admin@vit.edu.in",
+      department: "EXCS",
+      role: "super_admin",
+    },
+    {
+      id: fHodExcs,
+      authUserId: authId("dev.hod.excs@vit.edu.in"),
+      firstName: "Ravi",
+      lastName: "Kulkarni",
+      employeeId: "VIT0002",
+      email: "dev.hod.excs@vit.edu.in",
+      department: "EXCS",
+      role: "hod",
+    },
+    {
+      id: fHodExtc,
+      authUserId: authId("dev.hod.extc@vit.edu.in"),
+      firstName: "Sunita",
+      lastName: "Rane",
+      employeeId: "VIT0003",
+      email: "dev.hod.extc@vit.edu.in",
+      department: "EXTC",
+      role: "hod",
+    },
+    {
+      id: fHodCmpn,
+      authUserId: null,
+      firstName: "Deepak",
+      lastName: "Bhandari",
+      employeeId: "VIT0008",
+      email: "dev.hod.cmpn@vit.edu.in",
+      department: "CMPN",
+      role: "hod",
+    },
+    {
+      id: fCoord,
+      authUserId: authId("dev.coordinator@vit.edu.in"),
+      firstName: "Priya",
+      lastName: "Nair",
+      employeeId: "VIT0004",
+      email: "dev.coordinator@vit.edu.in",
+      department: "EXCS",
+      role: "faculty",
+    },
+    {
+      id: fDav,
+      authUserId: authId("dev.teacher.dav@vit.edu.in"),
+      firstName: "Mandar",
+      lastName: "Patil",
+      employeeId: "VIT0005",
+      email: "dev.teacher.dav@vit.edu.in",
+      department: "EXCS",
+      role: "faculty",
+    },
+    {
+      id: fCn,
+      authUserId: authId("dev.teacher.cn@vit.edu.in"),
+      firstName: "Kavita",
+      lastName: "Joshi",
+      employeeId: "VIT0006",
+      email: "dev.teacher.cn@vit.edu.in",
+      department: "EXCS",
+      role: "faculty",
+    },
+    {
+      id: fTeacherB,
+      authUserId: authId("dev.teacher.b@vit.edu.in"),
+      firstName: "Imran",
+      lastName: "Shaikh",
+      employeeId: "VIT0007",
+      email: "dev.teacher.b@vit.edu.in",
+      department: "EXCS",
+      role: "faculty",
+    },
+  ]
+
+  // Enough other staff that the faculty table, its filters and the appointment
+  // pickers have a realistic amount to sift through.
+  const bulkFaculty: FacRow[] = []
+  let empNo = 100
+  for (const d of DEPTS) {
+    for (let i = 0; i < 16; i++) {
+      const first = pick(FIRST)
+      const last = pick(LAST)
+      empNo++
+      bulkFaculty.push({
+        id: uid(),
+        authUserId: null,
+        firstName: first,
+        lastName: last,
+        employeeId: `VIT0${empNo}`,
+        email: `${first.toLowerCase()}.${last.toLowerCase()}${empNo}@vit.edu.in`,
+        department: d.code,
+        role: "faculty",
+      })
+    }
+  }
+  await insertAll(schema.faculty, [...named, ...bulkFaculty])
+
+  await db.insert(schema.deptAppointments).values([
+    { deptCode: "EXCS", facultyId: fHodExcs, appointment: "hod" },
+    { deptCode: "EXTC", facultyId: fHodExtc, appointment: "hod" },
+    { deptCode: "CMPN", facultyId: fHodCmpn, appointment: "hod" },
+  ])
+
+  // The coordinator coordinates and does not teach; the teachers teach and do
+  // not coordinate. Keeping them apart is what makes it obvious when a rule
+  // that should be the coordinator's has leaked to everybody on the class.
+  type AssignRow = typeof schema.facultyClassAssignments.$inferInsert
+  const assignments: AssignRow[] = [
+    { facultyId: fCoord, classId: classA, role: "academic_coordinator" },
+    { facultyId: fDav, classId: classA, role: "tr" },
+    { facultyId: fCn, classId: classA, role: "tr" },
+    { facultyId: fTeacherB, classId: classB, role: "academic_coordinator" },
+  ]
+  // Most other classes get a coordinator; a few are deliberately left unstaffed
+  // so the HOD's department health has a real gap to report.
+  const staffed = classes.filter((c) => c.id !== classA && c.id !== classB)
+  staffed.forEach((c, i) => {
+    if (i % 5 === 0) return
+    const pool = bulkFaculty.filter((f) => f.department === c.departmentCode)
+    if (pool.length === 0) return
+    assignments.push({
+      facultyId: pool[i % pool.length].id!,
+      classId: c.id,
+      role: "academic_coordinator",
+    })
+  })
+  await insertAll(schema.facultyClassAssignments, assignments)
+
+  // ── courses: one set per department per cohort ─────────────────────────
+  type CourseRow = typeof schema.courses.$inferInsert & { id: string }
+  const courses: CourseRow[] = []
+  for (const d of DEPTS) {
+    for (const c of COHORTS) {
+      for (const [suffix, name, type] of SUBJECTS[c.year]) {
+        const practical = type === "practical"
+        courses.push({
+          id: uid(),
+          courseCode: `${d.prefix}${suffix}`,
+          courseName: name,
+          departmentCode: d.code,
+          courseType: type,
+          credits: practical ? 1 : 4,
+          maxIsa: practical ? 50 : 20,
+          maxMse: practical ? 0 : 30,
+          maxEse: 50,
+          maxTotal: 100,
+          year: c.year,
+        })
+      }
+    }
+  }
+  await insertAll(schema.courses, courses)
+  const courseFor = (dept: string, year: string, suffix: string) =>
+    courses.find(
+      (c) =>
+        c.departmentCode === dept &&
+        c.year === year &&
+        c.courseCode.endsWith(suffix)
+    )!
+
+  // ── offerings ──────────────────────────────────────────────────────────
+  type OffRow = typeof schema.courseOfferings.$inferInsert & { id: string }
+  const offerings: OffRow[] = []
+  const semesterOf = (admissionYear: number) =>
+    COHORTS.find((c) => c.admissionYear === admissionYear)!.semester
+  const yearOf = (admissionYear: number) =>
+    COHORTS.find((c) => c.admissionYear === admissionYear)!.year
+
+  for (const cls of classes) {
+    const year = yearOf(cls.admissionYear)
+    const teachers = bulkFaculty.filter(
+      (f) => f.department === cls.departmentCode
+    )
+    SUBJECTS[year].forEach(([suffix], i) => {
+      const course = courseFor(cls.departmentCode, year, suffix)
+      // Roughly one subject in six has nobody on it, which is the shape of a
+      // department mid-allocation and what the attention inbox is for.
+      const unstaffed = (i + cls.division.charCodeAt(0)) % 6 === 0
+      offerings.push({
+        id: uid(),
+        courseId: course.id,
+        classId: cls.id,
+        facultyId:
+          unstaffed || teachers.length === 0
+            ? null
+            : teachers[i % teachers.length].id!,
+        semester: semesterOf(cls.admissionYear),
+      })
+    })
+  }
+  // The focus class is wired by hand rather than by the rule above.
+  const focus = offerings.filter((o) => o.classId === classA)
+  const oDav = focus[0],
+    oCn = focus[1],
+    oMl = focus[2],
+    oLab = focus[3]
+  oDav.facultyId = fDav
+  oCn.facultyId = fCn
+  oMl.facultyId = null // nobody teaches it: top of the attention inbox
+  oLab.facultyId = fDav
+  await insertAll(schema.courseOfferings, offerings)
+
+  // ── students ───────────────────────────────────────────────────────────
+  type StuRow = typeof schema.students.$inferInsert & { id: string }
+  const students: StuRow[] = []
+  const idsA: string[] = []
+
+  for (const cls of classes) {
+    const year = yearOf(cls.admissionYear)
+    const isFocus = cls.id === classA
+    const size = isFocus ? 62 : 55 + Math.floor(rand() * 12)
+    for (let i = 0; i < size; i++) {
+      const id = uid()
+      const roll = `${String(cls.admissionYear).slice(2)}${cls.branchCode}${cls.division}${String(i + 1).padStart(4, "0")}`
+      // The first two of the focus class are personas, so the switcher can
+      // become them; the rest are unclaimed, which is the normal state of a
+      // roster before a cohort signs in.
+      const persona =
+        isFocus && i === 0
+          ? "dev.student@vit.edu.in"
+          : isFocus && i === 1
+            ? "dev.student.fresh@vit.edu.in"
+            : null
+      if (isFocus) idsA.push(id)
+      students.push({
+        id,
+        authUserId: persona ? authId(persona) : null,
+        firstName: persona ? (i === 0 ? "Neha" : "Omkar") : pick(FIRST),
+        lastName: persona ? (i === 0 ? "Bhosale" : "Sawant") : pick(LAST),
+        rollNumber: roll,
+        email: persona ?? `${roll.toLowerCase()}@vit.edu.in`,
+        department: cls.departmentCode,
+        division: cls.division,
+        year,
+        classKey: cls.classKey,
+      })
+    }
+  }
+  await insertAll(schema.students, students)
+
+  // ── marks, in three deliberately different states ──────────────────────
+  //
+  // DAV is finished, locked and published, so the student persona has a real
+  // result and an SGPI to read. Publication now requires every active student
+  // to be complete, so this has to be the whole roster — a seed that skipped
+  // one would be refused, which is the rule working.
+  type MarkRow = typeof schema.marks.$inferInsert
+  const marks: MarkRow[] = idsA.map((studentId, i) => ({
+    courseOfferingId: oDav.id,
+    studentId,
+    isa: 11 + (i % 10),
+    mse1: 16 + (i % 15),
+    mse2: 18 + (i % 13),
+    ese: 24 + (i % 27),
+    recordedByFacultyId: fDav,
+  }))
+  // CN is mid-term: ISA for everybody, nothing else. This is what "provisional"
+  // and "In progress" are for, and it keeps the dashboard's completion count
+  // honest — 62 rows touched, 0 complete.
+  marks.push(
+    ...idsA.map((studentId, i) => ({
+      courseOfferingId: oCn.id,
+      studentId,
+      isa: 9 + (i % 12),
+      mse1: null,
+      mse2: null,
+      ese: null,
+      recordedByFacultyId: fCn,
+    }))
+  )
+  await insertAll(schema.marks, marks)
+
+  await db.insert(schema.marksLocks).values(
+    (["isa", "mse", "ese"] as const).map((component) => ({
+      courseOfferingId: oDav.id,
+      component,
+      isLocked: true,
+      lockedByFacultyId: fDav,
+      lockedAt: now,
+    }))
+  )
+  await db
+    .update(schema.courseOfferings)
+    .set({ publishedAt: now, publishedByFacultyId: fCoord })
+    .where(eq(schema.courseOfferings.id, oDav.id))
+
+  // ── attendance ─────────────────────────────────────────────────────────
+  // A fortnight of class registers and one subject register, with today left
+  // empty on purpose so the attention inbox has a register to ask for the
+  // moment you sign in.
+  type AttRow = typeof schema.attendance.$inferInsert
+  const attendance: AttRow[] = []
+  for (let d = 1; d <= 14; d++) {
+    const day = daysAgo(d)
+    // No registers at the weekend, so the percentages read like a real term.
+    if ([0, 6].includes(new Date(day).getDay())) continue
+    idsA.forEach((studentId, i) => {
+      attendance.push({
+        studentId,
+        classId: classA,
+        courseOfferingId: null,
+        sessionDate: day,
+        sessionSlot: "1",
+        status: rand() < 0.12 ? "absent" : rand() < 0.04 ? "late" : "present",
+        recordedByFacultyId: fCoord,
+      })
+      // One student is deliberately short of the 75% rule, so the student view
+      // has a real warning to show rather than a uniform wall of green.
+      if (i === 3) {
+        attendance[attendance.length - 1].status =
+          d % 3 === 0 ? "present" : "absent"
+      }
+    })
+  }
+  for (const d of [1, 3, 6, 8]) {
+    const day = daysAgo(d)
+    if ([0, 6].includes(new Date(day).getDay())) continue
+    idsA.forEach((studentId) => {
+      attendance.push({
+        studentId,
+        classId: classA,
+        courseOfferingId: oDav.id,
+        sessionDate: day,
+        sessionSlot: "3",
+        status: rand() < 0.15 ? "absent" : "present",
+        recordedByFacultyId: fDav,
+      })
+    })
+  }
+  await insertAll(schema.attendance, attendance)
+
+  // ── a decision waiting for somebody ────────────────────────────────────
+  await db.insert(schema.enrollmentRequests).values({
+    authUserId: authId("dev.unbound@vit.edu.in")!,
+    rollNumber: "23108A0099",
+    firstName: "Rohit",
+    lastName: "Gaikwad",
+    email: "dev.unbound@vit.edu.in",
+    classId: classA,
+    status: "pending",
+  })
+
+  const unstaffed = offerings.filter((o) => o.facultyId === null).length
+  console.log(`
+seeded
+  departments        ${DEPTS.length}  (EXCS, CMPN, EXTC)
+  classes            ${classes.length}  — FE / SE / TE / BE across every division
+  faculty            ${named.length + bulkFaculty.length}
+  students           ${students.length}
+  offerings          ${offerings.length}, of which ${unstaffed} have no teacher
+  marks              ${marks.length}
+  attendance         ${attendance.length}
+  enrolment requests 1 pending on ${DEV_CLASS_A}
+
+BE EXCS A is the class wired end to end:
+  EC33T  published — the student persona has a result and an SGPI
+  EC34T  ISA only — provisional, "In progress", 0 of 62 complete
+  EC35T  no teacher — top of the attention inbox
+  EC36P  untouched lab
+  today's register deliberately not taken
+
+Pick who you are from the switcher beside the VOSS mark in the sidebar.
+`)
+  await pool.end()
+}
+
+main().catch(async (err) => {
+  console.error(err)
+  await pool.end()
+  process.exit(1)
+})

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -4,6 +4,7 @@ import { CommandPalette } from "@/components/command-palette"
 import { SessionProvider } from "@/components/session-provider"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { getSessionUser, isUnbound } from "@/lib/session"
+import { devAuthProps } from "@/lib/dev-auth"
 
 export const dynamic = "force-dynamic"
 
@@ -19,6 +20,10 @@ export default async function DashboardLayout({
   const user = await getSessionUser()
   if (!user) redirect("/login")
   if (isUnbound(user)) redirect("/unclaimed")
+
+  // Null unless this is a development machine with the flag on, and a null prop
+  // means the switcher and its persona list never reach the browser.
+  const devAuth = await devAuthProps()
 
   // Resolved once here and handed down, rather than every client component
   // fetching /api/me for itself.
@@ -38,7 +43,7 @@ export default async function DashboardLayout({
       }}
     >
       <SidebarProvider>
-        <AppSidebar />
+        <AppSidebar devAuth={devAuth} />
         <SidebarInset>{children}</SidebarInset>
         {/* Mounted once at the layout so Cmd+K works from every page, rather
             than each page remembering to include it. */}

--- a/src/app/login/dev-sign-in.tsx
+++ b/src/app/login/dev-sign-in.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { useTransition } from "react"
+import { FlaskConicalIcon } from "lucide-react"
+import type { DevPersona } from "@/lib/dev-personas"
+import { setDevActor } from "@/lib/dev-auth-actions"
+
+/**
+ * The way in when there is no way in.
+ *
+ * A contributor cannot complete a VOSS sign-in, so without this the login page
+ * is a wall. Rendered only when the server hands it personas, which it does
+ * only on a development machine with the flag set.
+ */
+export function DevSignIn({ personas }: { personas: DevPersona[] }) {
+  const [pending, start] = useTransition()
+  return (
+    <div className="border-attention/50 mx-auto mt-6 w-full max-w-sm rounded-lg border border-dashed p-4">
+      <p className="flex items-center gap-2 text-sm font-medium">
+        <FlaskConicalIcon className="text-attention size-4" />
+        Development sign-in
+      </p>
+      <p className="text-muted-foreground mt-1 text-xs">
+        No VOSS credentials needed. Permissions still come from the database, so
+        what each of these can do is the real answer.
+      </p>
+      <div className="mt-3 flex flex-col gap-1">
+        {personas.map((p) => (
+          <button
+            key={p.key}
+            type="button"
+            disabled={pending}
+            onClick={() => start(() => void setDevActor(p.key))}
+            className="hover:bg-muted focus-visible:ring-ring flex flex-col rounded px-2 py-1.5 text-left transition-colors focus-visible:ring-2 focus-visible:outline-none"
+          >
+            <span className="text-sm">
+              {p.name}
+              <span className="text-muted-foreground ml-1.5 text-xs">
+                {p.role}
+              </span>
+            </span>
+            <span className="text-muted-foreground text-xs">{p.scope}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,22 @@
+import { redirect } from "next/navigation"
 import { LoginForm } from "@/components/login-form"
+import { DevSignIn } from "./dev-sign-in"
+import { devAuthProps } from "@/lib/dev-auth"
+import { getSessionUser } from "@/lib/session"
 
-export default function LoginPage() {
-  return <LoginForm />
+export const dynamic = "force-dynamic"
+
+export default async function LoginPage() {
+  const devAuth = await devAuthProps()
+
+  // Choosing a persona sets a cookie and revalidates; without this the login
+  // page would keep rendering underneath an identity that already resolves.
+  if (devAuth?.current && (await getSessionUser())) redirect("/dashboard")
+
+  return (
+    <>
+      <LoginForm />
+      {devAuth && <DevSignIn personas={devAuth.personas} />}
+    </>
+  )
 }

--- a/src/app/unclaimed/page.tsx
+++ b/src/app/unclaimed/page.tsx
@@ -3,6 +3,7 @@ import { ClockIcon, AlertTriangleIcon } from "lucide-react"
 import { AppSidebar } from "@/components/app-sidebar"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { getSessionUser, isUnbound } from "@/lib/session"
+import { devAuthProps } from "@/lib/dev-auth"
 import { getLatestRequestForUser } from "@/db/queries/onboarding"
 import { RegisterForm } from "./register-form"
 
@@ -20,12 +21,15 @@ export default async function UnclaimedPage() {
   if (!user) redirect("/login")
   if (!isUnbound(user)) redirect("/dashboard")
 
+  // Without this the "unplaced" persona is a trap: you land here, the shell has
+  // no switcher, and the only way back is deleting a cookie by hand.
+  const devAuth = await devAuthProps()
   const req = await getLatestRequestForUser(user.id)
   const showForm = !req || req.status === "rejected"
 
   return (
     <SidebarProvider>
-      <AppSidebar />
+      <AppSidebar devAuth={devAuth} />
       <SidebarInset>
         <div className="flex min-h-svh items-center justify-center p-6">
           <div className="w-full max-w-md">

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -40,12 +40,21 @@ import { buildNavigation } from "@/lib/navigation"
 import { openCommandPalette } from "@/components/command-palette"
 import { SearchIcon } from "lucide-react"
 import { VossMark } from "@/components/voss-logo"
+import { DevActorSwitcher } from "@/components/dev-actor-switcher"
+import type { DevPersona } from "@/lib/dev-personas"
 
 // MVP surface only: roster and identity. Marks / attendance / courses come back
 // with the features that own them, each adding its own nav.
 // Super-admin also gets the console — the door to every CRUD.
 // Coordinators/TRs own their classes: approve enrolments, manage the roster.
-export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+export function AppSidebar({
+  devAuth,
+  ...props
+}: React.ComponentProps<typeof Sidebar> & {
+  // Resolved on the server, because the flag that enables it is not public. Null
+  // in every deployed environment, and then nothing below ships to the client.
+  devAuth?: { personas: DevPersona[]; current: string | null } | null
+}) {
   // Server-resolved, so the first paint already knows who this is. Reading it
   // from the session hook meant rendering "User" until a fetch returned, which
   // is what produced the identity flicker and the hydration mismatch.
@@ -90,6 +99,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>
+        {devAuth && (
+          <DevActorSwitcher
+            personas={devAuth.personas}
+            current={devAuth.current}
+          />
+        )}
       </SidebarHeader>
       <SidebarContent>
         <SidebarMenu className="px-2">

--- a/src/components/dev-actor-switcher.tsx
+++ b/src/components/dev-actor-switcher.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import { useTransition } from "react"
+import { CheckIcon, ChevronsUpDownIcon, FlaskConicalIcon } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar"
+import type { DevPersona } from "@/lib/dev-personas"
+import { setDevActor } from "@/lib/dev-auth-actions"
+
+/**
+ * Who you are, locally, without signing in.
+ *
+ * Rendered only when the server says impersonation is on, which is why this
+ * takes its personas as a prop rather than importing them: with the gate off,
+ * nothing here reaches the client bundle at all.
+ *
+ * Deliberately does not look like the rest of the product. A dashed border and
+ * a flask are there so that a screenshot taken from a contributor's laptop is
+ * never mistaken for the real application, and so nobody spends an afternoon
+ * looking for this control in production.
+ */
+export function DevActorSwitcher({
+  personas,
+  current,
+}: {
+  personas: DevPersona[]
+  current: string | null
+}) {
+  const [pending, start] = useTransition()
+  const active = personas.find((p) => p.key === current) ?? null
+
+  const choose = (key: string | null) => start(() => void setDevActor(key))
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <SidebarMenuButton
+                size="lg"
+                disabled={pending}
+                className="border-attention/50 hover:bg-attention/5 border border-dashed"
+              />
+            }
+          >
+            <div className="text-attention flex aspect-square size-8 items-center justify-center rounded-md border border-dashed">
+              <FlaskConicalIcon className="size-4" />
+            </div>
+            <div className="grid flex-1 text-left leading-tight">
+              <span className="truncate text-xs font-semibold">
+                {active ? active.name : "Not signed in"}
+              </span>
+              <span className="text-muted-foreground truncate text-xs">
+                {active ? active.role : "Pick someone to become"}
+              </span>
+            </div>
+            <ChevronsUpDownIcon className="ml-auto size-4 shrink-0 opacity-50" />
+          </DropdownMenuTrigger>
+
+          <DropdownMenuContent
+            align="start"
+            side="bottom"
+            sideOffset={4}
+            className="w-(--radix-dropdown-menu-trigger-width) min-w-72"
+          >
+            <DropdownMenuLabel className="text-muted-foreground text-xs font-normal">
+              Development only. Authentication is bypassed; every permission
+              below is resolved from the database exactly as in production.
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+
+            {personas.map((p) => (
+              <DropdownMenuItem
+                key={p.key}
+                onClick={() => choose(p.key)}
+                className="gap-2"
+              >
+                <div className="grid flex-1 leading-tight">
+                  <span className="text-sm font-medium">
+                    {p.name}
+                    <span className="text-muted-foreground ml-1.5 text-xs font-normal">
+                      {p.role}
+                    </span>
+                  </span>
+                  <span className="text-muted-foreground text-xs">
+                    {p.scope}
+                  </span>
+                </div>
+                {p.key === current && (
+                  <CheckIcon className="size-4 shrink-0" aria-hidden="true" />
+                )}
+                {p.key === current && <span className="sr-only">selected</span>}
+              </DropdownMenuItem>
+            ))}
+
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={() => choose(null)}
+              className="text-muted-foreground text-xs"
+            >
+              Sign out — fall back to the real VOSS login
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}

--- a/src/db/driver.ts
+++ b/src/db/driver.ts
@@ -1,0 +1,33 @@
+// Which Postgres driver this connection string needs.
+//
+// Production runs on Neon over HTTP: stateless, no connection to hold open, and
+// the right shape for a serverless deploy. That driver speaks Neon's HTTP
+// endpoint, not the Postgres wire protocol, so it cannot talk to a Postgres in
+// a container — which is what a contributor has, and why local development
+// previously needed a Neon account for a database nobody else would ever read.
+//
+// The rule is deliberately conservative: Neon unless the host is unmistakably a
+// local one. Sniffing for ".neon.tech" instead would silently change the driver
+// under anyone self-hosting, and a production deploy is not the place to
+// discover a driver swap.
+
+const LOCAL_HOSTS = new Set([
+  "localhost",
+  "127.0.0.1",
+  "::1",
+  "0.0.0.0",
+  "host.docker.internal",
+  // The service name inside docker-compose, for running the app in a container.
+  "postgres",
+  "db",
+])
+
+export function isLocalPostgres(url: string): boolean {
+  if (process.env.DATABASE_DRIVER === "pg") return true
+  if (process.env.DATABASE_DRIVER === "neon") return false
+  try {
+    return LOCAL_HOSTS.has(new URL(url).hostname)
+  } catch {
+    return false
+  }
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,19 +1,39 @@
 import { neon } from "@neondatabase/serverless"
-import { drizzle, NeonHttpDatabase } from "drizzle-orm/neon-http"
+import { drizzle } from "drizzle-orm/neon-http"
+import type { NeonHttpDatabase } from "drizzle-orm/neon-http"
+import { isLocalPostgres } from "./driver"
 import * as schema from "./schema"
 
-let _db: NeonHttpDatabase<typeof schema> | null = null
+// Typed as the Neon database because that is what production is. The local
+// driver is API-compatible for everything this codebase does — the one real
+// difference is that node-postgres supports transactions and neon-http does
+// not, so code written against local must still never assume them, or it will
+// work for the contributor and fail in production.
+type Db = NeonHttpDatabase<typeof schema>
 
-function getDb() {
-  if (!_db) {
-    const url = process.env.DATABASE_URL
-    if (!url) throw new Error("DATABASE_URL is not set")
-    _db = drizzle(neon(url), { schema })
+let _db: Db | null = null
+
+function getDb(): Db {
+  if (_db) return _db
+  const url = process.env.DATABASE_URL
+  if (!url) throw new Error("DATABASE_URL is not set")
+
+  if (isLocalPostgres(url)) {
+    // Required lazily: production never evaluates this branch, and a top-level
+    // import would pull the driver into every server bundle to be unused.
+    /* eslint-disable @typescript-eslint/no-require-imports */
+    const { Pool } = require("pg")
+    const { drizzle: pgDrizzle } = require("drizzle-orm/node-postgres")
+    /* eslint-enable @typescript-eslint/no-require-imports */
+    _db = pgDrizzle(new Pool({ connectionString: url }), { schema }) as Db
+    return _db
   }
+
+  _db = drizzle(neon(url), { schema })
   return _db
 }
 
-export const db = new Proxy({} as NeonHttpDatabase<typeof schema>, {
+export const db = new Proxy({} as Db, {
   get(_target, prop) {
     return (getDb() as unknown as Record<string | symbol, unknown>)[prop]
   },

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,12 +1,29 @@
 import { config } from "dotenv"
 config({ path: ".env.local" })
 
-import { Pool, neonConfig } from "@neondatabase/serverless"
-import ws from "ws"
 import * as fs from "fs"
 import * as path from "path"
+import { isLocalPostgres } from "./driver"
 
-neonConfig.webSocketConstructor = ws
+// A local container speaks the Postgres wire protocol and the Neon driver does
+// not, so the local case needs node-postgres. The hosted case is left on the
+// exact client it has always used: this script migrates production, and a
+// driver swap there would be a change nobody asked for riding along with a
+// developer-experience one.
+function makePool(url: string) {
+  if (isLocalPostgres(url)) {
+    /* eslint-disable @typescript-eslint/no-require-imports */
+    const { Pool: PgPool } = require("pg")
+    /* eslint-enable @typescript-eslint/no-require-imports */
+    return new PgPool({ connectionString: url })
+  }
+  /* eslint-disable @typescript-eslint/no-require-imports */
+  const { Pool: NeonPool, neonConfig } = require("@neondatabase/serverless")
+  const ws = require("ws")
+  /* eslint-enable @typescript-eslint/no-require-imports */
+  neonConfig.webSocketConstructor = ws
+  return new NeonPool({ connectionString: url })
+}
 
 const MIGRATIONS_DIR = path.join(__dirname, "migrations")
 
@@ -17,7 +34,7 @@ async function run() {
     process.exit(1)
   }
 
-  const pool = new Pool({ connectionString: url })
+  const pool = makePool(url)
 
   await pool.query(`
     CREATE TABLE IF NOT EXISTS _migrations (
@@ -30,7 +47,9 @@ async function run() {
   const { rows: applied } = await pool.query(
     "SELECT filename FROM _migrations ORDER BY filename"
   )
-  const appliedSet = new Set(applied.map((r) => r.filename))
+  const appliedSet = new Set(
+    applied.map((r: { filename: string }) => r.filename)
+  )
 
   // A fresh checkout can have no migrations at all — that is a valid state, not
   // a crash. drizzle-kit push carries the schema; these files carry the rest.
@@ -42,6 +61,24 @@ async function run() {
     : []
 
   const pending = files.filter((f) => !appliedSet.has(f))
+
+  // `drizzle-kit push` builds the whole current schema in one step, so a
+  // database created that way is already at head and these files would be
+  // re-applying what is there. Baselining records them as done without running
+  // them — which is what a fresh local database wants, and what lets a
+  // migration written tomorrow still run normally.
+  if (process.argv.includes("--baseline")) {
+    for (const file of pending) {
+      await pool.query("INSERT INTO _migrations (filename) VALUES ($1)", [file])
+    }
+    console.log(
+      pending.length === 0
+        ? "Already baselined."
+        : `Baselined ${pending.length} migration(s) against the pushed schema.`
+    )
+    await pool.end()
+    return
+  }
 
   if (pending.length === 0) {
     console.log("No pending migrations.")

--- a/src/db/migrations/0006_marks_range_constraints.sql
+++ b/src/db/migrations/0006_marks_range_constraints.sql
@@ -1,21 +1,28 @@
--- Marks must be non-negative. The application now validates against each
--- course's own maxima, which the database cannot see from this table -- but
--- "not negative" is true of every component of every course, and it is the
--- half that turns a silently wrong average into a rejected write.
+-- Marks must be non-negative. The application validates against each course's
+-- own maxima, which the database cannot see from this table -- but "not
+-- negative" is true of every component of every course, and it is the half that
+-- turns a silently wrong average into a rejected write.
 --
--- Applied as NOT VALID first so an existing bad row cannot block the deploy,
--- then validated: the constraint binds all new writes immediately either way.
+-- Guarded rather than bare: `drizzle-kit push` builds the schema from
+-- src/db/schema, which now declares these, so a freshly pushed database arrives
+-- here with them already present. A migration that cannot run twice is a
+-- migration that breaks every new environment.
 
-ALTER TABLE marks
-  ADD CONSTRAINT marks_isa_non_negative CHECK (isa IS NULL OR isa >= 0) NOT VALID;
-ALTER TABLE marks
-  ADD CONSTRAINT marks_mse1_non_negative CHECK (mse1 IS NULL OR mse1 >= 0) NOT VALID;
-ALTER TABLE marks
-  ADD CONSTRAINT marks_mse2_non_negative CHECK (mse2 IS NULL OR mse2 >= 0) NOT VALID;
-ALTER TABLE marks
-  ADD CONSTRAINT marks_ese_non_negative CHECK (ese IS NULL OR ese >= 0) NOT VALID;
-
-ALTER TABLE marks VALIDATE CONSTRAINT marks_isa_non_negative;
-ALTER TABLE marks VALIDATE CONSTRAINT marks_mse1_non_negative;
-ALTER TABLE marks VALIDATE CONSTRAINT marks_mse2_non_negative;
-ALTER TABLE marks VALIDATE CONSTRAINT marks_ese_non_negative;
+DO $$
+DECLARE
+  col TEXT;
+BEGIN
+  FOREACH col IN ARRAY ARRAY['isa', 'mse1', 'mse2', 'ese'] LOOP
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conrelid = 'marks'::regclass
+        AND conname = format('marks_%s_non_negative', col)
+    ) THEN
+      EXECUTE format(
+        'ALTER TABLE marks ADD CONSTRAINT marks_%1$s_non_negative
+         CHECK (%1$I IS NULL OR %1$I >= 0) NOT VALID', col
+      );
+      EXECUTE format('ALTER TABLE marks VALIDATE CONSTRAINT marks_%s_non_negative', col);
+    END IF;
+  END LOOP;
+END $$;

--- a/src/lib/dev-auth-actions.ts
+++ b/src/lib/dev-auth-actions.ts
@@ -1,0 +1,35 @@
+"use server"
+
+import { cookies } from "next/headers"
+import { revalidatePath } from "next/cache"
+import { DEV_ACTOR_COOKIE, devAuthEnabled } from "@/lib/dev-auth"
+import { findPersona } from "@/lib/dev-personas"
+
+/**
+ * Become one of the seeded personas, or stop being anybody.
+ *
+ * The gate is re-checked here and not only where the switcher renders. Hiding a
+ * control is a decision about the UI; this is a server action, and a server
+ * action is reachable by anyone who can post to the app. If the environment
+ * does not permit impersonation, this does nothing at all.
+ */
+export async function setDevActor(key: string | null) {
+  if (!devAuthEnabled()) return
+
+  const jar = await cookies()
+  if (key === null) {
+    jar.delete(DEV_ACTOR_COOKIE)
+  } else {
+    // Only a known persona: the cookie is input, and "become any email" is a
+    // larger hole than this needs to be even on a laptop.
+    if (!findPersona(key)) return
+    jar.set(DEV_ACTOR_COOKIE, key, {
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/",
+      // Deliberately a session cookie. Closing the browser forgets who you
+      // were, which is the right default for something that is not a login.
+    })
+  }
+  revalidatePath("/", "layout")
+}

--- a/src/lib/dev-auth-gate.ts
+++ b/src/lib/dev-auth-gate.ts
@@ -1,0 +1,29 @@
+// The gate on its own, importing nothing.
+//
+// Split out because the proxy (Next's middleware) has to ask the same question
+// as the server does, and it cannot import the module that answers it: that one
+// reaches for the database and for next/headers, neither of which exists in the
+// proxy runtime. Two copies of a condition that decides whether authentication
+// can be bypassed is exactly the drift worth preventing, so the condition lives
+// here alone and both sides import it.
+
+export const DEV_ACTOR_COOKIE = "verp_dev_actor"
+
+/**
+ * Whether impersonation is available at all.
+ *
+ * Three independent locks guard this feature; two of them are here. NODE_ENV
+ * must not be "production" — `next build` and `next start` both set it, so a
+ * deployed bundle fails regardless of configuration — and VERP_DEV_AUTH must be
+ * exactly "1", which nothing sets by accident. The third lock is in
+ * next.config.ts, which refuses to build at all when both are present.
+ *
+ * A function rather than a module constant: a constant is captured once at
+ * import, which makes it easy to test something that is not what the running
+ * process would actually do.
+ */
+export function devAuthEnabled(): boolean {
+  return (
+    process.env.NODE_ENV !== "production" && process.env.VERP_DEV_AUTH === "1"
+  )
+}

--- a/src/lib/dev-auth.test.ts
+++ b/src/lib/dev-auth.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { devAuthEnabled } from "./dev-auth"
+import { DEV_PERSONAS, findPersona } from "./dev-personas"
+
+// process.env.NODE_ENV is readonly in the types but writable at runtime, which
+// is exactly what has to be exercised: the question is what the gate does in a
+// process that thinks it is production.
+const setEnv = (nodeEnv: string, flag: string | undefined) => {
+  vi.stubEnv("NODE_ENV", nodeEnv)
+  if (flag === undefined) vi.stubEnv("VERP_DEV_AUTH", "")
+  else vi.stubEnv("VERP_DEV_AUTH", flag)
+}
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe("devAuthEnabled", () => {
+  // The one that matters. Everything else is convenience; this is the reason
+  // the feature is allowed to exist.
+  it("is off in production even with the flag explicitly set", () => {
+    setEnv("production", "1")
+    expect(devAuthEnabled()).toBe(false)
+  })
+
+  it("is off in development until the flag is set", () => {
+    setEnv("development", undefined)
+    expect(devAuthEnabled()).toBe(false)
+  })
+
+  it("is on only for development with the flag set to exactly 1", () => {
+    setEnv("development", "1")
+    expect(devAuthEnabled()).toBe(true)
+  })
+
+  // "true", "yes" and "0" are all things somebody would plausibly type, and
+  // none of them should turn an authentication bypass on by accident.
+  it.each(["true", "yes", "0", "on", " 1"])(
+    "does not accept %o as the flag",
+    (value) => {
+      setEnv("development", value)
+      expect(devAuthEnabled()).toBe(false)
+    }
+  )
+
+  it("is off in test runs unless asked for", () => {
+    setEnv("test", undefined)
+    expect(devAuthEnabled()).toBe(false)
+  })
+})
+
+describe("findPersona", () => {
+  // The cookie is input. Resolving it against the fixed list is what stops it
+  // naming an arbitrary address.
+  it("refuses anything that is not a seeded persona", () => {
+    expect(findPersona("admin' OR 1=1")).toBeNull()
+    expect(findPersona("dev.admin@vit.edu.in")).toBeNull()
+    expect(findPersona("")).toBeNull()
+    expect(findPersona(undefined)).toBeNull()
+  })
+
+  it("resolves each seeded persona", () => {
+    for (const p of DEV_PERSONAS) {
+      expect(findPersona(p.key)?.email).toBe(p.email)
+    }
+  })
+
+  it("keeps persona keys and emails unique", () => {
+    expect(new Set(DEV_PERSONAS.map((p) => p.key)).size).toBe(
+      DEV_PERSONAS.length
+    )
+    expect(new Set(DEV_PERSONAS.map((p) => p.email)).size).toBe(
+      DEV_PERSONAS.length
+    )
+  })
+})

--- a/src/lib/dev-auth.ts
+++ b/src/lib/dev-auth.ts
@@ -1,0 +1,100 @@
+// Signing in as somebody without signing in.
+//
+// A contributor cannot register VERP as a VOSS client, so before this the only
+// way to see any authenticated screen was to hold production OAuth credentials.
+// That is why the setup instructions had been unfollowable: the app ran, and
+// then redirected you to a login you could not complete.
+//
+// ── What is bypassed, and what is not ────────────────────────────────────
+//
+// AUTHENTICATION only. getSessionUser() takes four fields from Better Auth —
+// id, name, email, image — and resolves tier, department and class scope, and
+// the whole capability set from the database. This substitutes those four
+// fields and nothing else, so every authorization rule downstream runs exactly
+// as it does in production, against real rows. Switching to the HOD of EXTC
+// does not grant EXTC: it becomes a user whose faculty row says so, and the
+// same query decides the rest.
+//
+// That distinction is the point. A mock that returned a fabricated capability
+// set would let a contributor "test RBAC" against a fiction and ship a change
+// that fails the moment it meets a real session.
+//
+// ── Why this cannot reach production ─────────────────────────────────────
+//
+// Three independent locks, any one of which is sufficient:
+//
+//   1. NODE_ENV must not be "production". `next build` and `next start` both
+//      set it, so a deployed bundle fails here regardless of configuration.
+//   2. VERP_DEV_AUTH must be exactly "1". Absent by default; no deployment
+//      sets it by accident.
+//   3. next.config.ts refuses to BUILD when both a production build and this
+//      flag are present, so the artifact cannot be produced in the first place.
+//
+// The order matters: NODE_ENV is read first and is not something a .env file in
+// a deployment can talk its way past.
+
+import { cookies } from "next/headers"
+import { eq } from "drizzle-orm"
+import { db } from "@/db"
+import * as schema from "@/db/schema"
+import { DEV_PERSONAS, findPersona } from "@/lib/dev-personas"
+import { DEV_ACTOR_COOKIE, devAuthEnabled } from "@/lib/dev-auth-gate"
+
+export { DEV_ACTOR_COOKIE, devAuthEnabled } from "@/lib/dev-auth-gate"
+
+export type DevIdentity = {
+  id: string
+  name: string
+  email: string
+  image: string | null
+}
+
+/**
+ * The identity the dev cookie names, or null to fall through to real auth.
+ *
+ * Null on every uncertainty — gate off, no cookie, unknown persona, or no such
+ * user row — because falling through lands on the real login, which is a
+ * correct outcome. Inventing a session here would be the failure mode this
+ * whole file is trying to avoid.
+ */
+export async function devIdentity(): Promise<DevIdentity | null> {
+  if (!devAuthEnabled()) return null
+
+  const key = (await cookies()).get(DEV_ACTOR_COOKIE)?.value
+  // Only the seeded personas, never an arbitrary email from the cookie. The
+  // cookie is attacker-controlled input even locally, and "become any address"
+  // is a bigger hole than this needs to be.
+  const persona = findPersona(key)
+  if (!persona) return null
+
+  const row = await db.query.user.findFirst({
+    where: eq(schema.user.email, persona.email),
+    columns: { id: true, name: true, email: true, image: true },
+  })
+  if (!row) return null
+
+  return {
+    id: row.id,
+    name: row.name,
+    email: row.email,
+    image: row.image ?? null,
+  }
+}
+
+/**
+ * What the sidebar needs to render the switcher, or null to render nothing.
+ *
+ * Every shell that mounts AppSidebar asks this rather than reading the flag
+ * itself: a second copy of the condition is a second place for it to be wrong,
+ * and being wrong here means shipping an impersonation control.
+ */
+export async function devAuthProps(): Promise<{
+  personas: typeof DEV_PERSONAS
+  current: string | null
+} | null> {
+  if (!devAuthEnabled()) return null
+  return {
+    personas: DEV_PERSONAS,
+    current: (await cookies()).get(DEV_ACTOR_COOKIE)?.value ?? null,
+  }
+}

--- a/src/lib/dev-personas.ts
+++ b/src/lib/dev-personas.ts
@@ -1,0 +1,109 @@
+// The people the local development database contains.
+//
+// One definition, read by both the seeder that creates these rows and the
+// switcher that lets you become them. They are the same list on purpose: a
+// persona the switcher offers but the seed never created is a dead menu entry,
+// and that is exactly the drift a second list produces.
+//
+// Chosen to make the authorization rules visible rather than to look like a
+// real college. Two departments so cross-department isolation can be seen
+// failing; two teachers on one class so "that subject is allocated to another
+// teacher" can be reached; a coordinator distinct from the teachers so the
+// decisions that belong to the coordinator can be told apart from the ones that
+// do not.
+
+export type DevPersona = {
+  /** Cookie value, and the switcher's stable key. */
+  key: string
+  /** Resolved to a real `user` row, which is where the impersonation ends. */
+  email: string
+  name: string
+  /** What this person is, in the college's words. */
+  role: string
+  /** The scope that makes them interesting to test. */
+  scope: string
+}
+
+export const DEV_CLASS_A = "2023-108-A"
+export const DEV_CLASS_B = "2023-108-B"
+export const DEV_CLASS_EXTC = "2024-104-A"
+
+export const DEV_PERSONAS: DevPersona[] = [
+  {
+    key: "admin",
+    email: "dev.admin@vit.edu.in",
+    name: "Asha Deshpande",
+    role: "Super-admin",
+    scope: "The whole institution",
+  },
+  {
+    key: "hod-excs",
+    email: "dev.hod.excs@vit.edu.in",
+    name: "Ravi Kulkarni",
+    role: "HOD",
+    scope: "EXCS — two classes, cover authority",
+  },
+  {
+    key: "hod-extc",
+    email: "dev.hod.extc@vit.edu.in",
+    name: "Sunita Rane",
+    role: "HOD",
+    scope: "EXTC — nothing in EXCS is visible",
+  },
+  {
+    key: "coordinator",
+    email: "dev.coordinator@vit.edu.in",
+    name: "Priya Nair",
+    role: "Coordinator",
+    scope: "BE EXCS A — publishes, decides enrolment",
+  },
+  {
+    key: "teacher-dav",
+    email: "dev.teacher.dav@vit.edu.in",
+    name: "Mandar Patil",
+    role: "Teacher",
+    scope: "BE EXCS A — Data Analytics only",
+  },
+  {
+    key: "teacher-cn",
+    email: "dev.teacher.cn@vit.edu.in",
+    name: "Kavita Joshi",
+    role: "Teacher",
+    scope: "BE EXCS A — Computer Networks only",
+  },
+  {
+    key: "teacher-b",
+    email: "dev.teacher.b@vit.edu.in",
+    name: "Imran Shaikh",
+    role: "Teacher",
+    scope: "BE EXCS B — a different division",
+  },
+  {
+    key: "student",
+    email: "dev.student@vit.edu.in",
+    name: "Neha Bhosale",
+    role: "Student",
+    scope: "23108A0001 — has published results",
+  },
+  {
+    key: "student-fresh",
+    email: "dev.student.fresh@vit.edu.in",
+    name: "Omkar Sawant",
+    role: "Student",
+    scope: "23108A0002 — nothing published yet",
+  },
+  {
+    // Signed in, on no roster: the pending screen, which is easy to forget
+    // exists and easy to break.
+    key: "unbound",
+    email: "dev.unbound@vit.edu.in",
+    name: "Rohit Gaikwad",
+    role: "Unplaced",
+    scope: "Authenticated but on no roster",
+  },
+]
+
+export function findPersona(key: string | undefined): DevPersona | null {
+  if (!key) return null
+  return DEV_PERSONAS.find((p) => p.key === key) ?? null
+}

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,6 +1,7 @@
 import { headers } from "next/headers"
 import { and, eq, or } from "drizzle-orm"
 import { auth } from "@/lib/auth"
+import { devIdentity } from "@/lib/dev-auth"
 import { db } from "@/db"
 import * as schema from "@/db/schema"
 import {
@@ -25,6 +26,17 @@ const SUPER_ADMIN_EMAILS = (process.env.SUPER_ADMIN_EMAILS ?? "")
  * code defaults overlaid with the super-admin's permission_overrides — super_admin
  * carries an empty set because `can()` short-circuits it to allow-all.
  */
+async function realIdentity() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session?.user) return null
+  return {
+    id: session.user.id,
+    name: session.user.name,
+    email: session.user.email,
+    image: session.user.image ?? null,
+  }
+}
+
 export type SessionUser = {
   id: string
   name: string
@@ -82,16 +94,21 @@ async function capabilitiesFor(
 }
 
 export async function getSessionUser(): Promise<SessionUser | null> {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session?.user) return null
+  // Local development can name the actor with a cookie instead of completing an
+  // OAuth handshake nobody outside VOSS can complete. It substitutes these four
+  // fields and nothing else — every line below this point is the production
+  // path, resolving tier, scope and capabilities from real rows. See
+  // lib/dev-auth.ts for the three locks that keep it out of a deployed build.
+  const identity = (await devIdentity()) ?? (await realIdentity())
+  if (!identity) return null
 
-  const userId = session.user.id
-  const email = session.user.email.toLowerCase()
+  const userId = identity.id
+  const email = identity.email.toLowerCase()
   const base = {
     id: userId,
-    name: session.user.name,
-    email: session.user.email,
-    image: session.user.image ?? null,
+    name: identity.name,
+    email: identity.email,
+    image: identity.image,
   }
   const empty = {
     deptCodes: [] as string[],

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getSessionCookie } from "better-auth/cookies"
+import { DEV_ACTOR_COOKIE, devAuthEnabled } from "@/lib/dev-auth-gate"
 
 const publicRoutes = ["/login", "/api/auth"]
 
@@ -9,9 +10,19 @@ export function proxy(request: NextRequest) {
 
   if (isPublic) return NextResponse.next()
 
+  // Locally, the dev switcher's cookie is what stands in for a session. Without
+  // this the proxy turns every route into a redirect before any of it is
+  // reached, and the switcher looks broken rather than blocked.
+  //
+  // This decides only whether to let the request THROUGH. Who the caller is,
+  // and what they may do, is still resolved from the database further in — the
+  // proxy has never been the thing that answers that.
+  const devActor =
+    devAuthEnabled() && request.cookies.get(DEV_ACTOR_COOKIE)?.value
+
   const session = getSessionCookie(request)
 
-  if (!session) {
+  if (!session && !devActor) {
     return NextResponse.redirect(new URL("/login", request.url))
   }
 


### PR DESCRIPTION
## The problem

VERP authenticates through VOSS, and a contributor cannot register a VOSS client. The app ran, then redirected them to a login they had no way to complete. That is why the setup instructions have been unfollowable — through no fault of anyone following them.

```bash
npm install && npm run dev:setup && npm run dev
```

A Postgres container, the schema, and a college's worth of mock data. Then you pick who you are from a switcher beside the VOSS mark: super-admin, either HOD, the coordinator, three teachers, two students, or somebody authenticated but on no roster.

## The permissions stay real

This is the part worth reviewing carefully.

`getSessionUser()` takes four fields from the identity provider — id, name, email, image — and resolves tier, department and class scope, and the whole capability set **from the database**. The switcher substitutes those four fields and nothing else.

So becoming the HOD of EXTC does not *grant* EXTC. It becomes a person whose faculty row says so, and the same queries decide the rest. A mock that returned a fabricated capability set would let somebody test against a fiction and ship a change that fails the first time it meets a real session.

Measured on the seeded data — the roster each persona can actually read:

```
admin          1736     every student
hod-excs        509     EXCS only
hod-extc        503     EXTC only
coordinator      62     one class
teacher-dav      62     one class
unplaced          0
```

509 + 503 + 724 = 1736, no overlap.

## Three locks on the bypass, any one sufficient

1. `NODE_ENV` must not be `production` — both `next build` and `next start` set it.
2. `VERP_DEV_AUTH` must be exactly `"1"`. `"true"`, `"yes"`, `"0"` are rejected, with tests.
3. `next.config.ts` refuses to build **or start** when both are present.

Verified, not asserted. Production build with the flag set:

```
Error: VERP_DEV_AUTH is set for a production build. It bypasses sign-in and
must never be present in a deployed environment — unset it and rebuild.
```

Production build **without** it, handed a valid persona cookie:

```
admin        -> 307 /login
student      -> 307 /login
coordinator  -> 307 /login
login offers dev sign-in: 0
```

The gate compiles out entirely — `VERP_DEV_AUTH` appears nowhere in the production bundle. The switcher component itself is still emitted but is unreachable, since the server gate that supplies its props returns null.

## Production is otherwise untouched

- The app selects `node-postgres` **only** for a local host and stays on `neon-http` everywhere else; `pg` is declared in `serverExternalPackages` so it is not bundled.
- The migration runner keeps the **exact Neon client it had** for hosted databases. This script migrates production, and a driver swap there is not something to carry along with a developer-experience change. Verified against the live database: 6/6 applied, unchanged.
- The seeder refuses any host that is not local, because everything it does begins by deleting rows.

## The data

~1,700 students across three departments and all four year-cohorts, so filters, search, pagination and the scoped queries behave the way they will in front of a real roster.

**BE EXCS A** is wired end to end: `EC33T` published, `EC34T` at ISA only (provisional / "In progress"), `EC35T` with no teacher, an untouched lab, today's register deliberately not taken, a pending enrolment request, and one student below the 75% rule. Two teachers hold different subjects on that one class so "that subject is allocated to another teacher" is reachable rather than theoretical.

## Two things found by actually running it

**`src/proxy.ts` — Next 16's middleware — gates every route on a Better Auth cookie.** Nothing downstream was reachable until it learned about the dev one. This also corrects the record on #6, which I closed saying VERP has no middleware. It does; I searched for `middleware.ts` and Next 16 renamed it. I'll post a correction on that issue.

**Migration 0006 could not run on a fresh database.** `drizzle-kit push` builds the schema from `src/db/schema`, which declares those CHECK constraints, so a pushed database reached the migration with them already present and it failed on `MergeWithExistingConstraint`. It is now guarded, and `dev:setup` baselines the ledger rather than replaying changes the push already contains — so this was broken for *any* new environment, not just this one.

## Checks

`npm run check` — typecheck, lint (2 pre-existing warnings), format, **157 tests** (12 new on the gate). `npm run build` compiled. End-to-end verified on OrbStack: container, push, baseline, seed, seed again (idempotent), all ten personas resolving, and the scope table above.