### PR TITLE
Apply migrations from a workflow instead of a laptop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,46 @@ jobs:
           DATABASE_URL: "postgresql://fake:fake@localhost/fake"
           BETTER_AUTH_SECRET: "ci-secret"
           BETTER_AUTH_URL: "http://localhost:3000"
+
+  migrations:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: verp
+          POSTGRES_PASSWORD: verp
+          POSTGRES_DB: verp
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: "postgresql://verp:verp@localhost:5432/verp"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build the schema the way a fresh install does
+        run: npx drizzle-kit push --force
+
+      - name: Apply migrations
+        run: npm run db:migrate
+
+      - name: Applying them again changes nothing
+        run: npm run db:migrate
+
+      - name: Every migration file is recorded as applied
+        run: npx tsx scripts/check-migrations.ts

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,39 @@
+name: Migrate production
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/db/migrations/**"
+      - "src/db/migrate.ts"
+      - ".github/workflows/migrate.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: migrate-production
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Show what is pending
+        run: npm run db:migrate:status || true
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+
+      - name: Apply migrations
+        run: npm run db:migrate
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - "src/db/migrations/**"
       - "src/db/migrate.ts"
-      - ".github/workflows/migrate.yml"
   workflow_dispatch:
 
 concurrency:
@@ -27,6 +26,13 @@ jobs:
           cache: npm
 
       - run: npm ci
+
+      - name: Refuse without a database to migrate
+        if: ${{ secrets.PRODUCTION_DATABASE_URL == '' }}
+        run: |
+          echo "PRODUCTION_DATABASE_URL is not set on the production environment."
+          echo "Add it under Settings, Environments, production before running this."
+          exit 1
 
       - name: Show what is pending
         run: npm run db:migrate:status || true

--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,5 @@ next-env.d.ts
 !/scripts/setup.ts
 !/scripts/dev-setup.ts
 !/scripts/seed-dev.ts
+!/scripts/check-migrations.ts
 !/scripts/lib/

--- a/scripts/check-migrations.ts
+++ b/scripts/check-migrations.ts
@@ -1,0 +1,59 @@
+import { config } from "dotenv"
+config({ path: ".env.local" })
+
+import * as fs from "fs"
+import * as path from "path"
+import { isLocalPostgres } from "../src/db/driver"
+
+const MIGRATIONS_DIR = path.join(__dirname, "..", "src", "db", "migrations")
+
+function makePool(url: string) {
+  if (isLocalPostgres(url)) {
+    /* eslint-disable @typescript-eslint/no-require-imports */
+    const { Pool: PgPool } = require("pg")
+    /* eslint-enable @typescript-eslint/no-require-imports */
+    return new PgPool({ connectionString: url })
+  }
+  /* eslint-disable @typescript-eslint/no-require-imports */
+  const { Pool: NeonPool, neonConfig } = require("@neondatabase/serverless")
+  const ws = require("ws")
+  /* eslint-enable @typescript-eslint/no-require-imports */
+  neonConfig.webSocketConstructor = ws
+  return new NeonPool({ connectionString: url })
+}
+
+async function run() {
+  const url = process.env.DIRECT_URL ?? process.env.DATABASE_URL
+  if (!url) {
+    console.error("DATABASE_URL is not set")
+    process.exit(1)
+  }
+
+  const files = fs.existsSync(MIGRATIONS_DIR)
+    ? fs
+        .readdirSync(MIGRATIONS_DIR)
+        .filter((f) => f.endsWith(".sql") && !f.startsWith("0000"))
+        .sort()
+    : []
+
+  const pool = makePool(url)
+  const { rows } = await pool.query("SELECT filename FROM _migrations")
+  await pool.end()
+
+  const applied = new Set<string>(
+    rows.map((r: { filename: string }) => r.filename)
+  )
+  const missing = files.filter((f) => !applied.has(f))
+  const unknown = [...applied].filter((f) => !files.includes(f))
+
+  for (const f of missing) console.error(`not applied: ${f}`)
+  for (const f of unknown) console.error(`applied but not in the repo: ${f}`)
+
+  if (missing.length > 0 || unknown.length > 0) process.exit(1)
+  console.log(`${files.length} migration(s) applied, ledger matches the repo`)
+}
+
+run().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/components/voss-logo.tsx
+++ b/src/components/voss-logo.tsx
@@ -30,15 +30,12 @@ export function VossMark({ className }: { className?: string }) {
   return (
     <span
       className={cn(
-        "relative inline-flex items-center justify-center font-black select-none",
+        "inline-flex items-baseline gap-[2px] font-black select-none",
         className
       )}
     >
-      V
-      <span
-        aria-hidden
-        className="bg-blue absolute right-[3px] bottom-[5px] size-[5px]"
-      />
+      <span className="leading-none tracking-[-0.03em]">V</span>
+      <span aria-hidden className="bg-blue size-[5px] shrink-0" />
     </span>
   )
 }


### PR DESCRIPTION
Production ran ahead of its schema. The imports page shipped and queried `import_batches`, which no migration had created there, so `/dashboard/imports` failed for everyone while the fix sat in a file nobody had run. Nothing in the pipeline applied migrations — it was a matter of remembering.

## Applying them

`.github/workflows/migrate.yml` applies migrations on pushes to `main` that touch `src/db/migrations/**`, and can be run by hand from the Actions tab for a schema that is already behind. It reads the connection string from a `production` environment secret rather than a developer's `.env.local`, and a concurrency group stops two runs overlapping.

**Needs one thing from you before it works:** add `PRODUCTION_DATABASE_URL` under Settings → Environments → `production`. Putting it on an environment rather than the repo means you can also require an approval before any run touches the database, which is worth turning on for a system holding student records.

Once the secret exists, running the workflow by hand applies `0007_import_batches.sql` and fixes production — no laptop, no local credential.

## Proving they are safe to apply

CI gains a `migrations` job on every pull request. It starts a clean Postgres, builds the schema the way a fresh install does (`drizzle-kit push`), applies the migrations over it, then applies them **a second time** and asserts nothing changed.

That second run is the point. The production job is only safe to retry because re-running is a no-op, and that is worth proving on every PR rather than assuming. A ledger check then catches a migration committed but never recorded, or recorded but no longer in the repo.

## Not addressed here

`npm run db:migrate:status` reports against the wrong table name and claims a fully-migrated database has no migrations at all. The workflow calls it for visibility but ignores its exit code, so a wrong answer cannot fail a deploy. Worth fixing separately.

Strict ordering is still not guaranteed: Vercel builds on push at the same time as this workflow runs, so a deploy can briefly precede its schema. Migrations here are additive and guarded, so the window self-heals, but the clean fix is to turn off Vercel's git auto-deploy and trigger it from this workflow once migrations succeed.

## Also

Squares up the compact VOSS mark. The accent square was absolutely positioned on top of the V rather than beside it, so it clipped the letter's right arm — the wordmark already places it alongside the type, and the compact mark now does the same.
