### PR TITLE
fix(dev): check the target before connecting, and check both places it comes from

### DIFF
--- a/scripts/dev-setup.ts
+++ b/scripts/dev-setup.ts
@@ -11,48 +11,35 @@ import { isLocalPostgres } from "../src/db/driver"
 
 const step = (n: number, msg: string) => console.log(`\n[${n}/5] ${msg}`)
 
-/**
- * Refuse to touch anything that is not the local container.
- *
- * This runs before the schema push, and that ordering is the whole point. The
- * seeder had this check and the push did not, so a run against a leftover
- * production .env.local sailed through `drizzle-kit push --force` -- which
- * TRUNCATES a table to add a unique constraint -- and only stopped at the last
- * step, after the damage. A guard that fires after the destructive step is not
- * a guard.
- */
-function assertLocal(env: Record<string, string>) {
-  const targets: [string, string][] = [
-    ["DATABASE_URL", env.DATABASE_URL ?? ""],
-    ["DIRECT_URL", env.DIRECT_URL ?? env.DATABASE_URL ?? ""],
-  ]
-  const remote = targets.filter(([, url]) => url && !isLocalPostgres(url))
-  if (remote.length === 0) return
-
-  console.error("\n  Refusing to continue.\n")
-  for (const [name, url] of remote) {
-    let host = url
-    try {
-      host = new URL(url).hostname
-    } catch {}
-    console.error(`    ${name} points at ${host}`)
-  }
-  console.error(`
-  This command pushes a schema and rewrites data, and only ever runs against
-  the local container. Your .env.local is pointed somewhere else -- most
-  likely it is a real environment you were using earlier.
-
-  To set up the local database, move that file aside first:
-
-    mv .env.local .env.local.remote
-    npm run dev:setup
-
-  and put it back when you need the hosted one again.
-`)
-  process.exit(1)
+function run(cmd: string, args: string[]) {
+  const r = spawnSync(cmd, args, {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  })
+  if (r.status !== 0) process.exit(r.status ?? 1)
 }
 
-/** The env this run will actually use, read the way dotenv would. */
+function compose(): string[] {
+  // `docker compose` on anything current, `docker-compose` on older installs.
+  // OrbStack provides both, so nothing here is Docker Desktop specific.
+  try {
+    execSync("docker compose version", { stdio: "ignore" })
+    return ["docker", "compose"]
+  } catch {
+    try {
+      execSync("docker-compose version", { stdio: "ignore" })
+      return ["docker-compose"]
+    } catch {
+      console.error(
+        "\nNo Docker engine is available.\n" +
+          "Start OrbStack (or Docker Desktop) and re-run.\n"
+      )
+      process.exit(1)
+    }
+  }
+}
+
+/** The variables .env.local sets, read the way dotenv would read them. */
 function readEnvLocal(): Record<string, string> {
   const out: Record<string, string> = {}
   if (!existsSync(".env.local")) return out
@@ -64,31 +51,63 @@ function readEnvLocal(): Record<string, string> {
   return out
 }
 
-function run(cmd: string, args: string[]) {
-  const r = spawnSync(cmd, args, {
-    stdio: "inherit",
-    shell: process.platform === "win32",
-  })
-  if (r.status !== 0) process.exit(r.status ?? 1)
-}
-
-function compose(): string[] {
-  // `docker compose` on anything current, `docker-compose` on older installs.
-  try {
-    execSync("docker compose version", { stdio: "ignore" })
-    return ["docker", "compose"]
-  } catch {
-    try {
-      execSync("docker-compose version", { stdio: "ignore" })
-      return ["docker-compose"]
-    } catch {
-      console.error(
-        "\nDocker is not available.\n" +
-          "Install Docker Desktop (or any Docker engine) and start it, then re-run.\n"
-      )
-      process.exit(1)
-    }
+/**
+ * Refuse to touch anything that is not the local container.
+ *
+ * This runs before the schema push, and that ordering is the whole point. The
+ * seeder had this check and the push did not, so a run against a leftover
+ * production .env.local sailed through `drizzle-kit push --force` -- which
+ * TRUNCATES a table to add a unique constraint -- and only stopped at the last
+ * step, after the damage. A guard that fires after the destructive step is not
+ * a guard.
+ */
+function assertLocal() {
+  // Both sources, not one. dotenv does not overwrite a variable that is
+  // already exported, so a DATABASE_URL in the shell beats the file and would
+  // be the one drizzle-kit actually pushes to — a guard that reads only
+  // .env.local passes happily while the tool aims somewhere else. Refusing
+  // when EITHER names a remote host is correct whichever precedence applies.
+  const file = readEnvLocal()
+  const checks: [string, string, string][] = []
+  for (const name of ["DATABASE_URL", "DIRECT_URL"]) {
+    if (file[name]) checks.push([name, file[name], ".env.local"])
+    if (process.env[name]) checks.push([name, process.env[name]!, "the shell"])
   }
+
+  const remote = checks.filter(([, url]) => !isLocalPostgres(url))
+  if (remote.length === 0) return
+
+  console.error("\n  Refusing to continue.\n")
+  for (const [name, url, source] of remote) {
+    let host = url
+    try {
+      host = new URL(url).hostname
+    } catch {}
+    console.error(`    ${name} points at ${host}  (from ${source})`)
+  }
+
+  const fromShell = remote.some(([, , src]) => src === "the shell")
+  console.error(`
+  This command pushes a schema and rewrites data, and only ever runs against
+  the local container.
+`)
+  if (fromShell) {
+    console.error(`  That value is exported in your shell, which beats .env.local — unset it:
+
+    unset DATABASE_URL DIRECT_URL
+    npm run dev:setup
+`)
+  } else {
+    console.error(`  Your .env.local is pointed somewhere else — most likely a real environment
+  you were using earlier. Move it aside:
+
+    mv .env.local .env.local.remote
+    npm run dev:setup
+
+  and put it back when you need the hosted one again.
+`)
+  }
+  process.exit(1)
 }
 
 async function main() {
@@ -101,7 +120,7 @@ async function main() {
   }
 
   step(2, "checking the target is local")
-  assertLocal(readEnvLocal())
+  assertLocal()
   console.log("  local container, safe to proceed")
 
   step(3, "database container")

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -34,6 +34,20 @@ async function run() {
     process.exit(1)
   }
 
+  // Before makePool, deliberately. The first version of this check sat further
+  // down and had already connected and created _migrations by the time it
+  // refused — the same mistake, in the same shape, as the one that let a schema
+  // push reach a hosted database. A guard belongs above the thing it guards.
+  const baseline = process.argv.includes("--baseline")
+  if (baseline && !isLocalPostgres(url)) {
+    console.error(
+      `Refusing to baseline ${new URL(url).hostname} — --baseline records ` +
+        "migrations as applied without running them, which is only ever\n" +
+        "correct for a freshly pushed local database. Use `npm run db:migrate`."
+    )
+    process.exit(1)
+  }
+
   const pool = makePool(url)
 
   await pool.query(`
@@ -67,18 +81,7 @@ async function run() {
   // re-applying what is there. Baselining records them as done without running
   // them — which is what a fresh local database wants, and what lets a
   // migration written tomorrow still run normally.
-  if (process.argv.includes("--baseline")) {
-    // Same rule as the seeder: this rewrites the migration ledger, and doing
-    // that to a hosted database would tell it changes had been applied that
-    // never ran.
-    if (!isLocalPostgres(url)) {
-      console.error(
-        `Refusing to baseline ${new URL(url).hostname} — --baseline is for a ` +
-          "freshly pushed local database only."
-      )
-      await pool.end()
-      process.exit(1)
-    }
+  if (baseline) {
     for (const file of pending) {
       await pool.query("INSERT INTO _migrations (filename) VALUES ($1)", [file])
     }


### PR DESCRIPTION
My previous fix (#99) was incomplete. Two holes, both the same mistake in a different place: **the guard sat after the thing it guards.**

## Hole 1 — it read only `.env.local`

`dotenv` does not overwrite a variable that is already exported, so a `DATABASE_URL` in the shell beats the file and is the one `drizzle-kit` actually pushes to. The guard read the file, saw `localhost`, and said "safe to proceed" while the tool aimed at a hosted database.

Demonstrated before the fix:

```
file says local; shell says remote:
[2/5] checking the target is local
  local container, safe to proceed      <-- about to push to the remote
```

It now refuses when **either** source names a remote host — correct whichever precedence applies — and names which one it found:

```
    DATABASE_URL points at fake-prod.us-east-1.aws.neon.tech  (from the shell)

  That value is exported in your shell, which beats .env.local — unset it:
    unset DATABASE_URL DIRECT_URL
```

## Hole 2 — `--baseline` refused after connecting

The check sat below `makePool()`, so it had already opened a connection and run `CREATE TABLE IF NOT EXISTS _migrations` against the remote database before deciding not to proceed. It now runs before the pool is opened.

## What is deliberately not restricted

Plain `npm run db:migrate` against a hosted database. That is how production is migrated. Only `--baseline` — which records migrations as applied *without running them* — is local-only, because doing that to a real database would tell it changes had been applied that never ran.

## Verified

```
MUST REFUSE:
  PASS  setup: DATABASE_URL remote in shell
  PASS  setup: DIRECT_URL remote in shell
  PASS  seed: remote
  PASS  baseline: remote (before connecting)
  PASS  setup: remote in .env.local

MUST STILL WORK:
  PASS  seed: local
  PASS  migrate: local
  PASS  baseline: local
```

`npm run check` — 157 tests. `npm run build` compiled.