### PR TITLE
fix(dev): refuse to set up against anything but the local container

### DIFF
--- a/scripts/dev-setup.ts
+++ b/scripts/dev-setup.ts
@@ -6,9 +6,63 @@
 // yet fails in a way that reads like a broken migration.
 
 import { execSync, spawnSync } from "node:child_process"
-import { existsSync, copyFileSync } from "node:fs"
+import { existsSync, copyFileSync, readFileSync } from "node:fs"
+import { isLocalPostgres } from "../src/db/driver"
 
-const step = (n: number, msg: string) => console.log(`\n[${n}/4] ${msg}`)
+const step = (n: number, msg: string) => console.log(`\n[${n}/5] ${msg}`)
+
+/**
+ * Refuse to touch anything that is not the local container.
+ *
+ * This runs before the schema push, and that ordering is the whole point. The
+ * seeder had this check and the push did not, so a run against a leftover
+ * production .env.local sailed through `drizzle-kit push --force` -- which
+ * TRUNCATES a table to add a unique constraint -- and only stopped at the last
+ * step, after the damage. A guard that fires after the destructive step is not
+ * a guard.
+ */
+function assertLocal(env: Record<string, string>) {
+  const targets: [string, string][] = [
+    ["DATABASE_URL", env.DATABASE_URL ?? ""],
+    ["DIRECT_URL", env.DIRECT_URL ?? env.DATABASE_URL ?? ""],
+  ]
+  const remote = targets.filter(([, url]) => url && !isLocalPostgres(url))
+  if (remote.length === 0) return
+
+  console.error("\n  Refusing to continue.\n")
+  for (const [name, url] of remote) {
+    let host = url
+    try {
+      host = new URL(url).hostname
+    } catch {}
+    console.error(`    ${name} points at ${host}`)
+  }
+  console.error(`
+  This command pushes a schema and rewrites data, and only ever runs against
+  the local container. Your .env.local is pointed somewhere else -- most
+  likely it is a real environment you were using earlier.
+
+  To set up the local database, move that file aside first:
+
+    mv .env.local .env.local.remote
+    npm run dev:setup
+
+  and put it back when you need the hosted one again.
+`)
+  process.exit(1)
+}
+
+/** The env this run will actually use, read the way dotenv would. */
+function readEnvLocal(): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (!existsSync(".env.local")) return out
+  for (const line of readFileSync(".env.local", "utf-8").split("\n")) {
+    const m = /^\s*([A-Z0-9_]+)\s*=\s*(.*)$/.exec(line)
+    if (!m) continue
+    out[m[1]] = m[2].trim().replace(/^["']|["']$/g, "")
+  }
+  return out
+}
 
 function run(cmd: string, args: string[]) {
   const r = spawnSync(cmd, args, {
@@ -46,7 +100,11 @@ async function main() {
     console.log("  .env.local already exists, leaving it alone")
   }
 
-  step(2, "database container")
+  step(2, "checking the target is local")
+  assertLocal(readEnvLocal())
+  console.log("  local container, safe to proceed")
+
+  step(3, "database container")
   const [bin, ...sub] = compose()
   run(bin, [...sub, "up", "-d"])
 
@@ -79,14 +137,14 @@ async function main() {
   }
   console.log(" ready")
 
-  step(3, "schema")
+  step(4, "schema")
   // push builds the whole current schema; --baseline then records the
   // migration files as applied rather than replaying changes the push already
   // contains. Any migration written after this point runs normally.
   run("npx", ["drizzle-kit", "push", "--force"])
   run("npx", ["tsx", "src/db/migrate.ts", "--baseline"])
 
-  step(4, "mock data")
+  step(5, "mock data")
   run("npx", ["tsx", "scripts/seed-dev.ts"])
 
   console.log(`

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -68,6 +68,17 @@ async function run() {
   // them — which is what a fresh local database wants, and what lets a
   // migration written tomorrow still run normally.
   if (process.argv.includes("--baseline")) {
+    // Same rule as the seeder: this rewrites the migration ledger, and doing
+    // that to a hosted database would tell it changes had been applied that
+    // never ran.
+    if (!isLocalPostgres(url)) {
+      console.error(
+        `Refusing to baseline ${new URL(url).hostname} — --baseline is for a ` +
+          "freshly pushed local database only."
+      )
+      await pool.end()
+      process.exit(1)
+    }
     for (const file of pending) {
       await pool.query("INSERT INTO _migrations (filename) VALUES ($1)", [file])
     }


### PR DESCRIPTION
## What happened

`npm run dev:setup` checked the target database only at its **last** step, the seeder. Everything before it ran unguarded — and `drizzle-kit push --force` truncates a table to add a unique constraint.

Run against a leftover hosted `.env.local`, it therefore:

1. started the container ✓
2. pushed the schema **to the hosted database**, truncating `course_offerings` (1 row) and `marks` (89 rows) to add `offering_course_class_sem_uniq` and `marks_offering_student_uniq`
3. rewrote that database's migration ledger
4. stopped politely at the seeder — with the damage already done

A guard that fires after the destructive step is not a guard. That is the bug.

## The fix

The check runs **before anything touches a database**, reads `.env.local` directly rather than trusting the process environment, and names the host it is refusing:

```
[2/5] checking the target is local

  Refusing to continue.

    DATABASE_URL points at ep-...-pooler.c-9.us-east-1.aws.neon.tech
    DIRECT_URL points at ep-....c-9.us-east-1.aws.neon.tech

  This command pushes a schema and rewrites data, and only ever runs against
  the local container. Your .env.local is pointed somewhere else -- most
  likely it is a real environment you were using earlier.

  To set up the local database, move that file aside first:

    mv .env.local .env.local.remote
    npm run dev:setup

  and put it back when you need the hosted one again.
```

`--baseline` takes the same rule: it rewrites the migration ledger, and doing that to a hosted database would record changes as applied that never ran.

The message says what to *do*, not only what went wrong — the person hitting this had a working environment configured a moment ago and needs it back.

## Verified

Run against a hosted `.env.local`: refuses at step 2, before the container step and long before the push.