### PR TITLE
fix: three runtime failures the dev switcher walked straight into

### DIFF
--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -134,6 +134,16 @@ coordinator  -> 307 /login
 The seeder has its own lock: it refuses to run against any host that is not
 local, because everything it does begins by deleting rows.
 
+## Building locally
+
+`npm run build` refuses while `VERP_DEV_AUTH` is set — the guard cannot tell a
+laptop's production build from a deployable one, and it should not try, because
+the artifact is the same either way. To check that a change compiles:
+
+```bash
+VERP_DEV_AUTH= npm run build
+```
+
 ## Working against the real thing
 
 Nothing stops you. Put your Neon and VOSS credentials in `.env.local` and drop

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,8 +5,12 @@ import type { NextConfig } from "next"
 // at runtime is a bug report from a user; this is a build that never ships.
 if (process.env.NODE_ENV === "production" && process.env.VERP_DEV_AUTH) {
   throw new Error(
-    "VERP_DEV_AUTH is set for a production build. It bypasses sign-in and must " +
-      "never be present in a deployed environment — unset it and rebuild."
+    "VERP_DEV_AUTH is set for a production build.\n\n" +
+      "It bypasses sign-in, so it must never be present in anything deployable " +
+      "— including a build made on a laptop, since that artifact is what gets " +
+      "shipped.\n\n" +
+      "If you are only checking that your change compiles, build without it:\n" +
+      "  VERP_DEV_AUTH= npm run build\n"
   )
 }
 

--- a/src/app/login/dev-sign-in.tsx
+++ b/src/app/login/dev-sign-in.tsx
@@ -9,13 +9,18 @@ import { setDevActor } from "@/lib/dev-auth-actions"
  * The way in when there is no way in.
  *
  * A contributor cannot complete a VOSS sign-in, so without this the login page
- * is a wall. Rendered only when the server hands it personas, which it does
- * only on a development machine with the flag set.
+ * is a wall — it renders "Invalid OAuth configuration" and there is nothing
+ * else to click.
+ *
+ * Fixed rather than in the document flow. The login form is `min-h-svh`, so
+ * anything placed after it starts one full viewport down: the first version of
+ * this sat there, correct in the markup and invisible on the screen, which for
+ * the one control that lets you in is the same as not existing.
  */
 export function DevSignIn({ personas }: { personas: DevPersona[] }) {
   const [pending, start] = useTransition()
   return (
-    <div className="border-attention/50 mx-auto mt-6 w-full max-w-sm rounded-lg border border-dashed p-4">
+    <div className="bg-background border-attention/60 fixed right-4 bottom-4 z-50 flex max-h-[80vh] w-[min(22rem,calc(100vw-2rem))] flex-col overflow-y-auto rounded-lg border border-dashed p-4 shadow-lg">
       <p className="flex items-center gap-2 text-sm font-medium">
         <FlaskConicalIcon className="text-attention size-4" />
         Development sign-in

--- a/src/app/unclaimed/page.tsx
+++ b/src/app/unclaimed/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation"
 import { ClockIcon, AlertTriangleIcon } from "lucide-react"
 import { AppSidebar } from "@/components/app-sidebar"
+import { SessionProvider } from "@/components/session-provider"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { getSessionUser, isUnbound } from "@/lib/session"
 import { devAuthProps } from "@/lib/dev-auth"
@@ -27,37 +28,57 @@ export default async function UnclaimedPage() {
   const req = await getLatestRequestForUser(user.id)
   const showForm = !req || req.status === "rejected"
 
+  // AppSidebar reads the signed-in identity from context, so the shell has to
+  // provide it. This page rendered the sidebar without a provider from #82
+  // onward and threw on every visit — invisible because reaching it needs an
+  // account VOSS authenticated that VERP cannot place, which the dev switcher
+  // now makes reachable in one click.
   return (
-    <SidebarProvider>
-      <AppSidebar devAuth={devAuth} />
-      <SidebarInset>
-        <div className="flex min-h-svh items-center justify-center p-6">
-          <div className="w-full max-w-md">
-            {showForm ? (
-              <RegisterForm
-                email={user.email}
-                name={user.name}
-                rejection={
-                  req?.status === "rejected" ? req.rejectionReason : null
-                }
-              />
-            ) : req.status === "pending" ? (
-              <Status
-                icon={<ClockIcon className="size-5" />}
-                title="Waiting for approval"
-                body={`Your request for ${req.rollNumber} is with your class coordinator. You'll be linked automatically the moment they approve it.`}
-              />
-            ) : (
-              <Status
-                icon={<AlertTriangleIcon className="size-5" />}
-                title="Your class isn't set up yet"
-                body={`We have your details for ${req.rollNumber}, but your class has not been created in VERP yet. You'll be routed to your coordinator's queue automatically once it is — nothing more to do.`}
-              />
-            )}
+    <SessionProvider
+      session={{
+        name: user.name,
+        email: user.email,
+        image: user.image,
+        tier: user.tier,
+        facultyId: user.facultyId,
+        studentId: user.studentId,
+        deptCodes: user.deptCodes,
+        classIds: user.classIds,
+        coordinatorClassIds: user.coordinatorClassIds,
+        capabilities: [...user.capabilities],
+      }}
+    >
+      <SidebarProvider>
+        <AppSidebar devAuth={devAuth} />
+        <SidebarInset>
+          <div className="flex min-h-svh items-center justify-center p-6">
+            <div className="w-full max-w-md">
+              {showForm ? (
+                <RegisterForm
+                  email={user.email}
+                  name={user.name}
+                  rejection={
+                    req?.status === "rejected" ? req.rejectionReason : null
+                  }
+                />
+              ) : req.status === "pending" ? (
+                <Status
+                  icon={<ClockIcon className="size-5" />}
+                  title="Waiting for approval"
+                  body={`Your request for ${req.rollNumber} is with your class coordinator. You'll be linked automatically the moment they approve it.`}
+                />
+              ) : (
+                <Status
+                  icon={<AlertTriangleIcon className="size-5" />}
+                  title="Your class isn't set up yet"
+                  body={`We have your details for ${req.rollNumber}, but your class has not been created in VERP yet. You'll be routed to your coordinator's queue automatically once it is — nothing more to do.`}
+                />
+              )}
+            </div>
           </div>
-        </div>
-      </SidebarInset>
-    </SidebarProvider>
+        </SidebarInset>
+      </SidebarProvider>
+    </SessionProvider>
   )
 }
 

--- a/src/components/dev-actor-switcher.tsx
+++ b/src/components/dev-actor-switcher.tsx
@@ -5,6 +5,7 @@ import { CheckIcon, ChevronsUpDownIcon, FlaskConicalIcon } from "lucide-react"
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -73,12 +74,17 @@ export function DevActorSwitcher({
             align="start"
             side="bottom"
             sideOffset={4}
-            className="w-(--radix-dropdown-menu-trigger-width) min-w-72"
+            className="max-h-[80vh] min-w-72 overflow-y-auto rounded-lg"
           >
-            <DropdownMenuLabel className="text-muted-foreground text-xs font-normal">
-              Development only. Authentication is bypassed; every permission
-              below is resolved from the database exactly as in production.
-            </DropdownMenuLabel>
+            {/* The label is Base UI's Menu.GroupLabel underneath, and it throws
+                outside a Menu.Group — a runtime-only failure that typecheck and
+                the build both pass. */}
+            <DropdownMenuGroup>
+              <DropdownMenuLabel className="text-muted-foreground text-xs font-normal">
+                Development only. Authentication is bypassed; every permission
+                below is resolved from the database exactly as in production.
+              </DropdownMenuLabel>
+            </DropdownMenuGroup>
             <DropdownMenuSeparator />
 
             {personas.map((p) => (


### PR DESCRIPTION
None of these were caught by typecheck, lint or the build. All three only exist when a page actually renders.

## 1. The dev sign-in panel was invisible

`LoginForm` is `min-h-svh`, so anything placed after it starts one full viewport down. The panel was in the DOM with all ten personas and simply off the screen — and for the one control that lets a contributor in, that is the same as not existing.

Now fixed to the corner, independent of the form's height.

## 2. The switcher crashed the page on open

```
Error: Base UI: MenuGroupRootContext is missing.
Menu group parts must be used within <Menu.Group>.
```

`DropdownMenuLabel` is Base UI's `Menu.GroupLabel` underneath and throws outside a `Menu.Group`. Every other menu in the codebase wraps it; this one did not. I also scanned the rest of the tree for the same shape — no others.

## 3. `/unclaimed` has returned a 500 since #82

This is the one worth reading.

`/unclaimed` renders `AppSidebar`, which reads the signed-in identity from context and throws without a `SessionProvider`. That page has **never** had one:

```
when did AppSidebar start needing SessionProvider?
  42770f4 feat(ui): shell foundation from the UI/UX spec (#82)

has /unclaimed ever had a SessionProvider?
  (no commits)
```

Nobody hit it because reaching that route requires an account VOSS authenticated but VERP cannot place. The switcher makes that state one click away.

So the environment built to let contributors test authorization found, on its first run, a route that had been broken in production for weeks and that nobody could reach to notice. That is the argument for both this environment and for #28 (Playwright) in one bug.

## Verified

All ten personas resolve end to end, including `unbound` which now renders instead of 500ing:

```
admin 200 · hod-excs 200 · hod-extc 200 · coordinator 200
teacher-dav 200 · teacher-cn 200 · teacher-b 200
student 200 · student-fresh 200 · unbound 200
```

Switcher opened and used in a real browser; console clean. `npm run check` — 157 tests. `npm run build` compiled.