### PR TITLE
Contain page errors to the content area, and report them from there

### DIFF
--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useEffect } from "react"
+import { TriangleAlertIcon } from "lucide-react"
+
+import { EmptyState } from "@/components/empty-state"
+import { PageHeader } from "@/components/page-header"
+import { openBugReport } from "@/components/report-bug"
+import { useSessionUser } from "@/components/session-provider"
+import { Button } from "@/components/ui/button"
+import { startBugLogCapture } from "@/lib/bug-capture"
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const { bugReportConfigured } = useSessionUser()
+
+  useEffect(() => {
+    startBugLogCapture()
+    console.error(error)
+  }, [error])
+
+  return (
+    <>
+      <PageHeader
+        title="Something went wrong"
+        parent="Overview"
+        parentHref="/dashboard"
+      />
+      <div className="@container/main flex flex-1 flex-col gap-4 p-4 lg:p-6">
+        <EmptyState
+          icon={TriangleAlertIcon}
+          variant="dashed"
+          className="[&>svg]:text-destructive my-auto"
+          title="This page could not be loaded"
+          description="The page failed while it was being built, so none of it is showing. Everything else still works — try again, and report it if it keeps happening."
+          action={
+            <div className="flex flex-col items-center gap-3">
+              {error.digest && (
+                <p className="text-muted-foreground text-xs">
+                  Reference <span className="identifier">{error.digest}</span>
+                </p>
+              )}
+              <div className="flex items-center gap-2">
+                <Button onClick={reset}>Try again</Button>
+                {bugReportConfigured && (
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      openBugReport({
+                        description: "This page failed to load.",
+                        digest: error.digest,
+                      })
+                    }
+                  >
+                    Report this bug
+                  </Button>
+                )}
+              </div>
+            </div>
+          }
+        />
+      </div>
+    </>
+  )
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -90,6 +90,7 @@ export default async function DashboardLayout({
         classIds: user.classIds,
         coordinatorClassIds: user.coordinatorClassIds,
         capabilities: [...user.capabilities],
+        bugReportConfigured: isBugReportConfigured(),
         ...scope,
       }}
     >

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { useState } from "react"
+
 export default function Error({
   error,
   reset,
@@ -7,7 +9,20 @@ export default function Error({
   error: Error & { digest?: string }
   reset: () => void
 }) {
+  const [copied, setCopied] = useState(false)
+
   console.error(error)
+
+  async function copyDigest() {
+    if (!error.digest) return
+    try {
+      await navigator.clipboard.writeText(error.digest)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 2000)
+    } catch {
+      setCopied(false)
+    }
+  }
 
   return (
     <main className="flex min-h-screen items-center justify-center px-6 py-16">
@@ -25,7 +40,7 @@ export default function Error({
             Reference: {error.digest}
           </p>
         )}
-        <div className="mt-6 flex items-center justify-center gap-3">
+        <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
           <button
             type="button"
             className="bg-foreground text-background inline-flex cursor-pointer items-center rounded-md border px-4 py-2 text-sm font-medium"
@@ -33,6 +48,18 @@ export default function Error({
           >
             Try again
           </button>
+          {error.digest && (
+            <button
+              type="button"
+              aria-live="polite"
+              className="text-foreground inline-flex cursor-pointer items-center rounded-md border px-4 py-2 text-sm font-medium"
+              onClick={() => {
+                void copyDigest()
+              }}
+            >
+              {copied ? "Copied" : "Copy error reference"}
+            </button>
+          )}
         </div>
       </div>
     </main>

--- a/src/app/unclaimed/page.tsx
+++ b/src/app/unclaimed/page.tsx
@@ -66,6 +66,7 @@ export default async function UnclaimedPage() {
         scopeDepts: [],
         scopeClasses: [],
         rollNumber: null,
+        bugReportConfigured: false,
       }}
     >
       <SidebarProvider>

--- a/src/components/report-bug.tsx
+++ b/src/components/report-bug.tsx
@@ -64,6 +64,24 @@ const ROLE_LABEL: Record<
 type Shot = { dataUrl: string; bytes: number }
 type Snapshot = { device: BugDevice; logs: BugLogEntry[]; capturedAt: string }
 
+export const OPEN_BUG_REPORT = "verp:open-bug-report"
+
+export type BugReportPrefill = { description?: string; digest?: string }
+
+export function openBugReport(prefill?: BugReportPrefill) {
+  document.dispatchEvent(
+    new CustomEvent(OPEN_BUG_REPORT, { detail: prefill ?? {} })
+  )
+}
+
+function seedDescription(prefill: BugReportPrefill): string {
+  const lines: string[] = []
+  const typed = prefill.description?.trim()
+  if (typed) lines.push(typed, "")
+  if (prefill.digest) lines.push(`Error reference: ${prefill.digest}`)
+  return lines.join("\n")
+}
+
 function takeSnapshot(): Snapshot {
   return {
     device: captureDevice(),
@@ -98,6 +116,19 @@ export function ReportBugButton({ appVersion }: { appVersion: string }) {
 
   React.useEffect(() => {
     startBugLogCapture()
+  }, [])
+
+  React.useEffect(() => {
+    const onOpen = (event: Event) => {
+      const prefill = (event as CustomEvent<BugReportPrefill>).detail ?? {}
+      const seed = seedDescription(prefill)
+      setSnapshot(takeSnapshot())
+      setShotError(null)
+      setDescription((current) => (current.trim() ? current : seed))
+      setOpen(true)
+    }
+    document.addEventListener(OPEN_BUG_REPORT, onOpen)
+    return () => document.removeEventListener(OPEN_BUG_REPORT, onOpen)
   }, [])
 
   function changeOpen(next: boolean) {

--- a/src/components/session-provider.tsx
+++ b/src/components/session-provider.tsx
@@ -32,6 +32,7 @@ export type ClientSession = {
   scopeDepts: ScopeDept[]
   scopeClasses: ScopeClass[]
   rollNumber: string | null
+  bugReportConfigured: boolean
 }
 
 type Ctx = ClientSession & { capabilitySet: ReadonlySet<Capability> }


### PR DESCRIPTION
A page error took down the whole app. The only error boundary was the root one, so a failure anywhere under `/dashboard` replaced the sidebar, the navigation and the bug button with a bare full-screen message — exactly what production shows today on `/dashboard/imports`.

A dashboard-scoped boundary now contains the failure to the content area. The shell keeps working, and the error card carries the reference digest plus a report action that opens the bug dialog prefilled with it, so an issue can be tied back to server logs. The boundary starts log capture before it logs the error, so the failure itself rides along in the report without the reporter doing anything.

The report action only renders when reporting is configured, which the session now carries — otherwise it would dispatch an event nobody listens for. The root boundary deliberately keeps no report action, since it renders without a session and the action would refuse; it offers to copy the reference instead.

## Verified in the browser

Reproduced the production failure locally by making `/dashboard/imports` throw `relation "import_batches" does not exist`. The shell, navigation and floating button survived; the error card showed the digest; "Report this bug" opened the dialog prefilled with `Error reference: <digest>`; and the submitted payload carried the real error and stack captured automatically:

```
log: error - Error: relation "import_batches" does not exist
    at ImportsPage (...)
```

`npm run check` green (230 tests).

## Still outstanding

`0007_import_batches.sql` is **not applied on production** — that is the underlying cause of the error this PR makes survivable, not a fix for it. Run `npm run db:migrate` against the production database. Safe to re-run; the file is guarded and the ledger skips what is applied. Note `npm run db:migrate:status` reports against the wrong table name and cannot be trusted.
